### PR TITLE
feat: support set upstream ssl verify

### DIFF
--- a/patch/1.21.4/nginx-upstream_mtls.patch
+++ b/patch/1.21.4/nginx-upstream_mtls.patch
@@ -1,5 +1,5 @@
 diff --git src/http/ngx_http_upstream.c src/http/ngx_http_upstream.c
-index 76045c4..cee3e2a 100644
+index 04d813a..c812242 100644
 --- src/http/ngx_http_upstream.c
 +++ src/http/ngx_http_upstream.c
 @@ -8,6 +8,9 @@
@@ -10,9 +10,22 @@ index 76045c4..cee3e2a 100644
 +#include <ngx_http_apisix_module.h>
 +#endif
  
- #if (T_NGX_MULTI_UPSTREAM)
- #include <ngx_http_multi_upstream_module.h>
-@@ -1766,6 +1769,10 @@ ngx_http_upstream_ssl_init_connection(ngx_http_request_t *r,
+ 
+ #if (NGX_HTTP_CACHE)
+@@ -1697,8 +1700,11 @@ ngx_http_upstream_ssl_init_connection(ngx_http_request_t *r,
+                                            NGX_HTTP_INTERNAL_SERVER_ERROR);
+         return;
+     }
+-
++#if (NGX_HTTP_APISIX)
++    if (u->conf->ssl_server_name || ngx_http_apisix_get_upstream_ssl_verify(r, u->conf->ssl_verify)) {
++#else
+     if (u->conf->ssl_server_name || u->conf->ssl_verify) {
++#endif
+         if (ngx_http_upstream_ssl_name(r, u, c) != NGX_OK) {
+             ngx_http_upstream_finalize_request(r, u,
+                                                NGX_HTTP_INTERNAL_SERVER_ERROR);
+@@ -1738,6 +1744,10 @@ ngx_http_upstream_ssl_init_connection(ngx_http_request_t *r,
  
      r->connection->log->action = "SSL handshaking to upstream";
  
@@ -23,3 +36,15 @@ index 76045c4..cee3e2a 100644
      rc = ngx_ssl_handshake(c);
  
      if (rc == NGX_AGAIN) {
+@@ -1785,7 +1795,11 @@ ngx_http_upstream_ssl_handshake(ngx_http_request_t *r, ngx_http_upstream_t *u,
+ 
+     if (c->ssl->handshaked) {
+ 
++#if (NGX_HTTP_APISIX)
++        if (ngx_http_apisix_get_upstream_ssl_verify(r, u->conf->ssl_verify)) {
++#else
+         if (u->conf->ssl_verify) {
++#endif
+             rc = SSL_get_verify_result(c->ssl->connection);
+ 
+             if (rc != X509_V_OK) {

--- a/patch/1.25.3.1/nginx-upstream_mtls.patch
+++ b/patch/1.25.3.1/nginx-upstream_mtls.patch
@@ -1,5 +1,5 @@
 diff --git src/http/ngx_http_upstream.c src/http/ngx_http_upstream.c
-index 2be233c..78474f3 100644
+index 2be233c..06bbbb9 100644
 --- src/http/ngx_http_upstream.c
 +++ src/http/ngx_http_upstream.c
 @@ -8,6 +8,9 @@
@@ -12,7 +12,20 @@ index 2be233c..78474f3 100644
  
  
  #if (NGX_HTTP_CACHE)
-@@ -1756,6 +1759,10 @@ ngx_http_upstream_ssl_init_connection(ngx_http_request_t *r,
+@@ -1713,8 +1716,11 @@ ngx_http_upstream_ssl_init_connection(ngx_http_request_t *r,
+                                            NGX_HTTP_INTERNAL_SERVER_ERROR);
+         return;
+     }
+-
++#if (NGX_HTTP_APISIX)
++    if (u->conf->ssl_server_name || ngx_http_apisix_get_upstream_ssl_verify(r, u->conf->ssl_verify)) {
++#else
+     if (u->conf->ssl_server_name || u->conf->ssl_verify) {
++#endif
+         if (ngx_http_upstream_ssl_name(r, u, c) != NGX_OK) {
+             ngx_http_upstream_finalize_request(r, u,
+                                                NGX_HTTP_INTERNAL_SERVER_ERROR);
+@@ -1756,6 +1762,10 @@ ngx_http_upstream_ssl_init_connection(ngx_http_request_t *r,
  
      r->connection->log->action = "SSL handshaking to upstream";
  
@@ -23,3 +36,15 @@ index 2be233c..78474f3 100644
      rc = ngx_ssl_handshake(c);
  
      if (rc == NGX_AGAIN) {
+@@ -1803,7 +1813,11 @@ ngx_http_upstream_ssl_handshake(ngx_http_request_t *r, ngx_http_upstream_t *u,
+ 
+     if (c->ssl->handshaked) {
+ 
++#if (NGX_HTTP_APISIX)
++        if (ngx_http_apisix_get_upstream_ssl_verify(r, u->conf->ssl_verify)) {
++#else
+         if (u->conf->ssl_verify) {
++#endif
+             rc = SSL_get_verify_result(c->ssl->connection);
+ 
+             if (rc != X509_V_OK) {

--- a/src/ngx_http_apisix_module.c
+++ b/src/ngx_http_apisix_module.c
@@ -383,6 +383,42 @@ failed:
 
     ngx_http_apisix_flush_ssl_error();
 }
+
+
+int
+ngx_http_apisix_upstream_set_ssl_verify(ngx_http_request_t *r, int verify)
+{
+    ngx_http_apisix_ctx_t       *ctx;
+
+    ctx = ngx_http_apisix_get_module_ctx(r);
+
+    if (ctx == NULL) {
+        return NGX_ERROR;
+    }
+    
+    ctx->upstream_ssl_verify_set = 1;
+    ctx->upstream_ssl_verify = verify;
+
+    return NGX_OK;
+}
+
+ngx_flag_t
+ngx_http_apisix_get_upstream_ssl_verify(ngx_http_request_t *r, ngx_flag_t proxy_ssl_verify)
+{
+    ngx_http_apisix_ctx_t       *ctx;
+
+    ctx = ngx_http_apisix_get_module_ctx(r);
+
+    if (ctx == NULL) {
+        return proxy_ssl_verify;
+    }
+
+    if (!ctx->upstream_ssl_verify_set) {
+        return proxy_ssl_verify;
+    }
+
+    return ctx->upstream_ssl_verify;
+}
 #endif
 
 

--- a/src/ngx_http_apisix_module.h
+++ b/src/ngx_http_apisix_module.h
@@ -35,10 +35,13 @@ typedef struct {
     unsigned             request_header_set:1;
     unsigned             header_filter_by_lua_skipped:1;
     unsigned             body_filter_by_lua_skipped:1;
+    unsigned             upstream_ssl_verify:1;
+    unsigned             upstream_ssl_verify_set:1;
 } ngx_http_apisix_ctx_t;
 
 
 void ngx_http_apisix_set_upstream_ssl(ngx_http_request_t *r, ngx_connection_t *c);
+ngx_flag_t ngx_http_apisix_get_upstream_ssl_verify(ngx_http_request_t *r, ngx_flag_t proxy_ssl_verify);
 
 ngx_flag_t ngx_http_apisix_delay_client_max_body_check(ngx_http_request_t *r);
 off_t ngx_http_apisix_client_max_body_size(ngx_http_request_t *r);

--- a/t/upstream_ssl_verify.t
+++ b/t/upstream_ssl_verify.t
@@ -1,0 +1,269 @@
+use t::APISIX_NGINX 'no_plan';
+
+repeat_each(2);
+
+add_block_preprocessor(sub {
+    my ($block) = @_;
+
+    if (!$block->http_config) {
+        my $http_config = <<'_EOC_';
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+        server_name admin.apisix.dev;
+        ssl_certificate ../../certs/mtls_server.crt;
+        ssl_certificate_key ../../certs/mtls_server.key;
+        ssl_client_certificate ../../certs/mtls_ca.crt;
+
+        server_tokens off;
+
+        location /tls {
+            return 200 'ok\n';
+        }
+    }
+
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/nginx2.sock ssl;
+        server_name admin.apisix.dev;
+        ssl_certificate ../../certs/mtls_server.crt;
+        ssl_certificate_key ../../certs/mtls_server.key;
+        ssl_client_certificate ../../certs/mtls_ca.crt;
+        ssl_verify_client on;
+
+        server_tokens off;
+
+        location /mtls {
+            return 200 'ok\n';
+        }
+    }
+
+_EOC_
+
+        $block->set_value("http_config", $http_config);
+    }
+});
+
+run_tests;
+
+__DATA__
+
+
+=== TEST 1: set ssl_verify with invalid ssl_name
+--- FIRST
+--- config
+    location /t {
+        access_by_lua_block {
+            local upstream = require("resty.apisix.upstream")
+            local ok, err = upstream.set_ssl_verify(true)
+            if not ok then
+                ngx.log(ngx.ERR, "set_ssl_verify failed: ", err)
+                ngx.exit(500)
+            end
+        }
+
+        proxy_pass https://unix:$TEST_NGINX_HTML_DIR/nginx.sock:/tls;
+        proxy_ssl_name invalid.name;
+    }
+--- error_code: 502
+--- error_log
+upstream SSL certificate verify error: (20:unable to get local issuer certificate) while SSL handshaking to upstream
+
+
+
+=== TEST 2: no ssl_verify with invalid ssl_name
+--- config
+    location /t {
+        access_by_lua_block {
+            local upstream = require("resty.apisix.upstream")
+            local ok, err = upstream.set_ssl_verify(false)
+            if not ok then
+                ngx.log(ngx.ERR, "set_ssl_verify failed: ", err)
+                ngx.exit(500)
+            end
+        }
+
+        proxy_pass https://unix:$TEST_NGINX_HTML_DIR/nginx.sock:/tls;
+        proxy_ssl_name invalid.name;
+    }
+
+--- response_body
+ok
+
+
+
+=== TEST 3: set ssl_verify
+--- config
+    location /t {
+        access_by_lua_block {
+            local upstream = require("resty.apisix.upstream")
+            local ok, err = upstream.set_ssl_verify(true)
+            if not ok then
+                ngx.log(ngx.ERR, "set_ssl_verify failed: ", err)
+                ngx.exit(500)
+            end
+        }
+
+        proxy_ssl_trusted_certificate ../../certs/mtls_ca.crt;
+        proxy_ssl_verify on;
+        proxy_pass https://unix:$TEST_NGINX_HTML_DIR/nginx.sock:/tls;
+        proxy_ssl_name admin.apisix.dev;
+    }
+
+--- response_body
+ok
+
+
+
+=== TEST 4: invalid context
+--- config
+    location /t {
+        content_by_lua_block {
+            local upstream = require("resty.apisix.upstream")
+            upstream.set_ssl_verify(true)
+        }
+    }
+--- error_code: 500
+--- error_log
+API disabled in the current context
+
+
+
+=== TEST 5: invalid argument
+--- config
+    location /t {
+        rewrite_by_lua_block {
+            local upstream = require("resty.apisix.upstream")
+            ngx.status = 500
+            local ok, _ = pcall(upstream.set_ssl_verify, 1)
+            if not ok then
+                ngx.say("invalid argument type: number")
+            end
+            
+            local ok, _ = pcall(upstream.set_ssl_verify, "true")
+            if not ok then
+                ngx.say("invalid argument type: string")
+            end
+
+            local ok, err = pcall(upstream.set_ssl_verify, nil)
+            if not ok then
+                ngx.say("invalid argument type: nil")
+            end
+
+            local ok, err = pcall(upstream.set_ssl_verify, {})
+            if not ok then
+                ngx.say("invalid argument type: table")
+            end
+        }
+    }
+--- error_code: 500
+--- response_body
+invalid argument type: number
+invalid argument type: string
+invalid argument type: nil
+invalid argument type: table
+
+
+
+=== TEST 6: not verify upstream mtls certificate
+--- config
+    location /t {
+        access_by_lua_block {
+            local upstream = require("resty.apisix.upstream")
+            local ssl = require("ngx.ssl")
+
+            local f = assert(io.open("t/certs/mtls_client.crt"))
+            local cert_data = f:read("*a")
+            f:close()
+
+            local cert = assert(ssl.parse_pem_cert(cert_data))
+
+            f = assert(io.open("t/certs/mtls_client.key"))
+            local key_data = f:read("*a")
+            f:close()
+
+            local key = assert(ssl.parse_pem_priv_key(key_data))
+
+            local ok, err = upstream.set_cert_and_key(cert, key)
+            if not ok then
+                ngx.say("set_cert_and_key failed: ", err)
+                ngx.exit(500)
+            end
+
+            local ok, err = upstream.set_ssl_verify(false)
+            if not ok then
+                ngx.log(ngx.ERR, "set_ssl_verify failed: ", err)
+                ngx.exit(500)
+            end
+        }
+
+        proxy_pass https://unix:$TEST_NGINX_HTML_DIR/nginx2.sock:/mtls;
+    }
+--- error_code: 200
+--- response_body
+ok
+
+
+
+=== TEST 7: set ssl_verify in upstream mtls, verified successfully
+--- config
+    location /t {
+        access_by_lua_block {
+            local upstream = require("resty.apisix.upstream")
+            local ssl = require("ngx.ssl")
+
+            local f = assert(io.open("t/certs/mtls_client.crt"))
+            local cert_data = f:read("*a")
+            f:close()
+
+            local cert = assert(ssl.parse_pem_cert(cert_data))
+
+            f = assert(io.open("t/certs/mtls_client.key"))
+            local key_data = f:read("*a")
+            f:close()
+
+            local key = assert(ssl.parse_pem_priv_key(key_data))
+
+            local ok, err = upstream.set_cert_and_key(cert, key)
+            if not ok then
+                ngx.say("set_cert_and_key failed: ", err)
+            end
+
+            f = assert(io.open("t/certs/mtls_ca.crt"))
+            local ca_data = f:read("*a")
+            f:close()
+
+            local ca_cert = assert(ssl.parse_pem_cert(ca_data))
+
+            local openssl_x509_store = require "resty.openssl.x509.store"
+            local openssl_x509 = require "resty.openssl.x509"
+            local trust_store, err = openssl_x509_store.new()
+            if err then
+                ngx.log(ngx.ERR, "failed to create trust store: ", err)
+                ngx.exit(500)
+            end
+
+            local x509, err = openssl_x509.new(ca_data, "PEM")
+
+            local _, err = trust_store:add(x509)
+            if err then
+                ngx.log(ngx.ERR, "failed to add ca cert to trust store: ", err)
+                ngx.exit(500)
+            end
+
+            local ok, err = upstream.set_ssl_trusted_store(trust_store)
+            if not ok then
+                ngx.log(ngx.ERR, "set_ssl_trusted_store failed: ", err)
+                ngx.exit(500)
+            end
+
+            local ok, err = upstream.set_ssl_verify(true)
+            if not ok then
+                ngx.log(ngx.ERR, "set_ssl_verify failed: ", err)
+                ngx.exit(500)
+            end
+        }
+
+        proxy_pass https://unix:$TEST_NGINX_HTML_DIR/nginx2.sock:/mtls;
+        proxy_ssl_name admin.apisix.dev;
+    }
+--- response_body
+ok


### PR DESCRIPTION
```lua
local apisix_upstream = require("resty.apisix.upstream")

-- support set  ssl_verify in rewrite/access/balancer phases
local ok, err = apisix_upstream.set_ssl_verify(true)
if not ok then
     ...
end
```