### PR TITLE
fix: patch error

### DIFF
--- a/patch/1.21.4/nginx-client_max_body_size.patch
+++ b/patch/1.21.4/nginx-client_max_body_size.patch
@@ -1,5 +1,5 @@
 diff --git src/http/ngx_http_core_module.c src/http/ngx_http_core_module.c
-index 6388140..b900467 100644
+index fe1da4576..9beba971e 100644
 --- src/http/ngx_http_core_module.c
 +++ src/http/ngx_http_core_module.c
 @@ -8,6 +8,9 @@
@@ -12,7 +12,7 @@ index 6388140..b900467 100644
  
  
  typedef struct {
-@@ -985,7 +988,12 @@ ngx_http_core_find_config_phase(ngx_http_request_t *r,
+@@ -982,7 +985,12 @@ ngx_http_core_find_config_phase(ngx_http_request_t *r,
                     "http cl:%O max:%O",
                     r->headers_in.content_length_n, clcf->client_max_body_size);
  
@@ -26,7 +26,7 @@ index 6388140..b900467 100644
          && clcf->client_max_body_size
          && clcf->client_max_body_size < r->headers_in.content_length_n)
 diff --git src/http/ngx_http_request_body.c src/http/ngx_http_request_body.c
-index 71d7e9a..99fcbad 100644
+index ad3549f98..20a5ec500 100644
 --- src/http/ngx_http_request_body.c
 +++ src/http/ngx_http_request_body.c
 @@ -8,6 +8,9 @@
@@ -65,7 +65,7 @@ index 71d7e9a..99fcbad 100644
      if (ngx_http_test_expect(r) != NGX_OK) {
          rc = NGX_HTTP_INTERNAL_SERVER_ERROR;
          goto done;
-@@ -1025,6 +1047,10 @@ ngx_http_request_body_chunked_filter(ngx_http_request_t *r, ngx_chain_t *in)
+@@ -1072,6 +1094,10 @@ ngx_http_request_body_chunked_filter(ngx_http_request_t *r, ngx_chain_t *in)
      out = NULL;
      ll = &out;
  
@@ -74,9 +74,9 @@ index 71d7e9a..99fcbad 100644
 +#endif
 +
      if (rb->rest == -1) {
-
+ 
          ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-@@ -1048,8 +1074,15 @@ ngx_http_request_body_chunked_filter(ngx_http_request_t *r, ngx_chain_t *in)
+@@ -1111,8 +1137,15 @@ ngx_http_request_body_chunked_filter(ngx_http_request_t *r, ngx_chain_t *in)
  
                  clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
  
@@ -93,7 +93,7 @@ index 71d7e9a..99fcbad 100644
                  {
                      ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
 diff --git src/http/v2/ngx_http_v2.c src/http/v2/ngx_http_v2.c
-index 43a4fde..43c78f9 100644
+index 3afa8b638..c31b98b35 100644
 --- src/http/v2/ngx_http_v2.c
 +++ src/http/v2/ngx_http_v2.c
 @@ -9,6 +9,9 @@
@@ -106,7 +106,7 @@ index 43a4fde..43c78f9 100644
  
  
  typedef struct {
-@@ -4211,10 +4214,18 @@ ngx_http_v2_filter_request_body(ngx_http_request_t *r)
+@@ -4324,10 +4327,18 @@ ngx_http_v2_filter_request_body(ngx_http_request_t *r)
              }
  
          } else {


### PR DESCRIPTION
The original patch file will result the following error, a new *.orig file is created after patched
![d2b61b69-67d5-43dc-a34b-f59c781a7ec2](https://github.com/api7/apisix-nginx-module/assets/9354193/1c697ab0-e14c-4c51-9c84-8ab790cae2b0)
