### PR TITLE
fix: restore old context when input of body filter is NULL

### DIFF
--- a/patch/1.21.4/ngx_lua-body_filter_restore_context.patch
+++ b/patch/1.21.4/ngx_lua-body_filter_restore_context.patch
@@ -1,0 +1,12 @@
+diff --git src/ngx_http_lua_bodyfilterby.c src/ngx_http_lua_bodyfilterby.c
+index 78e3b5c2..dba7261a 100644
+--- src/ngx_http_lua_bodyfilterby.c
++++ src/ngx_http_lua_bodyfilterby.c
+@@ -368,6 +368,7 @@ ngx_http_lua_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
+         }
+ 
+     } else {
++        ctx->context = old_context;
+         out = NULL;
+     }
+ 

--- a/patch/1.25.3.1/ngx_lua-body_filter_restore_context.patch
+++ b/patch/1.25.3.1/ngx_lua-body_filter_restore_context.patch
@@ -1,0 +1,12 @@
+diff --git src/ngx_http_lua_bodyfilterby.c src/ngx_http_lua_bodyfilterby.c
+index 78e3b5c2..dba7261a 100644
+--- src/ngx_http_lua_bodyfilterby.c
++++ src/ngx_http_lua_bodyfilterby.c
+@@ -368,6 +368,7 @@ ngx_http_lua_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
+         }
+ 
+     } else {
++        ctx->context = old_context;
+         out = NULL;
+     }
+ 

--- a/patch/1.27.1.1/ngx_lua-body_filter_restore_context.patch
+++ b/patch/1.27.1.1/ngx_lua-body_filter_restore_context.patch
@@ -1,0 +1,12 @@
+diff --git src/ngx_http_lua_bodyfilterby.c src/ngx_http_lua_bodyfilterby.c
+index c0484c8d..179a501a 100644
+--- src/ngx_http_lua_bodyfilterby.c
++++ src/ngx_http_lua_bodyfilterby.c
+@@ -368,6 +368,7 @@ ngx_http_lua_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
+         }
+ 
+     } else {
++        ctx->context = old_context;
+         out = NULL;
+     }
+ 


### PR DESCRIPTION
NOTE: I have verified on a separate branch that this patch has no impact on the existing APISIX test cases.


Fixes apache/apisix#10069
