### PR TITLE
fix: Linux/ARM64 memory reallocation failure in 1.19.9

### DIFF
--- a/patch/1.19.9/LuaJIT-2.1-arm64-memory.patch
+++ b/patch/1.19.9/LuaJIT-2.1-arm64-memory.patch
@@ -1,0 +1,13 @@
+diff --git src/lj_alloc.c src/lj_alloc.c
+index 21fb7af5..165203fa 100644
+--- src/lj_alloc.c
++++ src/lj_alloc.c
+@@ -365,7 +365,7 @@ static void *CALL_MREMAP_(void *ptr, size_t osz, size_t nsz, int flags)
+ #define CALL_MREMAP(addr, osz, nsz, mv) CALL_MREMAP_((addr), (osz), (nsz), (mv))
+ #define CALL_MREMAP_NOMOVE	0
+ #define CALL_MREMAP_MAYMOVE	1
+-#if LJ_64 && !LJ_GC64
++#if LJ_64 && (!LJ_GC64 || LJ_TARGET_ARM64)
+ #define CALL_MREMAP_MV		CALL_MREMAP_NOMOVE
+ #else
+ #define CALL_MREMAP_MV		CALL_MREMAP_MAYMOVE

--- a/patch/patch.sh
+++ b/patch/patch.sh
@@ -47,6 +47,7 @@ elif [[ "$root" == *openresty-1.19.9.* ]]; then
     apply_patch "$patch_dir" "$root" "lua-resty-core" "0.1.22"
     apply_patch "$patch_dir" "$root" "ngx_lua" "0.10.20"
     apply_patch "$patch_dir" "$root" "ngx_stream_lua" "0.0.10"
+    apply_patch "$patch_dir" "$root" "LuaJIT-2.1" "20210510"
 else
     err "can't detect OpenResty version"
     exit 1


### PR DESCRIPTION
fix:  luarocks core dumped under Linux/ARM64. [LuaJIT-issue-671](https://github.com/LuaJIT/LuaJIT/issues/671)

```bash
LuaJIT ASSERT lj_gc.c:863: lj_mem_realloc: allocated memory address 0xffff9e326010 outside required range
```