### PR TITLE
fix: ci error about runner and gm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           wget https://raw.githubusercontent.com/api7/apisix-build-tools/master/build-apisix-base.sh
           chmod +x build-apisix-base.sh
-          OR_PREFIX=$OPENRESTY_PREFIX CC="clang -fsanitize=address -fcolor-diagnostics -Qunused-arguments" \
+          OR_PREFIX=$OPENRESTY_PREFIX CC="gcc -fsanitize=address -fdiagnostics-color=always -Wno-unused-but-set-variable -Wno-unused-parameter" \
               cc_opt="-Werror" ./build-apisix-base.sh latest
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,10 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
-      - name: Set up Clang
-        uses: egor-tensin/setup-clang@v1
+      - name: Set up build environment
+        run: |
+          sudo apt update
+          sudo apt install -y git wget build-essential
 
       - name: Get dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
           - "1.25.3.1"
           - "1.27.1.1"
 
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-latest"
 
     env:
       OPENRESTY_VERSION: ${{ matrix.op_version }}

--- a/.github/workflows/gm.yml
+++ b/.github/workflows/gm.yml
@@ -16,8 +16,10 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
-      - name: Set up Clang
-        uses: egor-tensin/setup-clang@v1
+      - name: Set up build environment
+        run: |
+          sudo apt update
+          sudo apt install -y git wget build-essential
 
       - name: Get dependencies
         run: sudo apt install -y cpanminus build-essential libncurses5-dev libreadline-dev libssl-dev perl
@@ -31,7 +33,7 @@ jobs:
         run: |
           # TODO: use a fixed release once they have created one.
           # See https://github.com/Tongsuo-Project/Tongsuo/issues/318
-          git clone https://github.com/api7/tongsuo --depth 1
+          git clone https://github.com/Tongsuo-Project/Tongsuo -b 8.4.0 --depth 1
           pushd tongsuo
           ./config shared enable-ntls -g --prefix=/usr/local/tongsuo
           make -j2

--- a/.github/workflows/gm.yml
+++ b/.github/workflows/gm.yml
@@ -31,8 +31,6 @@ jobs:
 
       - name: Install SSL lib
         run: |
-          # TODO: use a fixed release once they have created one.
-          # See https://github.com/Tongsuo-Project/Tongsuo/issues/318
           git clone -b 8.4.0 --depth 1 https://github.com/Tongsuo-Project/Tongsuo tongsuo
           pushd tongsuo
           ./config shared enable-ntls -g --prefix=/usr/local/tongsuo

--- a/.github/workflows/gm.yml
+++ b/.github/workflows/gm.yml
@@ -52,7 +52,7 @@ jobs:
 
           export cc_opt="-I${openssl_prefix}/include -Werror"
           export ld_opt="-L${openssl_prefix}/lib64 -Wl,-rpath,${openssl_prefix}/lib64"
-          OR_PREFIX=$OPENRESTY_PREFIX CC="clang -fsanitize=address -fcolor-diagnostics -Qunused-arguments" \
+          OR_PREFIX=$OPENRESTY_PREFIX CC="gcc -fsanitize=address -fdiagnostics-color=always -Wno-unused-but-set-variable -Wno-unused-parameter" \
               ./build-apisix-base.sh latest
 
       - name: Script

--- a/.github/workflows/gm.yml
+++ b/.github/workflows/gm.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Install
         run: |
           wget https://raw.githubusercontent.com/api7/apisix-build-tools/master/build-apisix-base.sh
+          sed -i '/--with-http_v3_module[[:space:]]*\\$/d' config.txt ## tongsuo does not support quic tls
           chmod +x build-apisix-base.sh
           export openssl_prefix=/usr/local/tongsuo
 

--- a/.github/workflows/gm.yml
+++ b/.github/workflows/gm.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install
         run: |
           wget https://raw.githubusercontent.com/api7/apisix-build-tools/master/build-apisix-base.sh
-          sed -i '/--with-http_v3_module[[:space:]]*\\$/d' config.txt ## tongsuo does not support quic tls
+          sed -i '/--with-http_v3_module[[:space:]]*\\$/d' build-apisix-base.sh ## tongsuo does not support quic tls
           chmod +x build-apisix-base.sh
           export openssl_prefix=/usr/local/tongsuo
 

--- a/.github/workflows/gm.yml
+++ b/.github/workflows/gm.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           # TODO: use a fixed release once they have created one.
           # See https://github.com/Tongsuo-Project/Tongsuo/issues/318
-          git clone https://github.com/Tongsuo-Project/Tongsuo -b 8.4.0 --depth 1
+          git clone -b 8.4.0 --depth 1 https://github.com/Tongsuo-Project/Tongsuo tongsuo
           pushd tongsuo
           ./config shared enable-ntls -g --prefix=/usr/local/tongsuo
           make -j2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-latest"
 
     steps:
       - name: Check out code

--- a/t/gm.t
+++ b/t/gm.t
@@ -353,7 +353,7 @@ SSL_do_handshake() failed
                 if ngx.shared.done:get("handshake") then
                     local out = f:read('*a')
                     ngx.log(ngx.INFO, out)
-                    ngx.say("ok", out)
+                    ngx.say("ok")
                     f:close()
                     return
                 end
@@ -364,10 +364,8 @@ SSL_do_handshake() failed
     }
 
 --- error_log
-New, TLSv1.2, Cipher is ECDHE-RSA-AES256-GCM-SHA384
+New, TLSv1.3, Cipher is TLS_AES_256_GCM_SHA384
 --- no_error_log
 [error]
 [alert]
 [emerg]
---- response_body
-123

--- a/t/gm.t
+++ b/t/gm.t
@@ -353,7 +353,7 @@ SSL_do_handshake() failed
                 if ngx.shared.done:get("handshake") then
                     local out = f:read('*a')
                     ngx.log(ngx.INFO, out)
-                    ngx.say("ok")
+                    ngx.say("ok", out)
                     f:close()
                     return
                 end
@@ -369,3 +369,5 @@ New, TLSv1.2, Cipher is ECDHE-RSA-AES256-GCM-SHA384
 [error]
 [alert]
 [emerg]
+--- response_body
+123


### PR DESCRIPTION
1. Fix CI error caused by ubuntu 20.04 runner image deprecation
2. Fix CI error caused by api7 Tongsuo repository deletion
  Currently, the module is built with the latest tag from the tongsuo official repository (although that was also released 2-3 years ago), and that OpenSSL branch produces an error when building HTTP/3 and QUIC, and I have no desire to fix it.
  Various projects and openssl branches on GMSSL are no longer active, and I don't know what libraries still support it in an modern way (e.g., closely following patch packages released by OpenSSL, and dropping any vulnerability fixes on OpenSSL in order to use GMSSL is unlikely to be acceptable), and if this state of affairs persists, perhaps that support will be removed from the APISIX.
> Tongsuo is a fork based on OpenSSL 3.0.3, and since OpenSSL 3.0.3 it has fixed a number of critical CVEs, and I'm not sure if these patches have been applied on Tongsuo.