### PR TITLE
fix: version regex check for 1.25.3.*

### DIFF
--- a/patch/patch.sh
+++ b/patch/patch.sh
@@ -60,7 +60,7 @@ elif [[ "$root" == *openresty-1.21.4.* ]]; then
       apply_patch "$patch_dir" "$root" "lua-resty-core" "0.1.27"
       apply_patch "$patch_dir" "$root" "ngx_lua" "0.10.25"
       apply_patch "$patch_dir" "$root" "ngx_stream_lua" "0.0.13"
-elif [[ "$root" == *openresty-1.25.3.1 ]]; then
+elif [[ "$root" == *openresty-1.25.3.* ]]; then
       patch_dir="$PWD/1.25.3.1"
       apply_patch "$patch_dir" "$root" "nginx" "1.25.3"
       apply_patch "$patch_dir" "$root" "lua-resty-core" "0.1.28"


### PR DESCRIPTION
Needed in order to upgrade APISIX to openresty version 1.25.3.2.

In the  openresty version 1.25.3.2 release package I have confirmed that the versions of `nginx`, `lua-resty-core`, `ngx_lua`, `ngx_stream_lua` is as same as 1.25.3.1, so this change should have no side effect.