### PR TITLE
feat: support OpenResty 1.29.2.4 patches

### DIFF
--- a/lib/resty/apisix/process.lua
+++ b/lib/resty/apisix/process.lua
@@ -4,8 +4,7 @@ local tonumber = tonumber
 
 
 ffi.cdef[[
-typedef uintptr_t       ngx_uint_t;
-ngx_uint_t
+uint64_t
 ngx_worker_process_get_last_reopen_ms();
 ]]
 local _M = {}

--- a/patch/1.29.2.4/lua-resty-core-enable_keepalive.patch
+++ b/patch/1.29.2.4/lua-resty-core-enable_keepalive.patch
@@ -1,0 +1,144 @@
+diff --git lib/ngx/balancer.lua lib/ngx/balancer.lua
+index 18bdc2c..3a98f53 100644
+--- lib/ngx/balancer.lua
++++ lib/ngx/balancer.lua
+@@ -3,7 +3,7 @@
+ 
+ local base = require "resty.core.base"
+ base.allows_subsystem('http', 'stream')
+-
++require "resty.core.hash"
+ 
+ local ffi = require "ffi"
+ local C = ffi.C
+@@ -20,6 +20,7 @@ local error = error
+ local type = type
+ local tonumber = tonumber
+ local max = math.max
++local ngx_crc32_long = ngx.crc32_long
+ 
+ local subsystem = ngx.config.subsystem
+ local ngx_lua_ffi_balancer_set_current_peer
+@@ -35,8 +36,7 @@ if subsystem == 'http' then
+     ffi.cdef[[
+     int ngx_http_lua_ffi_balancer_set_current_peer(ngx_http_request_t *r,
+         const unsigned char *addr, size_t addr_len, int port,
+-        const unsigned char *host, ssize_t host_len,
+-        char **err);
++        unsigned int cpool_crc32, unsigned int cpool_size, char **err);
+ 
+     int ngx_http_lua_ffi_balancer_enable_keepalive(ngx_http_request_t *r,
+         unsigned long timeout, unsigned int max_requests, char **err);
+@@ -130,6 +130,7 @@ else
+     error("unknown subsystem: " .. subsystem)
+ end
+ 
++local DEFAULT_KEEPALIVE_POOL_SIZE = 30
+ local DEFAULT_KEEPALIVE_IDLE_TIMEOUT = 60000
+ local DEFAULT_KEEPALIVE_MAX_REQUESTS = 100
+ 
+@@ -143,27 +144,61 @@ local peer_state_names = {
+ local _M = { version = base.version }
+ 
+ if subsystem == "http" then
+-    function _M.set_current_peer(addr, port, host)
++    function _M.set_current_peer(addr, port, opts)
+         local r = get_request()
+         if not r then
+             error("no request found")
+         end
+ 
++        local pool_crc32
++        local pool_size
++        if opts then
++            if type(opts) ~= "table" then
++                error("bad argument #3 to 'set_current_peer' " ..
++                      "(table expected, got " .. type(opts) .. ")", 2)
++            end
++
++            local pool = opts.pool
++            pool_size = opts.pool_size
++
++            if pool then
++                if type(pool) ~= "string" then
++                    error("bad option 'pool' to 'set_current_peer' " ..
++                          "(string expected, got " .. type(pool) .. ")", 2)
++                end
++
++                pool_crc32 = ngx_crc32_long(pool)
++            end
++
++            if pool_size then
++                if type(pool_size) ~= "number" then
++                    error("bad option 'pool_size' to 'set_current_peer' " ..
++                          "(number expected, got " .. type(pool_size) .. ")", 2)
++
++                elseif pool_size < 1 then
++                    error("bad option 'pool_size' to 'set_current_peer' " ..
++                          "(expected > 0)", 2)
++                end
++            end
++        end
++
+         if not port then
+             port = 0
++
+         elseif type(port) ~= "number" then
+             port = tonumber(port)
+         end
+ 
+-        if host ~= nil and type(host) ~= "string" then
+-            error("bad argument #3 to 'set_current_peer' "
+-                  .. "(string expected, got " .. type(host) .. ")")
++        if not pool_crc32 then
++            pool_crc32 = 0
+         end
+ 
+-        local rc = ngx_lua_ffi_balancer_set_current_peer(r, addr, #addr,
+-                                                         port,
+-                                                         host,
+-                                                         host and #host or 0,
++        if not pool_size then
++            pool_size = DEFAULT_KEEPALIVE_POOL_SIZE
++        end
++
++        local rc = ngx_lua_ffi_balancer_set_current_peer(r, addr, #addr, port,
++                                                         pool_crc32, pool_size,
+                                                          errmsg)
+         if rc == FFI_OK then
+             return true
+@@ -172,26 +207,26 @@ if subsystem == "http" then
+         return nil, ffi_str(errmsg[0])
+     end
+ else
+-    function _M.set_current_peer(addr, port, host)
++    function _M.set_current_peer(addr, port, opts)
+         local r = get_request()
+         if not r then
+             error("no request found")
+         end
+ 
++        if opts then
++            error("bad argument #3 to 'set_current_peer' ('opts' not yet " ..
++                  "implemented in " .. subsystem .. " subsystem)", 2)
++        end
++
+         if not port then
+             port = 0
++
+         elseif type(port) ~= "number" then
+             port = tonumber(port)
+         end
+ 
+-        if host ~= nil then
+-            error("bad argument #3 to 'set_current_peer' ('host' not yet " ..
+-                  "implemented in " .. subsystem .. " subsystem)", 2)
+-        end
+-
+         local rc = ngx_lua_ffi_balancer_set_current_peer(r, addr, #addr,
+-                                                         port,
+-                                                         errmsg)
++                                                         port, errmsg)
+         if rc == FFI_OK then
+             return true
+         end

--- a/patch/1.29.2.4/lua-resty-core-enable_keepalive.patch
+++ b/patch/1.29.2.4/lua-resty-core-enable_keepalive.patch
@@ -37,7 +37,7 @@ index 18bdc2c..3a98f53 100644
  local DEFAULT_KEEPALIVE_IDLE_TIMEOUT = 60000
  local DEFAULT_KEEPALIVE_MAX_REQUESTS = 100
  
-@@ -143,27 +144,61 @@ local peer_state_names = {
+@@ -143,27 +144,68 @@ local peer_state_names = {
  local _M = { version = base.version }
  
  if subsystem == "http" then
@@ -63,9 +63,16 @@ index 18bdc2c..3a98f53 100644
 +                if type(pool) ~= "string" then
 +                    error("bad option 'pool' to 'set_current_peer' " ..
 +                          "(string expected, got " .. type(pool) .. ")", 2)
++                elseif pool == "" then
++                    error("bad option 'pool' to 'set_current_peer' " ..
++                          "(non-empty string expected)", 2)
 +                end
 +
 +                pool_crc32 = ngx_crc32_long(pool)
++                if pool_crc32 == 0 then
++                    error("bad option 'pool' to 'set_current_peer' " ..
++                          "(crc32 hash must not be 0)", 2)
++                end
 +            end
 +
 +            if pool_size then

--- a/patch/1.29.2.4/lua-resty-core-enable_keepalive.patch
+++ b/patch/1.29.2.4/lua-resty-core-enable_keepalive.patch
@@ -19,13 +19,14 @@ index 18bdc2c..3a98f53 100644
  
  local subsystem = ngx.config.subsystem
  local ngx_lua_ffi_balancer_set_current_peer
-@@ -35,8 +36,7 @@ if subsystem == 'http' then
+@@ -35,8 +36,8 @@ if subsystem == 'http' then
      ffi.cdef[[
      int ngx_http_lua_ffi_balancer_set_current_peer(ngx_http_request_t *r,
          const unsigned char *addr, size_t addr_len, int port,
 -        const unsigned char *host, ssize_t host_len,
 -        char **err);
-+        unsigned int cpool_crc32, unsigned int cpool_size, char **err);
++        unsigned int cpool_crc32, int cpool_set, unsigned int cpool_size,
++        char **err);
  
      int ngx_http_lua_ffi_balancer_enable_keepalive(ngx_http_request_t *r,
          unsigned long timeout, unsigned int max_requests, char **err);
@@ -37,7 +38,7 @@ index 18bdc2c..3a98f53 100644
  local DEFAULT_KEEPALIVE_IDLE_TIMEOUT = 60000
  local DEFAULT_KEEPALIVE_MAX_REQUESTS = 100
  
-@@ -143,27 +144,68 @@ local peer_state_names = {
+@@ -143,27 +144,67 @@ local peer_state_names = {
  local _M = { version = base.version }
  
  if subsystem == "http" then
@@ -49,6 +50,7 @@ index 18bdc2c..3a98f53 100644
          end
  
 +        local pool_crc32
++        local pool_set = 0
 +        local pool_size
 +        if opts then
 +            if type(opts) ~= "table" then
@@ -69,10 +71,7 @@ index 18bdc2c..3a98f53 100644
 +                end
 +
 +                pool_crc32 = ngx_crc32_long(pool)
-+                if pool_crc32 == 0 then
-+                    error("bad option 'pool' to 'set_current_peer' " ..
-+                          "(crc32 hash must not be 0)", 2)
-+                end
++                pool_set = 1
 +            end
 +
 +            if pool_size then
@@ -110,7 +109,8 @@ index 18bdc2c..3a98f53 100644
 +        end
 +
 +        local rc = ngx_lua_ffi_balancer_set_current_peer(r, addr, #addr, port,
-+                                                         pool_crc32, pool_size,
++                                                         pool_crc32, pool_set,
++                                                         pool_size,
                                                           errmsg)
          if rc == FFI_OK then
              return true

--- a/patch/1.29.2.4/lua-resty-core-init_worker_coroutine.patch
+++ b/patch/1.29.2.4/lua-resty-core-init_worker_coroutine.patch
@@ -1,0 +1,13 @@
+diff --git lib/resty/core/coroutine.lua lib/resty/core/coroutine.lua
+index 42cf0d8..a468147 100644
+--- lib/resty/core/coroutine.lua
++++ lib/resty/core/coroutine.lua
+@@ -13,7 +13,7 @@ do
+             local r = get_request()
+             if r ~= nil then
+                 local ctx = get_raw_phase(r)
+-                if ctx ~= 0x020 and ctx ~= 0x040 then
++                if ctx ~= 0x020 and ctx ~= 0x040 and ctx ~= 0x100 then
+                     return ours(...)
+                 end
+             end

--- a/patch/1.29.2.4/lua-resty-core-reject-in-handshake.patch
+++ b/patch/1.29.2.4/lua-resty-core-reject-in-handshake.patch
@@ -1,0 +1,48 @@
+diff --git lib/ngx/ssl.lua lib/ngx/ssl.lua
+index b696bea..f3b20e0 100644
+--- lib/ngx/ssl.lua
++++ lib/ngx/ssl.lua
+@@ -100,7 +100,7 @@ if subsystem == 'http' then
+     void ngx_http_lua_ffi_free_priv_key(void *cdata);
+ 
+     int ngx_http_lua_ffi_ssl_verify_client(void *r,
+-        void *client_certs, void *trusted_certs, int depth, char **err);
++        void *client_certs, void *trusted_certs, int depth, int reject_in_handshake, char **err);
+ 
+     int ngx_http_lua_ffi_ssl_client_random(ngx_http_request_t *r,
+         const unsigned char *out, size_t *outlen, char **err);
+@@ -198,7 +198,7 @@ elseif subsystem == 'stream' then
+     void ngx_stream_lua_ffi_free_priv_key(void *cdata);
+ 
+     int ngx_stream_lua_ffi_ssl_verify_client(void *r,
+-        void *client_certs, void *trusted_certs, int depth, char **err);
++        void *client_certs, void *trusted_certs, int depth, int reject_in_handshake, char **err);
+ 
+     int ngx_stream_lua_ffi_ssl_client_random(ngx_stream_lua_request_t *r,
+         unsigned char *out, size_t *outlen, char **err);
+@@ -484,7 +484,7 @@ function _M.set_priv_key(priv_key)
+ end
+ 
+ 
+-function _M.verify_client(client_certs, depth, trusted_certs)
++function _M.verify_client(client_certs, depth, trusted_certs, reject_in_handshake)
+     local r = get_request()
+     if not r then
+         error("no request found")
+@@ -494,8 +494,15 @@ function _M.verify_client(client_certs, depth, trusted_certs)
+         depth = -1
+     end
+ 
++    if reject_in_handshake == nil then
++        -- reject by default so we can migrate to the new behavior
++        -- without modifying Lua code
++        reject_in_handshake = true
++    end
++
++    local reject_in_handshake_int = reject_in_handshake and 1 or 0
+     local rc = ngx_lua_ffi_ssl_verify_client(r, client_certs, trusted_certs,
+-                                             depth, errmsg)
++                                             depth, reject_in_handshake_int, errmsg)
+     if rc == FFI_OK then
+         return true
+     end

--- a/patch/1.29.2.4/lua-resty-core-shared_shdict.patch
+++ b/patch/1.29.2.4/lua-resty-core-shared_shdict.patch
@@ -1,0 +1,400 @@
+diff --git lib/resty/core/shdict.lua lib/resty/core/shdict.lua
+index 8d60d16..7537e7b 100644
+--- lib/resty/core/shdict.lua
++++ lib/resty/core/shdict.lua
+@@ -28,7 +28,6 @@ local type = type
+ local error = error
+ local getmetatable = getmetatable
+ local FFI_DECLINED = base.FFI_DECLINED
+-local subsystem = ngx.config.subsystem
+ 
+ 
+ local ngx_lua_ffi_shdict_get
+@@ -42,181 +41,60 @@ local ngx_lua_ffi_shdict_free_space
+ local ngx_lua_ffi_shdict_udata_to_zone
+ 
+ 
+-if subsystem == 'http' then
+-    ffi.cdef[[
+-int ngx_http_lua_ffi_shdict_get(void *zone, const unsigned char *key,
++ffi.cdef[[
++int ngx_meta_lua_ffi_shdict_get(void *zone, const unsigned char *key,
+     size_t key_len, int *value_type, unsigned char **str_value_buf,
+     size_t *str_value_len, double *num_value, int *user_flags,
+     int get_stale, int *is_stale, char **errmsg);
+ 
+-int ngx_http_lua_ffi_shdict_incr(void *zone, const unsigned char *key,
++int ngx_meta_lua_ffi_shdict_incr(void *zone, const unsigned char *key,
+     size_t key_len, double *value, char **err, int has_init,
+     double init, long init_ttl, int *forcible);
+ 
+-int ngx_http_lua_ffi_shdict_store(void *zone, int op,
++int ngx_meta_lua_ffi_shdict_store(void *zone, int op,
+     const unsigned char *key, size_t key_len, int value_type,
+     const unsigned char *str_value_buf, size_t str_value_len,
+     double num_value, long exptime, int user_flags, char **errmsg,
+     int *forcible);
+ 
+-int ngx_http_lua_ffi_shdict_flush_all(void *zone);
++int ngx_meta_lua_ffi_shdict_flush_all(void *zone);
+ 
+-long ngx_http_lua_ffi_shdict_get_ttl(void *zone,
++long ngx_meta_lua_ffi_shdict_get_ttl(void *zone,
+     const unsigned char *key, size_t key_len);
+ 
+-int ngx_http_lua_ffi_shdict_set_expire(void *zone,
++int ngx_meta_lua_ffi_shdict_set_expire(void *zone,
+     const unsigned char *key, size_t key_len, long exptime);
+ 
+-size_t ngx_http_lua_ffi_shdict_capacity(void *zone);
+-
+-void *ngx_http_lua_ffi_shdict_udata_to_zone(void *zone_udata);
+-    ]]
+-
+-    ngx_lua_ffi_shdict_get = function(zone, key, key_len, value_type,
+-                                      str_value_buf, value_len,
+-                                      num_value, user_flags,
+-                                      get_stale, is_stale, errmsg)
+-
+-        return C.ngx_http_lua_ffi_shdict_get(zone, key, key_len, value_type,
+-                                             str_value_buf, value_len,
+-                                             num_value, user_flags,
+-                                             get_stale, is_stale, errmsg)
+-    end
+-
+-    ngx_lua_ffi_shdict_incr = function(zone, key,
+-                                       key_len, value, err, has_init,
+-                                       init, init_ttl, forcible)
++size_t ngx_meta_lua_ffi_shdict_capacity(void *zone);
+ 
+-        return C.ngx_http_lua_ffi_shdict_incr(zone, key,
+-                                              key_len, value, err, has_init,
+-                                              init, init_ttl, forcible)
+-    end
+-
+-    ngx_lua_ffi_shdict_store = function(zone, op,
+-                                        key, key_len, value_type,
+-                                        str_value_buf, str_value_len,
+-                                        num_value, exptime, user_flags,
+-                                        errmsg, forcible)
+-
+-        return C.ngx_http_lua_ffi_shdict_store(zone, op,
+-                                               key, key_len, value_type,
+-                                               str_value_buf, str_value_len,
+-                                               num_value, exptime, user_flags,
+-                                               errmsg, forcible)
+-    end
+-
+-    ngx_lua_ffi_shdict_flush_all = C.ngx_http_lua_ffi_shdict_flush_all
+-    ngx_lua_ffi_shdict_get_ttl = C.ngx_http_lua_ffi_shdict_get_ttl
+-    ngx_lua_ffi_shdict_set_expire = C.ngx_http_lua_ffi_shdict_set_expire
+-    ngx_lua_ffi_shdict_capacity = C.ngx_http_lua_ffi_shdict_capacity
+-    ngx_lua_ffi_shdict_udata_to_zone =
+-        C.ngx_http_lua_ffi_shdict_udata_to_zone
+-
+-    if not pcall(function ()
+-        return C.ngx_http_lua_ffi_shdict_free_space
+-    end)
+-    then
+-        ffi.cdef[[
+-size_t ngx_http_lua_ffi_shdict_free_space(void *zone);
+-        ]]
+-    end
+-
+-    pcall(function ()
+-        ngx_lua_ffi_shdict_free_space = C.ngx_http_lua_ffi_shdict_free_space
+-    end)
+-
+-elseif subsystem == 'stream' then
++void *ngx_meta_lua_ffi_shdict_udata_to_zone(void *zone_udata);
++]]
+ 
++if not pcall(function ()
++    return C.ngx_meta_lua_ffi_shdict_free_space
++end)
++then
+     ffi.cdef[[
+-int ngx_stream_lua_ffi_shdict_get(void *zone, const unsigned char *key,
+-    size_t key_len, int *value_type, unsigned char **str_value_buf,
+-    size_t *str_value_len, double *num_value, int *user_flags,
+-    int get_stale, int *is_stale, char **errmsg);
+-
+-int ngx_stream_lua_ffi_shdict_incr(void *zone, const unsigned char *key,
+-    size_t key_len, double *value, char **err, int has_init,
+-    double init, long init_ttl, int *forcible);
+-
+-int ngx_stream_lua_ffi_shdict_store(void *zone, int op,
+-    const unsigned char *key, size_t key_len, int value_type,
+-    const unsigned char *str_value_buf, size_t str_value_len,
+-    double num_value, long exptime, int user_flags, char **errmsg,
+-    int *forcible);
+-
+-int ngx_stream_lua_ffi_shdict_flush_all(void *zone);
+-
+-long ngx_stream_lua_ffi_shdict_get_ttl(void *zone,
+-     const unsigned char *key, size_t key_len);
+-
+-int ngx_stream_lua_ffi_shdict_set_expire(void *zone,
+-    const unsigned char *key, size_t key_len, long exptime);
+-
+-size_t ngx_stream_lua_ffi_shdict_capacity(void *zone);
+-
+-void *ngx_stream_lua_ffi_shdict_udata_to_zone(void *zone_udata);
++size_t ngx_meta_lua_ffi_shdict_free_space(void *zone);
+     ]]
+-
+-    ngx_lua_ffi_shdict_get = function(zone, key, key_len, value_type,
+-                                      str_value_buf, value_len,
+-                                      num_value, user_flags,
+-                                      get_stale, is_stale, errmsg)
+-
+-        return C.ngx_stream_lua_ffi_shdict_get(zone, key, key_len, value_type,
+-                                               str_value_buf, value_len,
+-                                               num_value, user_flags,
+-                                               get_stale, is_stale, errmsg)
+-    end
+-
+-    ngx_lua_ffi_shdict_incr = function(zone, key,
+-                                       key_len, value, err, has_init,
+-                                       init, init_ttl, forcible)
+-
+-        return C.ngx_stream_lua_ffi_shdict_incr(zone, key,
+-                                                key_len, value, err, has_init,
+-                                                init, init_ttl, forcible)
+-    end
+-
+-    ngx_lua_ffi_shdict_store = function(zone, op,
+-                                        key, key_len, value_type,
+-                                        str_value_buf, str_value_len,
+-                                        num_value, exptime, user_flags,
+-                                        errmsg, forcible)
+-
+-        return C.ngx_stream_lua_ffi_shdict_store(zone, op,
+-                                                 key, key_len, value_type,
+-                                                 str_value_buf, str_value_len,
+-                                                 num_value, exptime, user_flags,
+-                                                 errmsg, forcible)
+-    end
+-
+-    ngx_lua_ffi_shdict_flush_all = C.ngx_stream_lua_ffi_shdict_flush_all
+-    ngx_lua_ffi_shdict_get_ttl = C.ngx_stream_lua_ffi_shdict_get_ttl
+-    ngx_lua_ffi_shdict_set_expire = C.ngx_stream_lua_ffi_shdict_set_expire
+-    ngx_lua_ffi_shdict_capacity = C.ngx_stream_lua_ffi_shdict_capacity
+-    ngx_lua_ffi_shdict_udata_to_zone =
+-        C.ngx_stream_lua_ffi_shdict_udata_to_zone
+-
+-    if not pcall(function ()
+-        return C.ngx_stream_lua_ffi_shdict_free_space
+-    end)
+-    then
+-        ffi.cdef[[
+-size_t ngx_stream_lua_ffi_shdict_free_space(void *zone);
+-        ]]
+-    end
+-
+-    -- ngx_stream_lua is only compatible with NGINX >= 1.13.6, meaning it
+-    -- cannot lack support for ngx_stream_lua_ffi_shdict_free_space.
+-    ngx_lua_ffi_shdict_free_space = C.ngx_stream_lua_ffi_shdict_free_space
+-
+-else
+-    error("unknown subsystem: " .. subsystem)
+ end
+ 
++pcall(function ()
++    ngx_lua_ffi_shdict_get = C.ngx_meta_lua_ffi_shdict_get
++    ngx_lua_ffi_shdict_incr = C.ngx_meta_lua_ffi_shdict_incr
++    ngx_lua_ffi_shdict_store = C.ngx_meta_lua_ffi_shdict_store
++    ngx_lua_ffi_shdict_flush_all = C.ngx_meta_lua_ffi_shdict_flush_all
++    ngx_lua_ffi_shdict_get_ttl = C.ngx_meta_lua_ffi_shdict_get_ttl
++    ngx_lua_ffi_shdict_set_expire = C.ngx_meta_lua_ffi_shdict_set_expire
++    ngx_lua_ffi_shdict_capacity = C.ngx_meta_lua_ffi_shdict_capacity
++    ngx_lua_ffi_shdict_free_space = C.ngx_meta_lua_ffi_shdict_free_space
++    ngx_lua_ffi_shdict_udata_to_zone = C.ngx_meta_lua_ffi_shdict_udata_to_zone
++end)
++
+ 
+ local MACOS = jit and jit.os == "OSX"
+ 
+-if MACOS and subsystem == 'http' then
++if MACOS then
+     ffi.cdef[[
+ typedef struct {
+     void                  *zone;
+@@ -230,7 +108,7 @@ typedef struct {
+     int                    get_stale;
+     int                   *is_stale;
+     char                 **errmsg;
+-} ngx_http_lua_shdict_get_params_t;
++} ngx_meta_lua_shdict_get_params_t;
+ 
+ typedef struct {
+     void                  *zone;
+@@ -257,134 +135,19 @@ typedef struct {
+     double                 init;
+     long                   init_ttl;
+     int                   *forcible;
+-} ngx_http_lua_shdict_incr_params_t;
++} ngx_meta_lua_shdict_incr_params_t;
+ 
+-int ngx_http_lua_ffi_shdict_get_macos(
++int ngx_meta_lua_ffi_shdict_get_macos(
+         ngx_http_lua_shdict_get_params_t *p);
+-int ngx_http_lua_ffi_shdict_store_macos(
++int ngx_meta_lua_ffi_shdict_store_macos(
+         ngx_http_lua_shdict_store_params_t *p);
+-int ngx_http_lua_ffi_shdict_incr_macos(
++int ngx_meta_lua_ffi_shdict_incr_macos(
+         ngx_http_lua_shdict_incr_params_t *p);
+     ]]
+ 
+-    local get_params = ffi_new("ngx_http_lua_shdict_get_params_t")
+-    local incr_params = ffi_new("ngx_http_lua_shdict_incr_params_t")
+-    local store_params = ffi_new("ngx_http_lua_shdict_store_params_t")
+-
+-    ngx_lua_ffi_shdict_get = function(zone, key, key_len, value_type,
+-                                      str_value_buf, value_len,
+-                                      num_value, user_flags,
+-                                      get_stale, is_stale, errmsg)
+-
+-        get_params.zone = zone
+-        get_params.key = key
+-        get_params.key_len = key_len
+-        get_params.value_type = value_type
+-        get_params.str_value_buf = str_value_buf
+-        get_params.str_value_len = value_len
+-        get_params.num_value = num_value
+-        get_params.user_flags = user_flags
+-        get_params.get_stale = get_stale
+-        get_params.is_stale = is_stale
+-        get_params.errmsg = errmsg
+-
+-        return C.ngx_http_lua_ffi_shdict_get_macos(get_params)
+-    end
+-
+-    ngx_lua_ffi_shdict_incr = function(zone, key,
+-                                       key_len, value, err, has_init,
+-                                       init, init_ttl, forcible)
+-
+-        incr_params.zone = zone
+-        incr_params.key = key
+-        incr_params.key_len = key_len
+-        incr_params.num_value = value
+-        incr_params.errmsg = err
+-        incr_params.has_init = has_init
+-        incr_params.init = init
+-        incr_params.init_ttl = init_ttl
+-        incr_params.forcible = forcible
+-
+-        return C.ngx_http_lua_ffi_shdict_incr_macos(incr_params)
+-    end
+-
+-    ngx_lua_ffi_shdict_store = function(zone, op,
+-                                        key, key_len, value_type,
+-                                        str_value_buf, str_value_len,
+-                                        num_value, exptime, user_flags,
+-                                        errmsg, forcible)
+-
+-        store_params.zone = zone
+-        store_params.op = op
+-        store_params.key = key
+-        store_params.key_len = key_len
+-        store_params.value_type = value_type
+-        store_params.str_value_buf = str_value_buf
+-        store_params.str_value_len = str_value_len
+-        store_params.num_value = num_value
+-        store_params.exptime = exptime
+-        store_params.user_flags = user_flags
+-        store_params.errmsg = errmsg
+-        store_params.forcible = forcible
+-
+-        return C.ngx_http_lua_ffi_shdict_store_macos(store_params)
+-    end
+-end
+-
+-if MACOS and subsystem == 'stream' then
+-    ffi.cdef[[
+-typedef struct {
+-    void                  *zone;
+-    const unsigned char   *key;
+-    size_t                 key_len;
+-    int                   *value_type;
+-    unsigned char        **str_value_buf;
+-    size_t                *str_value_len;
+-    double                *num_value;
+-    int                   *user_flags;
+-    int                    get_stale;
+-    int                   *is_stale;
+-    char                 **errmsg;
+-} ngx_stream_lua_shdict_get_params_t;
+-
+-typedef struct {
+-    void                  *zone;
+-    int                    op;
+-    const unsigned char   *key;
+-    size_t                 key_len;
+-    int                    value_type;
+-    const unsigned char   *str_value_buf;
+-    size_t                 str_value_len;
+-    double                 num_value;
+-    long                   exptime;
+-    int                    user_flags;
+-    char                 **errmsg;
+-    int                   *forcible;
+-} ngx_stream_lua_shdict_store_params_t;
+-
+-typedef struct {
+-    void                  *zone;
+-    const unsigned char   *key;
+-    size_t                 key_len;
+-    double                *num_value;
+-    char                 **errmsg;
+-    int                    has_init;
+-    double                 init;
+-    long                   init_ttl;
+-    int                   *forcible;
+-} ngx_stream_lua_shdict_incr_params_t;
+-
+-int ngx_stream_lua_ffi_shdict_get_macos(
+-        ngx_stream_lua_shdict_get_params_t *p);
+-int ngx_stream_lua_ffi_shdict_store_macos(
+-        ngx_stream_lua_shdict_store_params_t *p);
+-int ngx_stream_lua_ffi_shdict_incr_macos(
+-        ngx_stream_lua_shdict_incr_params_t *p);
+-    ]]
+-
+-    local get_params = ffi_new("ngx_stream_lua_shdict_get_params_t")
+-    local store_params = ffi_new("ngx_stream_lua_shdict_store_params_t")
+-    local incr_params = ffi_new("ngx_stream_lua_shdict_incr_params_t")
++    local get_params = ffi_new("ngx_meta_lua_shdict_get_params_t")
++    local incr_params = ffi_new("ngx_meta_lua_shdict_incr_params_t")
++    local store_params = ffi_new("ngx_meta_lua_shdict_store_params_t")
+ 
+     ngx_lua_ffi_shdict_get = function(zone, key, key_len, value_type,
+                                       str_value_buf, value_len,
+@@ -403,7 +166,7 @@ int ngx_stream_lua_ffi_shdict_incr_macos(
+         get_params.is_stale = is_stale
+         get_params.errmsg = errmsg
+ 
+-        return C.ngx_stream_lua_ffi_shdict_get_macos(get_params)
++        return C.ngx_meta_lua_ffi_shdict_get_macos(get_params)
+     end
+ 
+     ngx_lua_ffi_shdict_incr = function(zone, key,
+@@ -420,7 +183,7 @@ int ngx_stream_lua_ffi_shdict_incr_macos(
+         incr_params.init_ttl = init_ttl
+         incr_params.forcible = forcible
+ 
+-        return C.ngx_stream_lua_ffi_shdict_incr_macos(incr_params)
++        return C.ngx_meta_lua_ffi_shdict_incr_macos(incr_params)
+     end
+ 
+     ngx_lua_ffi_shdict_store = function(zone, op,
+@@ -442,7 +205,7 @@ int ngx_stream_lua_ffi_shdict_incr_macos(
+         store_params.errmsg = errmsg
+         store_params.forcible = forcible
+ 
+-        return C.ngx_stream_lua_ffi_shdict_store_macos(store_params)
++        return C.ngx_meta_lua_ffi_shdict_store_macos(store_params)
+     end
+ end
+ 

--- a/patch/1.29.2.4/lua-resty-core-shared_shdict.patch
+++ b/patch/1.29.2.4/lua-resty-core-shared_shdict.patch
@@ -2,18 +2,18 @@ diff --git lib/resty/core/shdict.lua lib/resty/core/shdict.lua
 index 8d60d16..7537e7b 100644
 --- lib/resty/core/shdict.lua
 +++ lib/resty/core/shdict.lua
-@@ -28,7 +28,6 @@ local type = type
+@@ -28,7 +28,6 @@
  local error = error
  local getmetatable = getmetatable
  local FFI_DECLINED = base.FFI_DECLINED
 -local subsystem = ngx.config.subsystem
- 
- 
+
+
  local ngx_lua_ffi_shdict_get
-@@ -42,181 +41,60 @@ local ngx_lua_ffi_shdict_free_space
+@@ -42,296 +41,60 @@
  local ngx_lua_ffi_shdict_udata_to_zone
- 
- 
+
+
 -if subsystem == 'http' then
 -    ffi.cdef[[
 -int ngx_http_lua_ffi_shdict_get(void *zone, const unsigned char *key,
@@ -22,30 +22,30 @@ index 8d60d16..7537e7b 100644
      size_t key_len, int *value_type, unsigned char **str_value_buf,
      size_t *str_value_len, double *num_value, int *user_flags,
      int get_stale, int *is_stale, char **errmsg);
- 
+
 -int ngx_http_lua_ffi_shdict_incr(void *zone, const unsigned char *key,
 +int ngx_meta_lua_ffi_shdict_incr(void *zone, const unsigned char *key,
      size_t key_len, double *value, char **err, int has_init,
      double init, long init_ttl, int *forcible);
- 
+
 -int ngx_http_lua_ffi_shdict_store(void *zone, int op,
 +int ngx_meta_lua_ffi_shdict_store(void *zone, int op,
      const unsigned char *key, size_t key_len, int value_type,
      const unsigned char *str_value_buf, size_t str_value_len,
      double num_value, long exptime, int user_flags, char **errmsg,
      int *forcible);
- 
+
 -int ngx_http_lua_ffi_shdict_flush_all(void *zone);
 +int ngx_meta_lua_ffi_shdict_flush_all(void *zone);
- 
+
 -long ngx_http_lua_ffi_shdict_get_ttl(void *zone,
 +long ngx_meta_lua_ffi_shdict_get_ttl(void *zone,
      const unsigned char *key, size_t key_len);
- 
+
 -int ngx_http_lua_ffi_shdict_set_expire(void *zone,
 +int ngx_meta_lua_ffi_shdict_set_expire(void *zone,
      const unsigned char *key, size_t key_len, long exptime);
- 
+
 -size_t ngx_http_lua_ffi_shdict_capacity(void *zone);
 -
 -void *ngx_http_lua_ffi_shdict_udata_to_zone(void *zone_udata);
@@ -66,7 +66,7 @@ index 8d60d16..7537e7b 100644
 -                                       key_len, value, err, has_init,
 -                                       init, init_ttl, forcible)
 +size_t ngx_meta_lua_ffi_shdict_capacity(void *zone);
- 
+
 -        return C.ngx_http_lua_ffi_shdict_incr(zone, key,
 -                                              key_len, value, err, has_init,
 -                                              init, init_ttl, forcible)
@@ -108,7 +108,7 @@ index 8d60d16..7537e7b 100644
 -elseif subsystem == 'stream' then
 +void *ngx_meta_lua_ffi_shdict_udata_to_zone(void *zone_udata);
 +]]
- 
+
 +if not pcall(function ()
 +    return C.ngx_meta_lua_ffi_shdict_free_space
 +end)
@@ -199,7 +199,7 @@ index 8d60d16..7537e7b 100644
 -else
 -    error("unknown subsystem: " .. subsystem)
  end
- 
+
 +pcall(function ()
 +    ngx_lua_ffi_shdict_get = C.ngx_meta_lua_ffi_shdict_get
 +    ngx_lua_ffi_shdict_incr = C.ngx_meta_lua_ffi_shdict_incr
@@ -211,42 +211,60 @@ index 8d60d16..7537e7b 100644
 +    ngx_lua_ffi_shdict_free_space = C.ngx_meta_lua_ffi_shdict_free_space
 +    ngx_lua_ffi_shdict_udata_to_zone = C.ngx_meta_lua_ffi_shdict_udata_to_zone
 +end)
-+
- 
- local MACOS = jit and jit.os == "OSX"
- 
+
+-local MACOS = jit and jit.os == "OSX"
+
 -if MACOS and subsystem == 'http' then
-+if MACOS then
-     ffi.cdef[[
- typedef struct {
-     void                  *zone;
-@@ -230,7 +108,7 @@ typedef struct {
-     int                    get_stale;
-     int                   *is_stale;
-     char                 **errmsg;
+-    ffi.cdef[[
+-typedef struct {
+-    void                  *zone;
+-    const unsigned char   *key;
+-    size_t                 key_len;
+-    int                   *value_type;
+-    unsigned char        **str_value_buf;
+-    size_t                *str_value_len;
+-    double                *num_value;
+-    int                   *user_flags;
+-    int                    get_stale;
+-    int                   *is_stale;
+-    char                 **errmsg;
 -} ngx_http_lua_shdict_get_params_t;
-+} ngx_meta_lua_shdict_get_params_t;
- 
- typedef struct {
-     void                  *zone;
-@@ -257,134 +135,19 @@ typedef struct {
-     double                 init;
-     long                   init_ttl;
-     int                   *forcible;
+-
+-typedef struct {
+-    void                  *zone;
+-    int                    op;
+-    const unsigned char   *key;
+-    size_t                 key_len;
+-    int                    value_type;
+-    const unsigned char   *str_value_buf;
+-    size_t                 str_value_len;
+-    double                 num_value;
+-    long                   exptime;
+-    int                    user_flags;
+-    char                 **errmsg;
+-    int                   *forcible;
+-} ngx_http_lua_shdict_store_params_t;
+-
+-typedef struct {
+-    void                  *zone;
+-    const unsigned char   *key;
+-    size_t                 key_len;
+-    double                *num_value;
+-    char                 **errmsg;
+-    int                    has_init;
+-    double                 init;
+-    long                   init_ttl;
+-    int                   *forcible;
 -} ngx_http_lua_shdict_incr_params_t;
-+} ngx_meta_lua_shdict_incr_params_t;
- 
+-
 -int ngx_http_lua_ffi_shdict_get_macos(
-+int ngx_meta_lua_ffi_shdict_get_macos(
-         ngx_http_lua_shdict_get_params_t *p);
+-        ngx_http_lua_shdict_get_params_t *p);
 -int ngx_http_lua_ffi_shdict_store_macos(
-+int ngx_meta_lua_ffi_shdict_store_macos(
-         ngx_http_lua_shdict_store_params_t *p);
+-        ngx_http_lua_shdict_store_params_t *p);
 -int ngx_http_lua_ffi_shdict_incr_macos(
-+int ngx_meta_lua_ffi_shdict_incr_macos(
-         ngx_http_lua_shdict_incr_params_t *p);
-     ]]
- 
+-        ngx_http_lua_shdict_incr_params_t *p);
+-    ]]
+-
 -    local get_params = ffi_new("ngx_http_lua_shdict_get_params_t")
 -    local incr_params = ffi_new("ngx_http_lua_shdict_incr_params_t")
 -    local store_params = ffi_new("ngx_http_lua_shdict_store_params_t")
@@ -310,91 +328,85 @@ index 8d60d16..7537e7b 100644
 -        return C.ngx_http_lua_ffi_shdict_store_macos(store_params)
 -    end
 -end
--
++local MACOS = jit and jit.os == "OSX"
+
 -if MACOS and subsystem == 'stream' then
--    ffi.cdef[[
--typedef struct {
--    void                  *zone;
--    const unsigned char   *key;
--    size_t                 key_len;
--    int                   *value_type;
--    unsigned char        **str_value_buf;
--    size_t                *str_value_len;
--    double                *num_value;
--    int                   *user_flags;
--    int                    get_stale;
--    int                   *is_stale;
--    char                 **errmsg;
++if MACOS then
+     ffi.cdef[[
+ typedef struct {
+     void                  *zone;
+@@ -345,7 +108,7 @@
+     int                    get_stale;
+     int                   *is_stale;
+     char                 **errmsg;
 -} ngx_stream_lua_shdict_get_params_t;
--
--typedef struct {
--    void                  *zone;
--    int                    op;
--    const unsigned char   *key;
--    size_t                 key_len;
--    int                    value_type;
--    const unsigned char   *str_value_buf;
--    size_t                 str_value_len;
--    double                 num_value;
--    long                   exptime;
--    int                    user_flags;
--    char                 **errmsg;
--    int                   *forcible;
++} ngx_meta_lua_shdict_get_params_t;
+
+ typedef struct {
+     void                  *zone;
+@@ -360,7 +123,7 @@
+     int                    user_flags;
+     char                 **errmsg;
+     int                   *forcible;
 -} ngx_stream_lua_shdict_store_params_t;
--
--typedef struct {
--    void                  *zone;
--    const unsigned char   *key;
--    size_t                 key_len;
--    double                *num_value;
--    char                 **errmsg;
--    int                    has_init;
--    double                 init;
--    long                   init_ttl;
--    int                   *forcible;
++} ngx_meta_lua_shdict_store_params_t;
+
+ typedef struct {
+     void                  *zone;
+@@ -372,19 +135,19 @@
+     double                 init;
+     long                   init_ttl;
+     int                   *forcible;
 -} ngx_stream_lua_shdict_incr_params_t;
--
++} ngx_meta_lua_shdict_incr_params_t;
+
 -int ngx_stream_lua_ffi_shdict_get_macos(
 -        ngx_stream_lua_shdict_get_params_t *p);
 -int ngx_stream_lua_ffi_shdict_store_macos(
 -        ngx_stream_lua_shdict_store_params_t *p);
 -int ngx_stream_lua_ffi_shdict_incr_macos(
 -        ngx_stream_lua_shdict_incr_params_t *p);
--    ]]
--
++int ngx_meta_lua_ffi_shdict_get_macos(
++        ngx_meta_lua_shdict_get_params_t *p);
++int ngx_meta_lua_ffi_shdict_store_macos(
++        ngx_meta_lua_shdict_store_params_t *p);
++int ngx_meta_lua_ffi_shdict_incr_macos(
++        ngx_meta_lua_shdict_incr_params_t *p);
+     ]]
+
 -    local get_params = ffi_new("ngx_stream_lua_shdict_get_params_t")
 -    local store_params = ffi_new("ngx_stream_lua_shdict_store_params_t")
 -    local incr_params = ffi_new("ngx_stream_lua_shdict_incr_params_t")
 +    local get_params = ffi_new("ngx_meta_lua_shdict_get_params_t")
 +    local incr_params = ffi_new("ngx_meta_lua_shdict_incr_params_t")
 +    local store_params = ffi_new("ngx_meta_lua_shdict_store_params_t")
- 
+
      ngx_lua_ffi_shdict_get = function(zone, key, key_len, value_type,
                                        str_value_buf, value_len,
-@@ -403,7 +166,7 @@ int ngx_stream_lua_ffi_shdict_incr_macos(
+@@ -403,7 +166,7 @@
          get_params.is_stale = is_stale
          get_params.errmsg = errmsg
- 
+
 -        return C.ngx_stream_lua_ffi_shdict_get_macos(get_params)
 +        return C.ngx_meta_lua_ffi_shdict_get_macos(get_params)
      end
- 
+
      ngx_lua_ffi_shdict_incr = function(zone, key,
-@@ -420,7 +183,7 @@ int ngx_stream_lua_ffi_shdict_incr_macos(
+@@ -420,7 +183,7 @@
          incr_params.init_ttl = init_ttl
          incr_params.forcible = forcible
- 
+
 -        return C.ngx_stream_lua_ffi_shdict_incr_macos(incr_params)
 +        return C.ngx_meta_lua_ffi_shdict_incr_macos(incr_params)
      end
- 
+
      ngx_lua_ffi_shdict_store = function(zone, op,
-@@ -442,7 +205,7 @@ int ngx_stream_lua_ffi_shdict_incr_macos(
+@@ -442,7 +205,7 @@
          store_params.errmsg = errmsg
          store_params.forcible = forcible
- 
+
 -        return C.ngx_stream_lua_ffi_shdict_store_macos(store_params)
 +        return C.ngx_meta_lua_ffi_shdict_store_macos(store_params)
      end
  end
- 
+

--- a/patch/1.29.2.4/lua-resty-core-ssl_session_hostname.patch
+++ b/patch/1.29.2.4/lua-resty-core-ssl_session_hostname.patch
@@ -1,0 +1,76 @@
+diff --git lib/ngx/ssl.lua lib/ngx/ssl.lua
+index b696bea..ff1f251 100644
+--- lib/ngx/ssl.lua
++++ lib/ngx/ssl.lua
+@@ -26,6 +26,7 @@ local ngx_lua_ffi_ssl_set_der_private_key
+ local ngx_lua_ffi_ssl_raw_server_addr
+ local ngx_lua_ffi_ssl_server_port
+ local ngx_lua_ffi_ssl_server_name
++local ngx_lua_ffi_ssl_session_hostname
+ local ngx_lua_ffi_ssl_raw_client_addr
+ local ngx_lua_ffi_cert_pem_to_der
+ local ngx_lua_ffi_priv_key_pem_to_der
+@@ -64,6 +65,9 @@ if subsystem == 'http' then
+     int ngx_http_lua_ffi_ssl_server_name(ngx_http_request_t *r, char **name,
+         size_t *namelen, char **err);
+ 
++    int ngx_http_lua_ffi_ssl_session_hostname(ngx_http_request_t *r, char **name,
++        size_t *namelen, char **err);
++
+     int ngx_http_lua_ffi_ssl_raw_client_addr(ngx_http_request_t *r, char **addr,
+         size_t *addrlen, int *addrtype, char **err);
+ 
+@@ -124,6 +128,7 @@ if subsystem == 'http' then
+     ngx_lua_ffi_ssl_raw_server_addr = C.ngx_http_lua_ffi_ssl_raw_server_addr
+     ngx_lua_ffi_ssl_server_port = C.ngx_http_lua_ffi_ssl_server_port
+     ngx_lua_ffi_ssl_server_name = C.ngx_http_lua_ffi_ssl_server_name
++    ngx_lua_ffi_ssl_session_hostname = C.ngx_http_lua_ffi_ssl_session_hostname
+     ngx_lua_ffi_ssl_raw_client_addr = C.ngx_http_lua_ffi_ssl_raw_client_addr
+     ngx_lua_ffi_cert_pem_to_der = C.ngx_http_lua_ffi_cert_pem_to_der
+     ngx_lua_ffi_priv_key_pem_to_der = C.ngx_http_lua_ffi_priv_key_pem_to_der
+@@ -164,6 +169,9 @@ elseif subsystem == 'stream' then
+     int ngx_stream_lua_ffi_ssl_server_name(ngx_stream_lua_request_t *r,
+         char **name, size_t *namelen, char **err);
+ 
++    int ngx_stream_lua_ffi_ssl_session_hostname(ngx_stream_lua_request_t *r,
++        char **name, size_t *namelen, char **err);
++
+     int ngx_stream_lua_ffi_ssl_raw_client_addr(ngx_stream_lua_request_t *r,
+         char **addr, size_t *addrlen, int *addrtype, char **err);
+ 
+@@ -212,6 +220,7 @@ elseif subsystem == 'stream' then
+     ngx_lua_ffi_ssl_raw_server_addr = C.ngx_stream_lua_ffi_ssl_raw_server_addr
+     ngx_lua_ffi_ssl_server_port = C.ngx_stream_lua_ffi_ssl_server_port
+     ngx_lua_ffi_ssl_server_name = C.ngx_stream_lua_ffi_ssl_server_name
++    ngx_lua_ffi_ssl_session_hostname = C.ngx_stream_lua_ffi_ssl_session_hostname
+     ngx_lua_ffi_ssl_raw_client_addr = C.ngx_stream_lua_ffi_ssl_raw_client_addr
+     ngx_lua_ffi_cert_pem_to_der = C.ngx_stream_lua_ffi_cert_pem_to_der
+     ngx_lua_ffi_priv_key_pem_to_der = C.ngx_stream_lua_ffi_priv_key_pem_to_der
+@@ -346,6 +355,27 @@ function _M.server_name()
+ end
+ 
+ 
++function _M.session_hostname()
++    local r = get_request()
++    if not r then
++        error("no request found")
++    end
++
++    local sizep = get_size_ptr()
++
++    local rc = ngx_lua_ffi_ssl_session_hostname(r, charpp, sizep, errmsg)
++    if rc ~= FFI_OK then
++        return nil, ffi_str(errmsg[0])
++    end
++
++    if sizep[0] == 0 then
++        return nil
++    end
++
++    return ffi_str(charpp[0], sizep[0])
++end
++
++
+ function _M.raw_client_addr()
+     local r = get_request()
+     if not r then

--- a/patch/1.29.2.4/lua-resty-core-tlshandshake.patch
+++ b/patch/1.29.2.4/lua-resty-core-tlshandshake.patch
@@ -1,0 +1,340 @@
+diff --git Makefile Makefile
+index 3caabe2..6361a23 100644
+--- Makefile
++++ Makefile
+@@ -12,10 +12,12 @@ all: ;
+ 
+ install: all
+ 	$(INSTALL) -d $(DESTDIR)$(LUA_LIB_DIR)/resty/core/
++	$(INSTALL) -d $(DESTDIR)$(LUA_LIB_DIR)/resty/core/socket
+ 	$(INSTALL) -d $(DESTDIR)$(LUA_LIB_DIR)/ngx/
+ 	$(INSTALL) -d $(DESTDIR)$(LUA_LIB_DIR)/ngx/ssl
+ 	$(INSTALL) lib/resty/*.lua $(DESTDIR)$(LUA_LIB_DIR)/resty/
+ 	$(INSTALL) lib/resty/core/*.lua $(DESTDIR)$(LUA_LIB_DIR)/resty/core/
++	$(INSTALL) lib/resty/core/socket/*.lua $(DESTDIR)$(LUA_LIB_DIR)/resty/core/socket
+ 	$(INSTALL) lib/ngx/*.lua $(DESTDIR)$(LUA_LIB_DIR)/ngx/
+ 	$(INSTALL) lib/ngx/ssl/*.lua $(DESTDIR)$(LUA_LIB_DIR)/ngx/ssl/
+ 
+diff --git lib/resty/core.lua lib/resty/core.lua
+index 5c7ef69..f2c2f3a 100644
+--- lib/resty/core.lua
++++ lib/resty/core.lua
+@@ -23,6 +23,7 @@ if subsystem == 'http' then
+ end
+ 
+ require "resty.core.socket"
++require "resty.core.socket.tcp"
+ require "resty.core.misc"
+ require "resty.core.ctx"
+ 
+diff --git lib/resty/core/socket/tcp.lua lib/resty/core/socket/tcp.lua
+new file mode 100644
+index 0000000..b6e009c
+--- /dev/null
++++ lib/resty/core/socket/tcp.lua
+@@ -0,0 +1,305 @@
++-- Copyright (C) by OpenResty Inc.
++
++
++local base = require "resty.core.base"
++local ffi = require "ffi"
++local ssl = require "ngx.ssl"
++
++
++local C = ffi.C
++local ffi_str = ffi.string
++local ffi_gc = ffi.gc
++local FFI_ERROR = base.FFI_ERROR
++local FFI_DONE = base.FFI_DONE
++local FFI_OK = base.FFI_OK
++local FFI_AGAIN = base.FFI_AGAIN
++local FFI_NO_REQ_CTX = base.FFI_NO_REQ_CTX
++local get_request = base.get_request
++local new_tab = base.new_tab
++local clear_tab = base.clear_tab
++local error = error
++local assert = assert
++local type = type
++local pcall = pcall
++local select = select
++local co_yield = coroutine._yield
++local io_open = io.open
++local subsystem = ngx.config.subsystem
++
++
++local ngx_lua_ffi_socket_tcp_tlshandshake
++local ngx_lua_ffi_socket_tcp_get_tlshandshake_result
++local ngx_lua_ffi_tls_free_session
++
++if subsystem == 'http' then
++    ffi.cdef[[
++typedef struct ngx_http_lua_socket_tcp_upstream_s
++    ngx_http_lua_socket_tcp_upstream_t;
++
++int ngx_http_lua_ffi_socket_tcp_tlshandshake(ngx_http_request_t *r,
++    ngx_http_lua_socket_tcp_upstream_t *u, void *sess,
++    int enable_session_reuse, ngx_str_t *server_name, int verify,
++    int ocsp_status_req, void *chain, void *pkey, char **errmsg);
++
++int ngx_http_lua_ffi_socket_tcp_get_tlshandshake_result(ngx_http_request_t *r,
++    ngx_http_lua_socket_tcp_upstream_t *u, void **sess, char **errmsg,
++    int *openssl_error_code);
++
++void ngx_http_lua_ffi_tls_free_session(void *sess);
++]]
++
++    ngx_lua_ffi_socket_tcp_tlshandshake =
++        C.ngx_http_lua_ffi_socket_tcp_tlshandshake
++    ngx_lua_ffi_socket_tcp_get_tlshandshake_result =
++        C.ngx_http_lua_ffi_socket_tcp_get_tlshandshake_result
++    ngx_lua_ffi_tls_free_session = C.ngx_http_lua_ffi_tls_free_session
++
++elseif subsystem == 'stream' then
++    ffi.cdef[[
++typedef struct ngx_stream_lua_socket_tcp_upstream_s
++    ngx_stream_lua_socket_tcp_upstream_t;
++
++int ngx_stream_lua_ffi_socket_tcp_tlshandshake(ngx_stream_lua_request_t *r,
++    ngx_stream_lua_socket_tcp_upstream_t *u, void *sess,
++    int enable_session_reuse, ngx_str_t *server_name, int verify,
++    int ocsp_status_req, void *chain, void *pkey, char **errmsg);
++
++int ngx_stream_lua_ffi_socket_tcp_get_tlshandshake_result(
++    ngx_stream_lua_request_t *r,
++    ngx_stream_lua_socket_tcp_upstream_t *u, void **sess, char **errmsg,
++    int *openssl_error_code);
++
++void ngx_stream_lua_ffi_tls_free_session(void *sess);
++]]
++
++    ngx_lua_ffi_socket_tcp_tlshandshake =
++        C.ngx_stream_lua_ffi_socket_tcp_tlshandshake
++    ngx_lua_ffi_socket_tcp_get_tlshandshake_result =
++        C.ngx_stream_lua_ffi_socket_tcp_get_tlshandshake_result
++    ngx_lua_ffi_tls_free_session = C.ngx_stream_lua_ffi_tls_free_session
++end
++
++
++local SOCKET_CTX_INDEX = 1
++
++
++local errmsg = base.get_errmsg_ptr()
++local session_ptr = ffi.new("void *[1]")
++local server_name_str = ffi.new("ngx_str_t[1]")
++local openssl_error_code = ffi.new("int[1]")
++local cached_options = new_tab(0, 4)
++
++
++local function read_file(path)
++    local f, err = io_open(path)
++    if not f then
++        return nil, err
++    end
++
++    local txt, err = f:read("*a")
++    f:close()
++    if not txt then
++        return nil, err
++    end
++
++    return txt
++end
++
++
++local function report_handshake_error(errmsg, openssl_error_code)
++    if openssl_error_code[0] ~= 0 then
++        return nil, openssl_error_code[0] .. ": " .. ffi_str(errmsg[0])
++    end
++
++    return nil, ffi_str(errmsg[0])
++end
++
++
++local function tlshandshake(self, options)
++    if not options then
++        clear_tab(cached_options)
++        options = cached_options
++
++    elseif type(options) ~= "table" then
++        error("bad options arg: table expected", 2)
++    end
++
++    local r = get_request()
++    if not r then
++        error("no request found", 2)
++    end
++
++    local reused_session = options.reused_session
++    session_ptr[0] = type(reused_session) == "cdata" and reused_session or nil
++
++    if options.server_name then
++        server_name_str[0].data = options.server_name
++        server_name_str[0].len = #options.server_name
++
++    else
++        server_name_str[0].data = nil
++        server_name_str[0].len = 0
++    end
++
++    local client_cert, client_pkey
++
++    if options.client_cert_path or options.client_cert then
++        if options.client_cert_path and options.client_cert then
++            error("client client_cert_path and client_cert both setting ", 2)
++        end
++
++        if not options.client_priv_key_path and not options.client_priv_key then
++            error("client certificate supplied without corresponding " ..
++                    "private key", 2)
++        end
++
++        if options.client_priv_key_path and options.client_priv_key then
++            error("client certificate private key supplied with " ..
++                    "client_priv_key and client_priv_key_path", 2)
++        end
++
++        if options.client_cert then
++            if type(options.client_cert) ~= "string" then
++                error("bad client_cert option type", 2)
++            end
++        else
++            if type(options.client_cert_path) ~= "string" then
++                error("bad client_cert option type", 2)
++            end
++
++            local txt, err = read_file(options.client_cert_path)
++            if not txt then
++                return nil, err
++            end
++
++            options.client_cert = txt
++        end
++
++        if options.client_priv_key then
++            if type(options.client_priv_key) ~= "string" then
++                error("bad client_priv_key option type", 2)
++            end
++        else
++            if type(options.client_priv_key_path) ~= "string" then
++                error("bad client_priv_key_path option type", 2)
++            end
++
++            local txt, err = read_file(options.client_priv_key_path)
++            if not txt then
++                return nil, err
++            end
++
++            options.client_priv_key = txt
++        end
++
++        local cert, err = ssl.parse_pem_cert(options.client_cert)
++        if not cert then
++            return nil, err
++        end
++        client_cert = cert
++
++        local pkey, err = ssl.parse_pem_priv_key(options.client_priv_key)
++        if not pkey then
++            return nil, err
++        end
++        client_pkey = pkey
++    end
++
++    local u = self[SOCKET_CTX_INDEX]
++
++    local rc = ngx_lua_ffi_socket_tcp_tlshandshake(r, u,
++                   session_ptr[0],
++                   reused_session ~= false,
++                   server_name_str,
++                   options.verify and 1 or 0,
++                   options.ocsp_status_req and 1 or 0,
++                   client_cert, client_pkey, errmsg)
++
++    if rc == FFI_NO_REQ_CTX then
++        error("no request ctx found", 2)
++    end
++
++    if rc == FFI_ERROR then
++        return nil, ffi_str(errmsg[0])
++    end
++
++    if rc == FFI_DONE then
++        return reused_session
++    end
++
++    while true do
++        if rc == FFI_OK then
++            if reused_session == false then
++                return true
++            end
++
++            rc = ngx_lua_ffi_socket_tcp_get_tlshandshake_result(r, u,
++                     session_ptr, errmsg, openssl_error_code)
++
++            if rc == FFI_ERROR then
++                return report_handshake_error(errmsg, openssl_error_code)
++            end
++
++            if session_ptr[0] == nil then
++                return nil
++            end
++
++            return ffi_gc(session_ptr[0], ngx_lua_ffi_tls_free_session)
++        end
++
++        assert(rc == FFI_AGAIN)
++
++        co_yield()
++
++        rc = ngx_lua_ffi_socket_tcp_get_tlshandshake_result(r, u,
++                 session_ptr, errmsg, openssl_error_code)
++
++        if rc == FFI_ERROR then
++            return report_handshake_error(errmsg, openssl_error_code)
++        end
++    end
++end
++
++
++local function sslhandshake(self, reused_session, server_name, ssl_verify,
++    send_status_req, ...)
++
++    local n = select("#", ...)
++    if not self or n > 1 then
++        error("ngx.socket sslhandshake: expecting 1 ~ 5 arguments " ..
++              "(including the object), but seen " .. (self and 5 + n or 0))
++    end
++
++    cached_options.reused_session = reused_session
++    cached_options.server_name = server_name
++    cached_options.verify = ssl_verify
++    cached_options.ocsp_status_req = send_status_req
++
++    local res, err = tlshandshake(self, cached_options)
++
++    clear_tab(cached_options)
++
++    return res, err
++end
++
++
++do
++    local old_socket_tcp = ngx.socket.tcp
++
++    function ngx.socket.tcp()
++        local ok, sock = pcall(old_socket_tcp)
++        if not ok then
++            error(sock, 2)
++        end
++
++        sock.tlshandshake = tlshandshake
++        sock.sslhandshake = sslhandshake
++
++        return sock
++    end
++end
++
++
++return {
++    version = base.version
++}

--- a/patch/1.29.2.4/lua-resty-core-tlshandshake.patch
+++ b/patch/1.29.2.4/lua-resty-core-tlshandshake.patch
@@ -300,7 +300,7 @@ index 0000000..b6e009c
 +    send_status_req, ...)
 +
 +    local n = select("#", ...)
-+    if not self or n > 1 then
++    if not self or n > 0 then
 +        error("ngx.socket sslhandshake: expecting 1 ~ 5 arguments " ..
 +              "(including the object), but seen " .. (self and 5 + n or 0))
 +    end

--- a/patch/1.29.2.4/lua-resty-core-tlshandshake.patch
+++ b/patch/1.29.2.4/lua-resty-core-tlshandshake.patch
@@ -180,7 +180,7 @@ index 0000000..b6e009c
 +
 +    if options.client_cert_path or options.client_cert then
 +        if options.client_cert_path and options.client_cert then
-+            error("client client_cert_path and client_cert both setting ", 2)
++            error("client_cert_path and client_cert cannot both be set", 2)
 +        end
 +
 +        if not options.client_priv_key_path and not options.client_priv_key then
@@ -199,7 +199,7 @@ index 0000000..b6e009c
 +            end
 +        else
 +            if type(options.client_cert_path) ~= "string" then
-+                error("bad client_cert option type", 2)
++                error("bad client_cert_path option type", 2)
 +            end
 +
 +            local txt, err = read_file(options.client_cert_path)

--- a/patch/1.29.2.4/nginx-client_max_body_size.patch
+++ b/patch/1.29.2.4/nginx-client_max_body_size.patch
@@ -1,0 +1,127 @@
+diff --git src/http/ngx_http_core_module.c src/http/ngx_http_core_module.c
+index 7845f8f..e1e1b77 100644
+--- src/http/ngx_http_core_module.c
++++ src/http/ngx_http_core_module.c
+@@ -8,6 +8,9 @@
+ #include <ngx_config.h>
+ #include <ngx_core.h>
+ #include <ngx_http.h>
++#if (NGX_HTTP_APISIX)
++#include <ngx_http_apisix_module.h>
++#endif
+ 
+ 
+ typedef struct {
+@@ -992,7 +995,12 @@ ngx_http_core_find_config_phase(ngx_http_request_t *r,
+                    "http cl:%O max:%O",
+                    r->headers_in.content_length_n, clcf->client_max_body_size);
+ 
++#if (NGX_HTTP_APISIX)
++    if (!ngx_http_apisix_delay_client_max_body_check(r)
++        && r->headers_in.content_length_n != -1
++#else
+     if (r->headers_in.content_length_n != -1
++#endif
+         && !r->discard_body
+         && clcf->client_max_body_size
+         && clcf->client_max_body_size < r->headers_in.content_length_n)
+diff --git src/http/ngx_http_request_body.c src/http/ngx_http_request_body.c
+index afb0423..6faa09e 100644
+--- src/http/ngx_http_request_body.c
++++ src/http/ngx_http_request_body.c
+@@ -8,6 +8,9 @@
+ #include <ngx_config.h>
+ #include <ngx_core.h>
+ #include <ngx_http.h>
++#if (NGX_HTTP_APISIX)
++#include <ngx_http_apisix_module.h>
++#endif
+ 
+ 
+ static void ngx_http_read_client_request_body_handler(ngx_http_request_t *r);
+@@ -48,6 +51,25 @@ ngx_http_read_client_request_body(ngx_http_request_t *r,
+         return NGX_OK;
+     }
+ 
++#if (NGX_HTTP_APISIX)
++    if (ngx_http_apisix_delay_client_max_body_check(r)) {
++        off_t max_body_size = ngx_http_apisix_client_max_body_size(r);
++
++        if (r->headers_in.content_length_n != -1
++            && max_body_size
++            && max_body_size < r->headers_in.content_length_n)
++        {
++            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
++                          "client intended to send too large body: %O bytes",
++                          r->headers_in.content_length_n);
++
++            r->expect_tested = 1;
++            rc = NGX_HTTP_REQUEST_ENTITY_TOO_LARGE;
++            goto done;
++        }
++    }
++#endif
++
+     if (ngx_http_test_expect(r) != NGX_OK) {
+         rc = NGX_HTTP_INTERNAL_SERVER_ERROR;
+         goto done;
+@@ -1100,6 +1122,10 @@ ngx_http_request_body_chunked_filter(ngx_http_request_t *r, ngx_chain_t *in)
+     out = NULL;
+     ll = &out;
+ 
++#if (NGX_HTTP_APISIX)
++    off_t max_body_size = ngx_http_apisix_client_max_body_size(r);
++#endif
++
+     if (rb->rest == -1) {
+ 
+         ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+@@ -1139,8 +1165,15 @@ ngx_http_request_body_chunked_filter(ngx_http_request_t *r, ngx_chain_t *in)
+ 
+                 clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
+ 
++#if (NGX_HTTP_APISIX)
++                (void) clcf; /* unused */
++
++                if (max_body_size
++                    && max_body_size
++#else
+                 if (clcf->client_max_body_size
+                     && clcf->client_max_body_size
++#endif
+                        - r->headers_in.content_length_n < rb->chunked->size)
+                 {
+                     ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+diff --git src/http/v2/ngx_http_v2.c src/http/v2/ngx_http_v2.c
+index 0f5bd3d..d343fe7 100644
+--- src/http/v2/ngx_http_v2.c
++++ src/http/v2/ngx_http_v2.c
+@@ -9,6 +9,9 @@
+ #include <ngx_core.h>
+ #include <ngx_http.h>
+ #include <ngx_http_v2_module.h>
++#if (NGX_HTTP_APISIX)
++#include <ngx_http_apisix_module.h>
++#endif
+ 
+ 
+ /* errors */
+@@ -4107,10 +4110,18 @@ ngx_http_v2_filter_request_body(ngx_http_request_t *r)
+             }
+ 
+         } else {
++#if (NGX_HTTP_APISIX)
++            off_t max_body_size = ngx_http_apisix_client_max_body_size(r);
++
++            (void) clcf; /* unused */
++
++            if (max_body_size && rb->received > max_body_size)
++#else
+             clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
+ 
+             if (clcf->client_max_body_size
+                 && rb->received > clcf->client_max_body_size)
++#endif
+             {
+                 ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+                               "client intended to send too large chunked body: "

--- a/patch/1.29.2.4/nginx-client_max_body_size.patch
+++ b/patch/1.29.2.4/nginx-client_max_body_size.patch
@@ -76,7 +76,7 @@ index afb0423..6faa09e 100644
      if (rb->rest == -1) {
  
          ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-@@ -1139,8 +1165,15 @@ ngx_http_request_body_chunked_filter(ngx_http_request_t *r, ngx_chain_t *in)
+@@ -1139,8 +1165,14 @@ ngx_http_request_body_chunked_filter(ngx_http_request_t *r, ngx_chain_t *in)
  
                  clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
  
@@ -84,7 +84,6 @@ index afb0423..6faa09e 100644
 +                (void) clcf; /* unused */
 +
 +                if (max_body_size
-+                    && max_body_size
 +#else
                  if (clcf->client_max_body_size
                      && clcf->client_max_body_size

--- a/patch/1.29.2.4/nginx-connection-original-dst.patch
+++ b/patch/1.29.2.4/nginx-connection-original-dst.patch
@@ -1,0 +1,112 @@
+diff --git auto/os/linux auto/os/linux
+index 02dcaf2..790bc80 100644
+--- auto/os/linux
++++ auto/os/linux
+@@ -215,6 +215,21 @@ ngx_feature_test="struct __user_cap_data_struct    data;
+                   (void) SYS_capset"
+ . auto/feature
+ 
++# netfilter_ipv4
++
++ngx_feature="netfilter_ipv4"
++ngx_feature_name="NGX_HAVE_NETFILTER_IPV4"
++ngx_feature_run=no
++ngx_feature_incs="#include <linux/netfilter_ipv4.h>"
++ngx_feature_path=
++ngx_feature_libs=
++ngx_feature_test="int so_original_dst;
++
++                  so_original_dst = SO_ORIGINAL_DST;
++
++                  (void) so_original_dst;"
++. auto/feature
++
+ 
+ # crypt_r()
+ 
+diff --git src/http/ngx_http_variables.c src/http/ngx_http_variables.c
+index 4f0bd0e..218668b 100644
+--- src/http/ngx_http_variables.c
++++ src/http/ngx_http_variables.c
+@@ -132,6 +132,11 @@ static ngx_int_t ngx_http_variable_connection_requests(ngx_http_request_t *r,
+ static ngx_int_t ngx_http_variable_connection_time(ngx_http_request_t *r,
+     ngx_http_variable_value_t *v, uintptr_t data);
+ 
++#if (NGX_HAVE_NETFILTER_IPV4)
++static ngx_int_t ngx_http_variable_connection_dst(ngx_http_request_t *r,
++    ngx_http_variable_value_t *v, uintptr_t data);
++#endif
++
+ static ngx_int_t ngx_http_variable_nginx_version(ngx_http_request_t *r,
+     ngx_http_variable_value_t *v, uintptr_t data);
+ static ngx_int_t ngx_http_variable_hostname(ngx_http_request_t *r,
+@@ -351,6 +356,11 @@ static ngx_http_variable_t  ngx_http_core_variables[] = {
+     { ngx_string("connection_time"), NULL, ngx_http_variable_connection_time,
+       0, NGX_HTTP_VAR_NOCACHEABLE, 0 },
+ 
++#if (NGX_HAVE_NETFILTER_IPV4)
++    { ngx_string("connection_original_dst"), NULL,
++      ngx_http_variable_connection_dst, 0, 0, 0 },
++#endif
++
+     { ngx_string("nginx_version"), NULL, ngx_http_variable_nginx_version,
+       0, 0, 0 },
+ 
+@@ -2347,6 +2357,43 @@ ngx_http_variable_connection_time(ngx_http_request_t *r,
+ }
+ 
+ 
++#if (NGX_HAVE_NETFILTER_IPV4)
++static ngx_int_t
++ngx_http_variable_connection_dst(ngx_http_request_t *r,
++    ngx_http_variable_value_t *v, uintptr_t data)
++{
++    struct sockaddr_in  dst;
++    socklen_t           socklen;
++    int                 rn;
++    u_char             *p;
++
++    socklen = sizeof(struct sockaddr_in);
++
++    rn = getsockopt(r->connection->fd, SOL_IP, SO_ORIGINAL_DST, (void *) &dst,
++                    &socklen);
++    if (rn < 0) {
++        ngx_log_error(NGX_LOG_CRIT, r->connection->log, ngx_socket_errno,
++                      "getsockopt(SO_ORIGINAL_DST) failed");
++        return NGX_ERROR;
++    }
++
++    p = ngx_pnalloc(r->pool, NGX_SOCKADDR_STRLEN);
++    if (p == NULL) {
++        return NGX_ERROR;
++    }
++
++    v->len = ngx_sock_ntop((struct sockaddr *) &dst, socklen, p,
++                           NGX_SOCKADDR_STRLEN, dst.sin_port);
++    v->valid = 1;
++    v->no_cacheable = 0;
++    v->not_found = 0;
++    v->data = p;
++
++    return NGX_OK;
++}
++#endif
++
++
+ static ngx_int_t
+ ngx_http_variable_nginx_version(ngx_http_request_t *r,
+     ngx_http_variable_value_t *v, uintptr_t data)
+diff --git src/os/unix/ngx_linux_config.h src/os/unix/ngx_linux_config.h
+index 88fef47..1d0d54b 100644
+--- src/os/unix/ngx_linux_config.h
++++ src/os/unix/ngx_linux_config.h
+@@ -107,6 +107,9 @@ typedef struct iocb  ngx_aiocb_t;
+ #include <netinet/udp.h>
+ #endif
+ 
++#if (NGX_HAVE_NETFILTER_IPV4)
++#include <linux/netfilter_ipv4.h>
++#endif
+ 
+ #define NGX_LISTEN_BACKLOG        511
+ 

--- a/patch/1.29.2.4/nginx-connection-original-dst.patch
+++ b/patch/1.29.2.4/nginx-connection-original-dst.patch
@@ -52,7 +52,7 @@ index 4f0bd0e..218668b 100644
      { ngx_string("nginx_version"), NULL, ngx_http_variable_nginx_version,
        0, 0, 0 },
  
-@@ -2347,6 +2357,43 @@ ngx_http_variable_connection_time(ngx_http_request_t *r,
+@@ -2347,6 +2357,47 @@ ngx_http_variable_connection_time(ngx_http_request_t *r,
  }
  
  
@@ -68,12 +68,16 @@ index 4f0bd0e..218668b 100644
 +
 +    socklen = sizeof(struct sockaddr_in);
 +
++    if (r->connection->sockaddr->sa_family != AF_INET) {
++        v->not_found = 1;
++        return NGX_OK;
++    }
++
 +    rn = getsockopt(r->connection->fd, SOL_IP, SO_ORIGINAL_DST, (void *) &dst,
 +                    &socklen);
 +    if (rn < 0) {
-+        ngx_log_error(NGX_LOG_CRIT, r->connection->log, ngx_socket_errno,
-+                      "getsockopt(SO_ORIGINAL_DST) failed");
-+        return NGX_ERROR;
++        v->not_found = 1;
++        return NGX_OK;
 +    }
 +
 +    p = ngx_pnalloc(r->pool, NGX_SOCKADDR_STRLEN);

--- a/patch/1.29.2.4/nginx-enable_ntls.patch
+++ b/patch/1.29.2.4/nginx-enable_ntls.patch
@@ -1,0 +1,27 @@
+diff --git src/http/ngx_http_request.c src/http/ngx_http_request.c
+index bd2be5e..f073b2a 100644
+--- src/http/ngx_http_request.c
++++ src/http/ngx_http_request.c
+@@ -8,6 +8,9 @@
+ #include <ngx_config.h>
+ #include <ngx_core.h>
+ #include <ngx_http.h>
++#if (NGX_HTTP_APISIX)
++#include <ngx_http_apisix_module.h>
++#endif
+ 
+ 
+ static void ngx_http_wait_request_handler(ngx_event_t *ev);
+@@ -774,6 +777,12 @@ ngx_http_ssl_handshake(ngx_event_t *rev)
+                 return;
+             }
+ 
++#if (TONGSUO_VERSION_NUMBER && NGX_HTTP_APISIX)
++            if (ngx_http_apisix_is_ntls_enabled(hc->conf_ctx)) {
++                SSL_enable_ntls(c->ssl->connection);
++            }
++#endif
++
+             ngx_reusable_connection(c, 0);
+ 
+             rc = ngx_ssl_handshake(c);

--- a/patch/1.29.2.4/nginx-error_page_contains_apisix.patch
+++ b/patch/1.29.2.4/nginx-error_page_contains_apisix.patch
@@ -1,0 +1,44 @@
+diff --git docs/html/50x.html docs/html/50x.html
+index 0680bcb..bcf7a65 100644
+--- docs/html/50x.html
++++ docs/html/50x.html
+@@ -75,9 +75,8 @@
+ <body>
+ <section class="main main-theme">
+   <h1>An error occurred.</h1>
+-  <p>Sorry, the page you are looking for is currently unavailable. Please try again later.</p>
+-  <p>If you are the system administrator of this resource then you should check the <a href="http://nginx.org/r/error_log">error log</a> for details.</p>
+-  <p>Commercial support is available at <a href="https://openresty.com/">openresty.com</a>.</p>
++  <p>You can report issue to <a href="https://github.com/apache/apisix/issues">APISIX</a></p>
++  <p><em>Faithfully yours, <a href="https://apisix.apache.org/">APISIX</a>.</em></p>
+ </section>
+ <section class="social white-theme">
+   <ul>
+diff --git src/http/ngx_http_special_response.c src/http/ngx_http_special_response.c
+index b5db811..697c366 100644
+--- src/http/ngx_http_special_response.c
++++ src/http/ngx_http_special_response.c
+@@ -20,6 +20,7 @@ static ngx_int_t ngx_http_send_refresh(ngx_http_request_t *r);
+ 
+ static u_char ngx_http_error_full_tail[] =
+ "<hr><center>" NGINX_VER "</center>" CRLF
++"<p><em>Powered by <a href=\"https://apisix.apache.org/\">APISIX</a>.</em></p>"
+ "</body>" CRLF
+ "</html>" CRLF
+ ;
+@@ -27,6 +28,7 @@ static u_char ngx_http_error_full_tail[] =
+ 
+ static u_char ngx_http_error_build_tail[] =
+ "<hr><center>" NGINX_VER_BUILD "</center>" CRLF
++"<p><em>Powered by <a href=\"https://apisix.apache.org/\">APISIX</a>.</em></p>"
+ "</body>" CRLF
+ "</html>" CRLF
+ ;
+@@ -34,6 +36,7 @@ static u_char ngx_http_error_build_tail[] =
+ 
+ static u_char ngx_http_error_tail[] =
+ "<hr><center>openresty</center>" CRLF
++"<p><em>Powered by <a href=\"https://apisix.apache.org/\">APISIX</a>.</em></p>"
+ "</body>" CRLF
+ "</html>" CRLF
+ ;

--- a/patch/1.29.2.4/nginx-error_page_contains_apisix.patch
+++ b/patch/1.29.2.4/nginx-error_page_contains_apisix.patch
@@ -9,7 +9,7 @@ index 0680bcb..bcf7a65 100644
 -  <p>Sorry, the page you are looking for is currently unavailable. Please try again later.</p>
 -  <p>If you are the system administrator of this resource then you should check the <a href="http://nginx.org/r/error_log">error log</a> for details.</p>
 -  <p>Commercial support is available at <a href="https://openresty.com/">openresty.com</a>.</p>
-+  <p>You can report issue to <a href="https://github.com/apache/apisix/issues">APISIX</a></p>
++  <p>You can report an issue to <a href="https://github.com/apache/apisix/issues">APISIX</a>.</p>
 +  <p><em>Faithfully yours, <a href="https://apisix.apache.org/">APISIX</a>.</em></p>
  </section>
  <section class="social white-theme">

--- a/patch/1.29.2.4/nginx-get_last_reopen_time.patch
+++ b/patch/1.29.2.4/nginx-get_last_reopen_time.patch
@@ -1,0 +1,72 @@
+diff --git src/os/unix/ngx_process_cycle.c src/os/unix/ngx_process_cycle.c
+index dadf03f..68c74f4 100644
+--- src/os/unix/ngx_process_cycle.c
++++ src/os/unix/ngx_process_cycle.c
+@@ -45,6 +45,9 @@ sig_atomic_t  ngx_debug_quit;
+ ngx_uint_t    ngx_exiting;
+ sig_atomic_t  ngx_reconfigure;
+ sig_atomic_t  ngx_reopen;
++#if (NGX_HTTP_APISIX)
++ngx_uint_t    ngx_last_reopen_msec;
++#endif
+ 
+ sig_atomic_t  ngx_change_binary;
+ ngx_pid_t     ngx_new_binary;
+@@ -287,6 +290,9 @@ ngx_master_process_cycle(ngx_cycle_t *cycle)
+ void
+ ngx_single_process_cycle(ngx_cycle_t *cycle)
+ {
++#if (NGX_HTTP_APISIX)
++    ngx_time_t              *tp;
++#endif
+     ngx_uint_t  i;
+ 
+     if (ngx_set_environment(cycle, NULL) == NULL) {
+@@ -363,6 +369,10 @@ ngx_single_process_cycle(ngx_cycle_t *cycle)
+ 
+         if (ngx_reopen) {
+             ngx_reopen = 0;
++#if (NGX_HTTP_APISIX)
++            tp = ngx_timeofday();
++            ngx_last_reopen_msec = tp->sec * 1000 + tp->msec;
++#endif
+             ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0, "reopening logs");
+             ngx_reopen_files(cycle, (ngx_uid_t) -1);
+         }
+@@ -770,6 +780,9 @@ ngx_master_process_exit(ngx_cycle_t *cycle)
+ static void
+ ngx_worker_process_cycle(ngx_cycle_t *cycle, void *data)
+ {
++#if (NGX_HTTP_APISIX)
++    ngx_time_t              *tp;
++#endif
+     ngx_int_t worker = (intptr_t) data;
+ 
+     ngx_process = NGX_PROCESS_WORKER;
+@@ -814,6 +827,10 @@ ngx_worker_process_cycle(ngx_cycle_t *cycle, void *data)
+ 
+         if (ngx_reopen) {
+             ngx_reopen = 0;
++#if (NGX_HTTP_APISIX)
++            tp = ngx_timeofday();
++            ngx_last_reopen_msec = tp->sec * 1000 + tp->msec;
++#endif
+             ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0, "reopening logs");
+             ngx_reopen_files(cycle, -1);
+         }
+@@ -821,6 +838,15 @@ ngx_worker_process_cycle(ngx_cycle_t *cycle, void *data)
+ }
+ 
+ 
++#if (NGX_HTTP_APISIX)
++ngx_uint_t
++ngx_worker_process_get_last_reopen_ms()
++{
++    return ngx_last_reopen_msec;
++}
++#endif
++
++
+ static void
+ ngx_worker_process_init(ngx_cycle_t *cycle, ngx_int_t worker)
+ {

--- a/patch/1.29.2.4/nginx-get_last_reopen_time.patch
+++ b/patch/1.29.2.4/nginx-get_last_reopen_time.patch
@@ -7,7 +7,7 @@ index dadf03f..68c74f4 100644
  sig_atomic_t  ngx_reconfigure;
  sig_atomic_t  ngx_reopen;
 +#if (NGX_HTTP_APISIX)
-+ngx_uint_t    ngx_last_reopen_msec;
++uint64_t      ngx_last_reopen_msec;
 +#endif
  
  sig_atomic_t  ngx_change_binary;
@@ -28,7 +28,7 @@ index dadf03f..68c74f4 100644
              ngx_reopen = 0;
 +#if (NGX_HTTP_APISIX)
 +            tp = ngx_timeofday();
-+            ngx_last_reopen_msec = tp->sec * 1000 + tp->msec;
++            ngx_last_reopen_msec = (uint64_t) tp->sec * 1000 + tp->msec;
 +#endif
              ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0, "reopening logs");
              ngx_reopen_files(cycle, (ngx_uid_t) -1);
@@ -49,7 +49,7 @@ index dadf03f..68c74f4 100644
              ngx_reopen = 0;
 +#if (NGX_HTTP_APISIX)
 +            tp = ngx_timeofday();
-+            ngx_last_reopen_msec = tp->sec * 1000 + tp->msec;
++            ngx_last_reopen_msec = (uint64_t) tp->sec * 1000 + tp->msec;
 +#endif
              ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0, "reopening logs");
              ngx_reopen_files(cycle, -1);
@@ -59,7 +59,7 @@ index dadf03f..68c74f4 100644
  
  
 +#if (NGX_HTTP_APISIX)
-+ngx_uint_t
++uint64_t
 +ngx_worker_process_get_last_reopen_ms()
 +{
 +    return ngx_last_reopen_msec;

--- a/patch/1.29.2.4/nginx-grpc_set_header_authority.patch
+++ b/patch/1.29.2.4/nginx-grpc_set_header_authority.patch
@@ -1,0 +1,18 @@
+diff --git src/http/modules/ngx_http_grpc_module.c src/http/modules/ngx_http_grpc_module.c
+index dfe49c5..a679235 100644
+--- src/http/modules/ngx_http_grpc_module.c
++++ src/http/modules/ngx_http_grpc_module.c
+@@ -4622,6 +4622,13 @@ ngx_http_grpc_init_headers(ngx_conf_t *cf, ngx_http_grpc_loc_conf_t *conf,
+                 conf->host_set = 1;
+             }
+ 
++#if (NGX_HTTP_APISIX)
++            if (src[i].key.len == 10
++                && ngx_strncasecmp(src[i].key.data, (u_char *) ":authority", 10) == 0)
++            {
++                conf->host_set = 1;
++            }
++#endif
+             s = ngx_array_push(&headers_merged);
+             if (s == NULL) {
+                 return NGX_ERROR;

--- a/patch/1.29.2.4/nginx-gzip.patch
+++ b/patch/1.29.2.4/nginx-gzip.patch
@@ -1,0 +1,143 @@
+diff --git src/http/modules/ngx_http_gzip_filter_module.c src/http/modules/ngx_http_gzip_filter_module.c
+index ed0de60..791c9e8 100644
+--- src/http/modules/ngx_http_gzip_filter_module.c
++++ src/http/modules/ngx_http_gzip_filter_module.c
+@@ -8,6 +8,9 @@
+ #include <ngx_config.h>
+ #include <ngx_core.h>
+ #include <ngx_http.h>
++#if (NGX_HTTP_APISIX)
++#include <ngx_http_apisix_module.h>
++#endif
+ 
+ #include <zlib.h>
+ 
+@@ -226,6 +229,26 @@ ngx_http_gzip_header_filter(ngx_http_request_t *r)
+ 
+     conf = ngx_http_get_module_loc_conf(r, ngx_http_gzip_filter_module);
+ 
++#if (NGX_HTTP_APISIX)
++    if ((r->headers_out.status != NGX_HTTP_OK
++            && r->headers_out.status != NGX_HTTP_FORBIDDEN
++            && r->headers_out.status != NGX_HTTP_NOT_FOUND)
++        || (r->headers_out.content_encoding
++            && r->headers_out.content_encoding->value.len)
++        || r->header_only)
++    {
++        return ngx_http_next_header_filter(r);
++    }
++
++    if (!ngx_http_apisix_is_gzip_set(r)
++        && (!conf->enable
++            || (r->headers_out.content_length_n != -1
++                && r->headers_out.content_length_n < conf->min_length)
++            || ngx_http_test_content_type(r, &conf->types) == NULL))
++    {
++        return ngx_http_next_header_filter(r);
++    }
++#else
+     if (!conf->enable
+         || (r->headers_out.status != NGX_HTTP_OK
+             && r->headers_out.status != NGX_HTTP_FORBIDDEN
+@@ -239,6 +262,7 @@ ngx_http_gzip_header_filter(ngx_http_request_t *r)
+     {
+         return ngx_http_next_header_filter(r);
+     }
++#endif
+ 
+     r->gzip_vary = 1;
+ 
+@@ -521,7 +545,18 @@ ngx_http_gzip_filter_memory(ngx_http_request_t *r, ngx_http_gzip_ctx_t *ctx)
+          * and 128K hash.
+          */
+ 
++#if (NGX_HTTP_APISIX)
++        ngx_int_t       level;
++
++        level = ngx_http_apisix_get_gzip_compress_level(r);
++        if (level == NGX_DECLINED) {
++            level = conf->level;
++        }
++
++        if (level == 1) {
++#else
+         if (conf->level == 1) {
++#endif
+             wbits = ngx_max(wbits, 13);
+         }
+ 
+@@ -621,8 +656,20 @@ ngx_http_gzip_filter_deflate_start(ngx_http_request_t *r,
+     ctx->zstream.zfree = ngx_http_gzip_filter_free;
+     ctx->zstream.opaque = ctx;
+ 
++#if (NGX_HTTP_APISIX)
++    ngx_int_t           level;
++
++    level = ngx_http_apisix_get_gzip_compress_level(r);
++    if (level == NGX_DECLINED) {
++        level = conf->level;
++    }
++
++    rc = deflateInit2(&ctx->zstream, (int) level, Z_DEFLATED,
++                      ctx->wbits + 16, ctx->memlevel, Z_DEFAULT_STRATEGY);
++#else
+     rc = deflateInit2(&ctx->zstream, (int) conf->level, Z_DEFLATED,
+                       ctx->wbits + 16, ctx->memlevel, Z_DEFAULT_STRATEGY);
++#endif
+ 
+     if (rc != Z_OK) {
+         ngx_log_error(NGX_LOG_ALERT, r->connection->log, 0,
+@@ -711,6 +758,16 @@ ngx_http_gzip_filter_get_buf(ngx_http_request_t *r, ngx_http_gzip_ctx_t *ctx)
+ 
+     conf = ngx_http_get_module_loc_conf(r, ngx_http_gzip_filter_module);
+ 
++#if (NGX_HTTP_APISIX)
++    ngx_int_t           num;
++    size_t              size;
++
++    if (ngx_http_apisix_get_gzip_buffer_conf(r, &num, &size) == NGX_DECLINED) {
++        num = conf->bufs.num;
++        size = conf->bufs.size;
++    }
++#endif
++
+     if (ctx->free) {
+ 
+         cl = ctx->free;
+@@ -719,9 +776,15 @@ ngx_http_gzip_filter_get_buf(ngx_http_request_t *r, ngx_http_gzip_ctx_t *ctx)
+ 
+         ngx_free_chain(r->pool, cl);
+ 
++#if (NGX_HTTP_APISIX)
++    } else if (ctx->bufs < num) {
++
++        ctx->out_buf = ngx_create_temp_buf(r->pool, size);
++#else
+     } else if (ctx->bufs < conf->bufs.num) {
+ 
+         ctx->out_buf = ngx_create_temp_buf(r->pool, conf->bufs.size);
++#endif
+         if (ctx->out_buf == NULL) {
+             return NGX_ERROR;
+         }
+diff --git src/http/ngx_http_core_module.c src/http/ngx_http_core_module.c
+index 7845f8f..6bbb9a3 100644
+--- src/http/ngx_http_core_module.c
++++ src/http/ngx_http_core_module.c
+@@ -2074,9 +2074,16 @@ ngx_http_gzip_ok(ngx_http_request_t *r)
+         return NGX_DECLINED;
+     }
+ 
++#if (NGX_HTTP_APISIX)
++    if (!ngx_http_apisix_is_gzip_set(r)
++        && r->http_version < clcf->gzip_http_version) {
++        return NGX_DECLINED;
++    }
++#else
+     if (r->http_version < clcf->gzip_http_version) {
+         return NGX_DECLINED;
+     }
++#endif
+ 
+     if (r->headers_in.via == NULL) {
+         goto ok;

--- a/patch/1.29.2.4/nginx-listen-in-privileged-agent.patch
+++ b/patch/1.29.2.4/nginx-listen-in-privileged-agent.patch
@@ -1,0 +1,142 @@
+diff --git src/core/ngx_connection.c src/core/ngx_connection.c
+index b7c0fe2..2e3e3c2 100644
+--- src/core/ngx_connection.c
++++ src/core/ngx_connection.c
+@@ -434,6 +434,10 @@ ngx_open_listening_sockets(ngx_cycle_t *cycle)
+                 continue;
+             }
+ 
++            if (ngx_is_privileged_agent != ls[i].privileged_agent) {
++                continue;
++            }
++
+ #if (NGX_HAVE_REUSEPORT)
+ 
+             if (ls[i].add_reuseport) {
+diff --git src/core/ngx_connection.h src/core/ngx_connection.h
+index 84dd804..d3d6930 100644
+--- src/core/ngx_connection.h
++++ src/core/ngx_connection.h
+@@ -66,6 +66,7 @@ struct ngx_listening_s {
+     unsigned            shared:1;    /* shared between threads or processes */
+     unsigned            addr_ntop:1;
+     unsigned            wildcard:1;
++    unsigned            privileged_agent:1;
+ 
+ #if (NGX_HAVE_INET6)
+     unsigned            ipv6only:1;
+diff --git src/event/ngx_event.c src/event/ngx_event.c
+index d0b4a55..54bdaae 100644
+--- src/event/ngx_event.c
++++ src/event/ngx_event.c
+@@ -845,7 +845,9 @@ ngx_event_process_init(ngx_cycle_t *cycle)
+     for (i = 0; i < cycle->listening.nelts; i++) {
+ 
+ #if (NGX_HAVE_REUSEPORT)
+-        if (ls[i].reuseport && ls[i].worker != ngx_worker) {
++        if ((ngx_is_privileged_agent && !ls[i].privileged_agent)
++            || (ls[i].reuseport && ls[i].worker != ngx_worker))
++        {
+             ngx_log_debug2(NGX_LOG_DEBUG_CORE, cycle->log, 0,
+                            "closing unused fd:%d listening on %V",
+                            ls[i].fd, &ls[i].addr_text);
+@@ -860,6 +862,10 @@ ngx_event_process_init(ngx_cycle_t *cycle)
+ 
+             continue;
+         }
++
++        if (!ngx_is_privileged_agent && ls[i].privileged_agent) {
++            continue;
++        }
+ #endif
+ 
+         c = ngx_get_connection(ls[i].fd, cycle->log);
+diff --git src/http/ngx_http.c src/http/ngx_http.c
+index d835f89..8f019c2 100644
+--- src/http/ngx_http.c
++++ src/http/ngx_http.c
+@@ -1262,6 +1262,13 @@ ngx_http_add_addresses(ngx_conf_t *cf, ngx_http_core_srv_conf_t *cscf,
+             continue;
+         }
+ 
++        if (lsopt->privileged_agent != addr[i].opt.privileged_agent) {
++            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
++                               "%V is already occupied by privileged agent",
++                               &addr[i].opt.addr_text);
++            return NGX_ERROR;
++        }
++
+         /* the address is already in the address list */
+ 
+         if (ngx_http_add_server(cf, cscf, &addr[i]) != NGX_OK) {
+@@ -1886,6 +1893,8 @@ ngx_http_add_listening(ngx_conf_t *cf, ngx_http_conf_addr_t *addr)
+     ls->quic = addr->opt.quic;
+ #endif
+ 
++    ls->privileged_agent = addr->opt.privileged_agent;
++
+     return ls;
+ }
+ 
+diff --git src/http/ngx_http_core_module.c src/http/ngx_http_core_module.c
+index 7845f8f..161de8b 100644
+--- src/http/ngx_http_core_module.c
++++ src/http/ngx_http_core_module.c
+@@ -4308,6 +4308,20 @@ ngx_http_core_listen(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+             continue;
+         }
+ 
++        if (ngx_strncmp(value[n].data, "enable_process=", 15) == 0) {
++            if (ngx_strcmp(&value[n].data[15], "privileged_agent") == 0) {
++                lsopt.privileged_agent = 1;
++
++            } else {
++                ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
++                                   "invalid enable_process value: \"%s\"",
++                                   &value[n].data[15]);
++                return NGX_CONF_ERROR;
++            }
++
++            continue;
++        }
++
+         ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                            "invalid parameter \"%V\"", &value[n]);
+         return NGX_CONF_ERROR;
+diff --git src/http/ngx_http_core_module.h src/http/ngx_http_core_module.h
+index 765e7ff..302a14b 100644
+--- src/http/ngx_http_core_module.h
++++ src/http/ngx_http_core_module.h
+@@ -83,6 +83,7 @@ typedef struct {
+     unsigned                   reuseport:1;
+     unsigned                   so_keepalive:2;
+     unsigned                   proxy_protocol:1;
++    unsigned                   privileged_agent:1;
+ 
+     int                        backlog;
+     int                        rcvbuf;
+diff --git src/os/unix/ngx_process_cycle.c src/os/unix/ngx_process_cycle.c
+index dadf03f..6794b34 100644
+--- src/os/unix/ngx_process_cycle.c
++++ src/os/unix/ngx_process_cycle.c
+@@ -1227,7 +1227,11 @@ ngx_privileged_agent_process_cycle(ngx_cycle_t *cycle, void *data)
+     ngx_process = NGX_PROCESS_HELPER;
+     ngx_is_privileged_agent = 1;
+ 
+-    ngx_close_listening_sockets(cycle);
++    if (ngx_open_listening_sockets(cycle) != NGX_OK) {
++        ngx_log_error(NGX_LOG_ALERT, cycle->log, ngx_errno,
++                      "failed to init privileged agent listeners");
++        exit(2);
++    }
+ 
+     /* Set a moderate number of connections for a helper process. */
+     cycle->connection_n = ccf->privileged_agent_connections;
+@@ -1242,6 +1246,7 @@ ngx_privileged_agent_process_cycle(ngx_cycle_t *cycle, void *data)
+ 
+         if (ngx_terminate || ngx_quit) {
+             ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0, "exiting");
++            ngx_close_listening_sockets(cycle);
+             ngx_worker_process_exit(cycle);
+         }
+ 

--- a/patch/1.29.2.4/nginx-listen-in-privileged-agent.patch
+++ b/patch/1.29.2.4/nginx-listen-in-privileged-agent.patch
@@ -29,28 +29,29 @@ diff --git src/event/ngx_event.c src/event/ngx_event.c
 index d0b4a55..54bdaae 100644
 --- src/event/ngx_event.c
 +++ src/event/ngx_event.c
-@@ -845,7 +845,9 @@ ngx_event_process_init(ngx_cycle_t *cycle)
+@@ -845,6 +845,22 @@ ngx_event_process_init(ngx_cycle_t *cycle)
      for (i = 0; i < cycle->listening.nelts; i++) {
  
- #if (NGX_HAVE_REUSEPORT)
--        if (ls[i].reuseport && ls[i].worker != ngx_worker) {
-+        if ((ngx_is_privileged_agent && !ls[i].privileged_agent)
-+            || (ls[i].reuseport && ls[i].worker != ngx_worker))
-+        {
-             ngx_log_debug2(NGX_LOG_DEBUG_CORE, cycle->log, 0,
-                            "closing unused fd:%d listening on %V",
-                            ls[i].fd, &ls[i].addr_text);
-@@ -860,6 +862,10 @@ ngx_event_process_init(ngx_cycle_t *cycle)
- 
-             continue;
-         }
++        if (ngx_is_privileged_agent != ls[i].privileged_agent) {
++            ngx_log_debug2(NGX_LOG_DEBUG_CORE, cycle->log, 0,
++                           "closing unused fd:%d listening on %V",
++                           ls[i].fd, &ls[i].addr_text);
 +
-+        if (!ngx_is_privileged_agent && ls[i].privileged_agent) {
++            if (ngx_close_socket(ls[i].fd) == -1) {
++                ngx_log_error(NGX_LOG_EMERG, cycle->log, ngx_socket_errno,
++                              ngx_close_socket_n " %V failed",
++                              &ls[i].addr_text);
++            }
++
++            ls[i].fd = (ngx_socket_t) -1;
++
 +            continue;
 +        }
- #endif
- 
-         c = ngx_get_connection(ls[i].fd, cycle->log);
++
+ #if (NGX_HAVE_REUSEPORT)
+         if (ls[i].reuseport && ls[i].worker != ngx_worker) {
+             ngx_log_debug2(NGX_LOG_DEBUG_CORE, cycle->log, 0,
+                            "closing unused fd:%d listening on %V",
 diff --git src/http/ngx_http.c src/http/ngx_http.c
 index d835f89..8f019c2 100644
 --- src/http/ngx_http.c

--- a/patch/1.29.2.4/nginx-mirror.patch
+++ b/patch/1.29.2.4/nginx-mirror.patch
@@ -1,0 +1,70 @@
+diff --git src/http/modules/ngx_http_mirror_module.c src/http/modules/ngx_http_mirror_module.c
+index 787adb3..61d0fd3 100644
+--- src/http/modules/ngx_http_mirror_module.c
++++ src/http/modules/ngx_http_mirror_module.c
+@@ -8,10 +8,16 @@
+ #include <ngx_config.h>
+ #include <ngx_core.h>
+ #include <ngx_http.h>
++#if (NGX_HTTP_APISIX)
++#include <ngx_http_apisix_module.h>
++#endif
+ 
+ 
+ typedef struct {
+     ngx_array_t  *mirror;
++#if (NGX_HTTP_APISIX)
++    ngx_flag_t    on_demand;
++#endif
+     ngx_flag_t    request_body;
+ } ngx_http_mirror_loc_conf_t;
+ 
+@@ -33,6 +39,15 @@ static ngx_int_t ngx_http_mirror_init(ngx_conf_t *cf);
+ 
+ static ngx_command_t  ngx_http_mirror_commands[] = {
+ 
++#if (NGX_HTTP_APISIX)
++    { ngx_string("apisix_mirror_on_demand"),
++      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_FLAG,
++      ngx_conf_set_flag_slot,
++      NGX_HTTP_LOC_CONF_OFFSET,
++      offsetof(ngx_http_mirror_loc_conf_t, on_demand),
++      NULL },
++#endif
++
+     { ngx_string("mirror"),
+       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+       ngx_http_mirror,
+@@ -99,6 +114,12 @@ ngx_http_mirror_handler(ngx_http_request_t *r)
+         return NGX_DECLINED;
+     }
+ 
++#if (NGX_HTTP_APISIX)
++    if (mlcf->on_demand && !ngx_http_apisix_is_mirror_enabled(r)) {
++        return NGX_DECLINED;
++    }
++#endif
++
+     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "mirror handler");
+ 
+     if (mlcf->request_body) {
+@@ -186,6 +207,9 @@ ngx_http_mirror_create_loc_conf(ngx_conf_t *cf)
+     }
+ 
+     mlcf->mirror = NGX_CONF_UNSET_PTR;
++#if (NGX_HTTP_APISIX)
++    mlcf->on_demand = NGX_CONF_UNSET;
++#endif
+     mlcf->request_body = NGX_CONF_UNSET;
+ 
+     return mlcf;
+@@ -198,6 +222,9 @@ ngx_http_mirror_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
+     ngx_http_mirror_loc_conf_t *prev = parent;
+     ngx_http_mirror_loc_conf_t *conf = child;
+ 
++#if (NGX_HTTP_APISIX)
++    ngx_conf_merge_value(conf->on_demand, prev->on_demand, 0);
++#endif
+     ngx_conf_merge_ptr_value(conf->mirror, prev->mirror, NULL);
+     ngx_conf_merge_value(conf->request_body, prev->request_body, 1);
+ 

--- a/patch/1.29.2.4/nginx-privileged_agent_process_thread.patch
+++ b/patch/1.29.2.4/nginx-privileged_agent_process_thread.patch
@@ -1,0 +1,14 @@
+diff --git src/core/ngx_thread_pool.c src/core/ngx_thread_pool.c
+index 23ae201..4a64ab5 100644
+--- src/core/ngx_thread_pool.c
++++ src/core/ngx_thread_pool.c
+@@ -622,6 +622,9 @@ ngx_thread_pool_exit_worker(ngx_cycle_t *cycle)
+     ngx_thread_pool_conf_t   *tcf;
+ 
+     if (ngx_process != NGX_PROCESS_WORKER
++#if HAVE_PRIVILEGED_PROCESS_PATCH
++        && !ngx_is_privileged_agent
++#endif
+         && ngx_process != NGX_PROCESS_SINGLE)
+     {
+         return;

--- a/patch/1.29.2.4/nginx-proxy_request_buffering.patch
+++ b/patch/1.29.2.4/nginx-proxy_request_buffering.patch
@@ -1,0 +1,26 @@
+diff --git src/http/modules/ngx_http_proxy_module.c src/http/modules/ngx_http_proxy_module.c
+index 4eb6931..23d2417 100644
+--- src/http/modules/ngx_http_proxy_module.c
++++ src/http/modules/ngx_http_proxy_module.c
+@@ -8,6 +8,9 @@
+ #include <ngx_config.h>
+ #include <ngx_core.h>
+ #include <ngx_http.h>
++#if (NGX_HTTP_APISIX)
++#include "ngx_http_apisix_module.h"
++#endif
+ 
+ 
+ #define  NGX_HTTP_PROXY_COOKIE_SECURE           0x0001
+@@ -1012,7 +1015,11 @@ ngx_http_proxy_handler(ngx_http_request_t *r)
+ 
+     u->accel = 1;
+ 
++#if (NGX_HTTP_APISIX)
++    if (!ngx_http_apisix_is_request_buffering(r, plcf->upstream.request_buffering)
++#else
+     if (!plcf->upstream.request_buffering
++#endif
+         && plcf->body_values == NULL && plcf->upstream.pass_request_body
+         && (!r->headers_in.chunked
+             || plcf->http_version == NGX_HTTP_VERSION_11))

--- a/patch/1.29.2.4/nginx-real_ip.patch
+++ b/patch/1.29.2.4/nginx-real_ip.patch
@@ -1,0 +1,52 @@
+diff --git auto/modules auto/modules
+index 300d07c..eb736eb 100644
+--- auto/modules
++++ auto/modules
+@@ -619,7 +619,7 @@ if [ $HTTP = YES ]; then
+ 
+         ngx_module_name=ngx_http_realip_module
+         ngx_module_incs=
+-        ngx_module_deps=
++        ngx_module_deps=src/http/modules/ngx_http_realip_module.h
+         ngx_module_srcs=src/http/modules/ngx_http_realip_module.c
+         ngx_module_libs=
+         ngx_module_link=$HTTP_REALIP
+diff --git src/http/modules/ngx_http_realip_module.c src/http/modules/ngx_http_realip_module.c
+index f6731e7..3646390 100644
+--- src/http/modules/ngx_http_realip_module.c
++++ src/http/modules/ngx_http_realip_module.c
+@@ -310,6 +310,15 @@ ngx_http_realip_cleanup(void *data)
+ }
+ 
+ 
++#if (NGX_HTTP_APISIX)
++ngx_int_t
++ngx_http_realip_set_real_addr(ngx_http_request_t *r, ngx_addr_t *addr)
++{
++    return ngx_http_realip_set_addr(r, addr);
++}
++#endif
++
++
+ static char *
+ ngx_http_realip_from(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+ {
+diff --git src/http/modules/ngx_http_realip_module.h src/http/modules/ngx_http_realip_module.h
+new file mode 100644
+index 0000000..8593c4b
+--- /dev/null
++++ src/http/modules/ngx_http_realip_module.h
+@@ -0,0 +1,13 @@
++#ifndef _NGX_HTTP_REALIP_H_INCLUDED_
++#define _NGX_HTTP_REALIP_H_INCLUDED_
++
++
++#include <ngx_config.h>
++#include <ngx_core.h>
++#include <ngx_http.h>
++
++
++ngx_int_t ngx_http_realip_set_real_addr(ngx_http_request_t *r, ngx_addr_t *addr);
++
++
++#endif /* _NGX_HTTP_REALIP_H_INCLUDED_ */

--- a/patch/1.29.2.4/nginx-tcp_over_tls.patch
+++ b/patch/1.29.2.4/nginx-tcp_over_tls.patch
@@ -1,0 +1,41 @@
+diff --git src/stream/ngx_stream_proxy_module.c src/stream/ngx_stream_proxy_module.c
+index 82dca1e..bb17aeb 100644
+--- src/stream/ngx_stream_proxy_module.c
++++ src/stream/ngx_stream_proxy_module.c
+@@ -8,6 +8,9 @@
+ #include <ngx_config.h>
+ #include <ngx_core.h>
+ #include <ngx_stream.h>
++#if (NGX_STREAM_APISIX)
++#include <ngx_stream_apisix_module.h>
++#endif
+ 
+ 
+ typedef struct {
+@@ -823,7 +826,14 @@ ngx_stream_proxy_init_upstream(ngx_stream_session_t *s)
+ 
+ #if (NGX_STREAM_SSL)
+ 
++#if (NGX_STREAM_APISIX)
++    if (pc->type == SOCK_STREAM &&
++        (ngx_stream_apisix_is_proxy_ssl_enabled(s) || pscf->ssl_enable))
++    {
++#else
++
+     if (pc->type == SOCK_STREAM && pscf->ssl_enable) {
++#endif
+ 
+         if (u->proxy_protocol) {
+             if (ngx_stream_proxy_send_proxy_protocol(s) != NGX_OK) {
+@@ -2223,7 +2233,11 @@ ngx_stream_proxy_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
+     ngx_conf_merge_ptr_value(conf->ssl_conf_commands,
+                               prev->ssl_conf_commands, NULL);
+ 
++#if (NGX_STREAM_APISIX)
++    if (ngx_stream_proxy_set_ssl(cf, conf) != NGX_OK) {
++#else
+     if (conf->ssl_enable && ngx_stream_proxy_set_ssl(cf, conf) != NGX_OK) {
++#endif
+         return NGX_CONF_ERROR;
+     }
+ 

--- a/patch/1.29.2.4/nginx-upstream_mtls.patch
+++ b/patch/1.29.2.4/nginx-upstream_mtls.patch
@@ -1,0 +1,50 @@
+diff --git src/http/ngx_http_upstream.c src/http/ngx_http_upstream.c
+index 2be233c..06bbbb9 100644
+--- src/http/ngx_http_upstream.c
++++ src/http/ngx_http_upstream.c
+@@ -8,6 +8,9 @@
+ #include <ngx_config.h>
+ #include <ngx_core.h>
+ #include <ngx_http.h>
++#if (NGX_HTTP_APISIX)
++#include <ngx_http_apisix_module.h>
++#endif
+ 
+ 
+ #if (NGX_HTTP_CACHE)
+@@ -1713,8 +1716,11 @@ ngx_http_upstream_ssl_init_connection(ngx_http_request_t *r,
+                                            NGX_HTTP_INTERNAL_SERVER_ERROR);
+         return;
+     }
+-
++#if (NGX_HTTP_APISIX)
++    if (u->conf->ssl_server_name || ngx_http_apisix_get_upstream_ssl_verify(r, u->conf->ssl_verify)) {
++#else
+     if (u->conf->ssl_server_name || u->conf->ssl_verify) {
++#endif
+         if (ngx_http_upstream_ssl_name(r, u, c) != NGX_OK) {
+             ngx_http_upstream_finalize_request(r, u,
+                                                NGX_HTTP_INTERNAL_SERVER_ERROR);
+@@ -1756,6 +1762,10 @@ ngx_http_upstream_ssl_init_connection(ngx_http_request_t *r,
+ 
+     r->connection->log->action = "SSL handshaking to upstream";
+ 
++#if (NGX_HTTP_APISIX)
++    ngx_http_apisix_set_upstream_ssl(r, c);
++#endif
++
+     rc = ngx_ssl_handshake(c);
+ 
+     if (rc == NGX_AGAIN) {
+@@ -1803,7 +1813,11 @@ ngx_http_upstream_ssl_handshake(ngx_http_request_t *r, ngx_http_upstream_t *u,
+ 
+     if (c->ssl->handshaked) {
+ 
++#if (NGX_HTTP_APISIX)
++        if (ngx_http_apisix_get_upstream_ssl_verify(r, u->conf->ssl_verify)) {
++#else
+         if (u->conf->ssl_verify) {
++#endif
+             rc = SSL_get_verify_result(c->ssl->connection);
+ 
+             if (rc != X509_V_OK) {

--- a/patch/1.29.2.4/nginx-upstream_pass_trailers.patch
+++ b/patch/1.29.2.4/nginx-upstream_pass_trailers.patch
@@ -1,0 +1,17 @@
+diff --git src/http/ngx_http_upstream.c src/http/ngx_http_upstream.c
+index d04d91e..2dd1102 100644
+--- src/http/ngx_http_upstream.c
++++ src/http/ngx_http_upstream.c
+@@ -2989,6 +2989,12 @@ ngx_http_upstream_process_trailers(ngx_http_request_t *r,
+         return NGX_OK;
+     }
+ 
++#if (NGX_HTTP_APISIX)
++    if (!ngx_http_apisix_is_upstream_pass_trailers(r)) {
++        return NGX_OK;
++    }
++#endif
++
+     part = &u->headers_in.trailers.part;
+     h = part->elts;
+ 

--- a/patch/1.29.2.4/ngx_lua-enable_keepalive.patch
+++ b/patch/1.29.2.4/ngx_lua-enable_keepalive.patch
@@ -1,0 +1,905 @@
+diff --git src/ngx_http_lua_balancer.c src/ngx_http_lua_balancer.c
+index ae0f1380..a51532da 100644
+--- src/ngx_http_lua_balancer.c
++++ src/ngx_http_lua_balancer.c
+@@ -31,10 +31,39 @@ typedef struct {
+ } ngx_http_lua_balancer_ka_item_t; /*balancer keepalive item*/
+ 
+ 
++typedef struct {
++    ngx_uint_t                               size;
++    ngx_uint_t                               connections;
++
++    uint32_t                                 crc32;
++
++    lua_State                               *lua_vm;
++
++    ngx_queue_t                              cache;
++    ngx_queue_t                              free;
++} ngx_http_lua_balancer_keepalive_pool_t;
++
++
++typedef struct {
++    ngx_queue_t                              queue;
++    ngx_connection_t                        *connection;
++
++    ngx_http_lua_balancer_keepalive_pool_t  *cpool;
++} ngx_http_lua_balancer_keepalive_item_t;
++
++
+ struct ngx_http_lua_balancer_peer_data_s {
++    ngx_uint_t                          cpool_size;
+     ngx_uint_t                          keepalive_requests;
+     ngx_msec_t                          keepalive_timeout;
+ 
++    ngx_uint_t                          more_tries;
++    ngx_uint_t                          total_tries;
++
++    int                                 last_peer_state;
++
++    uint32_t                            cpool_crc32;
++
+     void                               *data;
+ 
+     ngx_event_get_peer_pt               original_get_peer;
+@@ -45,20 +74,21 @@ struct ngx_http_lua_balancer_peer_data_s {
+     ngx_event_save_peer_session_pt      original_save_session;
+ #endif
+ 
+-    ngx_http_lua_srv_conf_t            *conf;
+-    ngx_http_request_t                 *request;
++    ngx_http_request_t                     *request;
++    ngx_http_lua_srv_conf_t                *conf;
++    ngx_http_lua_balancer_keepalive_pool_t *cpool;
+ 
+-    ngx_uint_t                          more_tries;
+-    ngx_uint_t                          total_tries;
+ 
+-    struct sockaddr                    *sockaddr;
+-    socklen_t                           socklen;
++    ngx_str_t                          *host;
++
+     ngx_addr_t                         *local;
+ 
+-    ngx_str_t                           host;
+     ngx_str_t                          *addr_text;
+ 
+-    int                                 last_peer_state;
++    struct sockaddr                        *sockaddr;
++    socklen_t                               socklen;
++
++
+ 
+ #if !(HAVE_NGX_UPSTREAM_TIMEOUT_FIELDS)
+     unsigned                            cloned_upstream_conf:1;
+@@ -73,10 +103,8 @@ static ngx_int_t ngx_http_lua_balancer_set_session(ngx_peer_connection_t *pc,
+     void *data);
+ static void ngx_http_lua_balancer_save_session(ngx_peer_connection_t *pc,
+     void *data);
+-static ngx_int_t
+-ngx_http_lua_upstream_get_ssl_name(ngx_http_request_t *r,
+-    ngx_http_upstream_t *u);
+ #endif
++
+ static ngx_int_t ngx_http_lua_balancer_init(ngx_conf_t *cf,
+     ngx_http_upstream_srv_conf_t *us);
+ static ngx_int_t ngx_http_lua_balancer_init_peer(ngx_http_request_t *r,
+@@ -87,17 +115,28 @@ static ngx_int_t ngx_http_lua_balancer_by_chunk(lua_State *L,
+     ngx_http_request_t *r);
+ static void ngx_http_lua_balancer_free_peer(ngx_peer_connection_t *pc,
+     void *data, ngx_uint_t state);
++static ngx_int_t ngx_http_lua_balancer_create_keepalive_pool(lua_State *L,
++    ngx_log_t *log, uint32_t cpool_crc32, ngx_uint_t cpool_size,
++    ngx_http_lua_balancer_keepalive_pool_t **cpool);
++static void ngx_http_lua_balancer_get_keepalive_pool(lua_State *L,
++    uint32_t cpool_crc32, ngx_http_lua_balancer_keepalive_pool_t **cpool);
++static void ngx_http_lua_balancer_free_keepalive_pool(ngx_log_t *log,
++    ngx_http_lua_balancer_keepalive_pool_t *cpool);
+ static void ngx_http_lua_balancer_notify_peer(ngx_peer_connection_t *pc,
+     void *data, ngx_uint_t type);
+ static void ngx_http_lua_balancer_close(ngx_connection_t *c);
+ static void ngx_http_lua_balancer_dummy_handler(ngx_event_t *ev);
+ static void ngx_http_lua_balancer_close_handler(ngx_event_t *ev);
+-static ngx_connection_t *ngx_http_lua_balancer_get_cached_item(
+-    ngx_http_lua_srv_conf_t *lscf, ngx_peer_connection_t *pc, ngx_str_t *name);
+-static ngx_uint_t ngx_http_lua_balancer_calc_hash(ngx_str_t *name,
+-    struct sockaddr *sockaddr, socklen_t socklen, ngx_addr_t *local);
+ 
+ 
++#define ngx_http_lua_balancer_keepalive_is_enabled(bp)                       \
++    ((bp)->keepalive)
++
++#define ngx_http_lua_balancer_peer_set(bp)                                   \
++    ((bp)->sockaddr && (bp)->socklen)
++
++
++static char              ngx_http_lua_balancer_keepalive_pools_table_key;
+ static struct sockaddr  *ngx_http_lua_balancer_default_server_sockaddr;
+ 
+ 
+@@ -181,7 +220,7 @@ ngx_http_lua_balancer_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
+ 
+     dd("enter");
+ 
+-    /*  must specify a content handler */
++    /* content handler setup */
+     if (cmd->post == NULL) {
+         return NGX_CONF_ERROR;
+     }
+@@ -246,6 +285,7 @@ ngx_http_lua_balancer_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
+         ngx_memzero(us, sizeof(ngx_http_upstream_server_t));
+         ngx_memzero(&url, sizeof(ngx_url_t));
+ 
++        /* just an invalid address as a place holder*/
+         ngx_str_set(&url.url, "0.0.0.1");
+         url.default_port = 80;
+ 
+@@ -261,8 +301,6 @@ ngx_http_lua_balancer_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
+     }
+ 
+     if (uscf->peer.init_upstream) {
+-        ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
+-                           "load balancing method redefined");
+ 
+         lscf->balancer.original_init_upstream = uscf->peer.init_upstream;
+ 
+@@ -286,16 +324,10 @@ ngx_http_lua_balancer_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
+ static ngx_int_t
+ ngx_http_lua_balancer_init(ngx_conf_t *cf, ngx_http_upstream_srv_conf_t *us)
+ {
+-    ngx_uint_t                            i;
+-    ngx_uint_t                            bucket_cnt;
+-    ngx_queue_t                          *buckets;
+     ngx_http_lua_srv_conf_t              *lscf;
+-    ngx_http_lua_balancer_ka_item_t      *cached;
+ 
+     lscf = ngx_http_conf_upstream_srv_conf(us, ngx_http_lua_module);
+ 
+-    ngx_conf_init_uint_value(lscf->balancer.max_cached, 32);
+-
+     if (lscf->balancer.original_init_upstream(cf, us) != NGX_OK) {
+         return NGX_ERROR;
+     }
+@@ -304,38 +336,6 @@ ngx_http_lua_balancer_init(ngx_conf_t *cf, ngx_http_upstream_srv_conf_t *us)
+ 
+     us->peer.init = ngx_http_lua_balancer_init_peer;
+ 
+-    /* allocate cache items and add to free queue */
+-
+-    cached = ngx_pcalloc(cf->pool,
+-                         sizeof(ngx_http_lua_balancer_ka_item_t)
+-                         * lscf->balancer.max_cached);
+-    if (cached == NULL) {
+-        return NGX_ERROR;
+-    }
+-
+-    ngx_queue_init(&lscf->balancer.cache);
+-    ngx_queue_init(&lscf->balancer.free);
+-
+-    for (i = 0; i < lscf->balancer.max_cached; i++) {
+-        ngx_queue_insert_head(&lscf->balancer.free, &cached[i].queue);
+-        cached[i].lscf = lscf;
+-    }
+-
+-    bucket_cnt = lscf->balancer.max_cached / 2;
+-    bucket_cnt = bucket_cnt > 0 ? bucket_cnt : 1;
+-    buckets = ngx_pcalloc(cf->pool, sizeof(ngx_queue_t) * bucket_cnt);
+-
+-    if (buckets == NULL) {
+-        return NGX_ERROR;
+-    }
+-
+-    for (i = 0; i < bucket_cnt; i++) {
+-        ngx_queue_init(&buckets[i]);
+-    }
+-
+-    lscf->balancer.buckets = buckets;
+-    lscf->balancer.bucket_cnt = bucket_cnt;
+-
+     return NGX_OK;
+ }
+ 
+@@ -387,6 +387,7 @@ ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
+     void                               *pdata;
+     lua_State                          *L;
+     ngx_int_t                           rc;
++    ngx_queue_t                        *q;
+     ngx_connection_t                   *c;
+     ngx_http_request_t                 *r;
+ #if (NGX_HTTP_SSL)
+@@ -394,6 +395,7 @@ ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
+ #endif
+     ngx_http_lua_ctx_t                 *ctx;
+     ngx_http_lua_srv_conf_t            *lscf;
++    ngx_http_lua_balancer_keepalive_item_t *item;
+     ngx_http_lua_balancer_peer_data_t  *bp = data;
+ 
+     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+@@ -425,9 +427,12 @@ ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
+ 
+     ctx->context = NGX_HTTP_LUA_CONTEXT_BALANCER;
+ 
++    bp->cpool = NULL;
+     bp->sockaddr = NULL;
+     bp->socklen = 0;
+     bp->more_tries = 0;
++    bp->cpool_crc32 = 0;
++    bp->cpool_size = 0;
+     bp->keepalive_requests = 0;
+     bp->keepalive_timeout = 0;
+     bp->keepalive = 0;
+@@ -465,10 +470,10 @@ ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
+         pc->local = bp->local;
+     }
+ 
+-    if (bp->sockaddr && bp->socklen) {
++    if (ngx_http_lua_balancer_peer_set(bp)) {
+         pc->sockaddr = bp->sockaddr;
+         pc->socklen = bp->socklen;
+-        pc->name = bp->addr_text;
++        pc->name = bp->host;
+         pc->cached = 0;
+         pc->connection = NULL;
+ 
+@@ -476,27 +481,59 @@ ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
+             r->upstream->peer.tries += bp->more_tries;
+         }
+ 
+-        if (bp->keepalive) {
+-#if (NGX_HTTP_SSL)
+-            if (bp->host.len == 0 && u->ssl) {
+-                ngx_http_lua_upstream_get_ssl_name(r, u);
+-                bp->host = u->ssl_name;
++        if (ngx_http_lua_balancer_keepalive_is_enabled(bp)) {
++            ngx_http_lua_balancer_get_keepalive_pool(L, bp->cpool_crc32,
++                                                     &bp->cpool);
++
++            if (bp->cpool == NULL
++                && ngx_http_lua_balancer_create_keepalive_pool(L, pc->log,
++                                                               bp->cpool_crc32,
++                                                               bp->cpool_size,
++                                                               &bp->cpool)
++                   != NGX_OK)
++            {
++                return NGX_ERROR;
+             }
+-#endif
+ 
+-            c = ngx_http_lua_balancer_get_cached_item(lscf, pc, &bp->host);
++            ngx_http_lua_assert(bp->cpool);
++
++            if (!ngx_queue_empty(&bp->cpool->cache)) {
++                q = ngx_queue_head(&bp->cpool->cache);
++
++                item = ngx_queue_data(q, ngx_http_lua_balancer_keepalive_item_t,
++                                      queue);
++                c = item->connection;
++
++                ngx_queue_remove(q);
++                ngx_queue_insert_head(&bp->cpool->free, q);
++
++                c->idle = 0;
++                c->sent = 0;
++                c->log = pc->log;
++                c->read->log = pc->log;
++                c->write->log = pc->log;
++                c->pool->log = pc->log;
++
++                if (c->read->timer_set) {
++                    ngx_del_timer(c->read);
++                }
++
++                pc->cached = 1;
++                pc->connection = c;
+ 
+-            if (c) {
+                 ngx_log_debug3(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+-                               "lua balancer: keepalive reusing connection %p,"
+-                               " host: %V, name: %V",
+-                               c, bp->addr_text, &bp->host);
++                               "lua balancer: keepalive reusing connection %p, "
++                               "requests: %ui, cpool: %p",
++                               c, c->requests, bp->cpool);
++
+                 return NGX_DONE;
+             }
+ 
+-            ngx_log_debug2(NGX_LOG_DEBUG_HTTP, pc->log, 0,
++            bp->cpool->connections++;
++
++            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                            "lua balancer: keepalive no free connection, "
+-                           "host: %V, name: %v",  bp->addr_text, &bp->host);
++                           "cpool: %p", bp->cpool);
+         }
+ 
+         return NGX_OK;
+@@ -577,14 +614,12 @@ static void
+ ngx_http_lua_balancer_free_peer(ngx_peer_connection_t *pc, void *data,
+     ngx_uint_t state)
+ {
+-    ngx_uint_t                                  hash;
+-    ngx_str_t                                  *host;
+     ngx_queue_t                                *q;
+     ngx_connection_t                           *c;
+     ngx_http_upstream_t                        *u;
+-    ngx_http_lua_balancer_ka_item_t            *item;
++    ngx_http_lua_balancer_keepalive_item_t     *item;
+     ngx_http_lua_balancer_peer_data_t          *bp = data;
+-    ngx_http_lua_srv_conf_t                    *lscf = bp->conf;
++    ngx_http_lua_balancer_keepalive_pool_t     *cpool;
+ 
+     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                    "lua balancer: free peer, tries: %ui", pc->tries);
+@@ -592,14 +627,16 @@ ngx_http_lua_balancer_free_peer(ngx_peer_connection_t *pc, void *data,
+     u = bp->request->upstream;
+     c = pc->connection;
+ 
+-    if (bp->sockaddr && bp->socklen) {
++    if (ngx_http_lua_balancer_peer_set(bp)) {
+         bp->last_peer_state = (int) state;
+ 
+         if (pc->tries) {
+             pc->tries--;
+         }
+ 
+-        if (bp->keepalive) {
++        if (ngx_http_lua_balancer_keepalive_is_enabled(bp)) {
++            cpool = bp->cpool;
++
+             if (state & NGX_PEER_FAILED
+                 || c == NULL
+                 || c->read->eof
+@@ -633,42 +670,41 @@ ngx_http_lua_balancer_free_peer(ngx_peer_connection_t *pc, void *data,
+                 goto invalid;
+             }
+ 
+-            if (ngx_queue_empty(&lscf->balancer.free)) {
+-                q = ngx_queue_last(&lscf->balancer.cache);
++            if (ngx_queue_empty(&cpool->free)) {
++                q = ngx_queue_last(&cpool->cache);
++                ngx_queue_remove(q);
+ 
+-                item = ngx_queue_data(q, ngx_http_lua_balancer_ka_item_t,
++                item = ngx_queue_data(q, ngx_http_lua_balancer_keepalive_item_t,
+                                       queue);
+-                ngx_queue_remove(q);
+-                ngx_queue_remove(&item->hnode);
+ 
+                 ngx_http_lua_balancer_close(item->connection);
+ 
+             } else {
+-                q = ngx_queue_head(&lscf->balancer.free);
++                q = ngx_queue_head(&cpool->free);
+                 ngx_queue_remove(q);
+ 
+-                item = ngx_queue_data(q, ngx_http_lua_balancer_ka_item_t,
++                item = ngx_queue_data(q, ngx_http_lua_balancer_keepalive_item_t,
+                                       queue);
+             }
+ 
+-            host = &bp->host;
+             ngx_log_debug3(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                            "lua balancer: keepalive saving connection %p, "
+-                           "host: %V, name: %V",
+-                           c, bp->addr_text, host);
+-
+-            ngx_queue_insert_head(&lscf->balancer.cache, q);
+-            hash = ngx_http_lua_balancer_calc_hash(host,
+-                                                   bp->sockaddr, bp->socklen,
+-                                                   bp->local);
+-            item->hash = hash;
+-            hash %= lscf->balancer.bucket_cnt;
+-            ngx_queue_insert_head(&lscf->balancer.buckets[hash], &item->hnode);
++                           "cpool: %p, connections: %ui",
++                           c, cpool, cpool->connections);
++
++            ngx_queue_insert_head(&cpool->cache, q);
++
+             item->connection = c;
++
+             pc->connection = NULL;
+ 
+-            c->read->delayed = 0;
+-            ngx_add_timer(c->read, bp->keepalive_timeout);
++            if (bp->keepalive_timeout) {
++                c->read->delayed = 0;
++                ngx_add_timer(c->read, bp->keepalive_timeout);
++
++            } else if (c->read->timer_set) {
++                ngx_del_timer(c->read);
++            }
+ 
+             if (c->write->timer_set) {
+                 ngx_del_timer(c->write);
+@@ -684,42 +720,6 @@ ngx_http_lua_balancer_free_peer(ngx_peer_connection_t *pc, void *data,
+             c->write->log = ngx_cycle->log;
+             c->pool->log = ngx_cycle->log;
+ 
+-            item->socklen = pc->socklen;
+-            ngx_memcpy(&item->sockaddr, pc->sockaddr, pc->socklen);
+-            if (pc->local) {
+-                ngx_memcpy(&item->local_sockaddr,
+-                           pc->local->sockaddr, pc->local->socklen);
+-
+-            } else {
+-                ngx_memzero(&item->local_sockaddr,
+-                            sizeof(item->local_sockaddr));
+-            }
+-
+-            if (host->data && host->len) {
+-                if (host->len <= sizeof(item->host_data)) {
+-                    ngx_memcpy(item->host_data, host->data, host->len);
+-                    item->host.data = item->host_data;
+-                    item->host.len = host->len;
+-
+-                } else {
+-                    item->host.data = ngx_pstrdup(c->pool, host);
+-                    if (item->host.data == NULL) {
+-                        ngx_http_lua_balancer_close(c);
+-
+-                        ngx_queue_remove(&item->queue);
+-                        ngx_queue_remove(&item->hnode);
+-                        ngx_queue_insert_head(&item->lscf->balancer.free,
+-                                              &item->queue);
+-                        return;
+-                    }
+-
+-                    item->host.len = host->len;
+-                }
+-
+-            } else {
+-                ngx_str_null(&item->host);
+-            }
+-
+             if (c->read->ready) {
+                 ngx_http_lua_balancer_close_handler(c->read);
+             }
+@@ -728,9 +728,16 @@ ngx_http_lua_balancer_free_peer(ngx_peer_connection_t *pc, void *data,
+ 
+ invalid:
+ 
+-            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+-                           "lua balancer: keepalive not saving connection %p",
+-                           c);
++            cpool->connections--;
++
++            ngx_log_debug3(NGX_LOG_DEBUG_HTTP, pc->log, 0,
++                           "lua balancer: keepalive not saving connection %p, "
++                           "cpool: %p, connections: %ui",
++                           c, cpool, cpool->connections);
++
++            if (cpool->connections == 0) {
++                ngx_http_lua_balancer_free_keepalive_pool(pc->log, cpool);
++            }
+         }
+ 
+         return;
+@@ -740,6 +747,123 @@ invalid:
+ }
+ 
+ 
++static ngx_int_t
++ngx_http_lua_balancer_create_keepalive_pool(lua_State *L, ngx_log_t *log,
++    uint32_t cpool_crc32, ngx_uint_t cpool_size,
++    ngx_http_lua_balancer_keepalive_pool_t **cpool)
++{
++    size_t                                       size;
++    ngx_uint_t                                   i;
++    ngx_http_lua_balancer_keepalive_pool_t      *upool;
++    ngx_http_lua_balancer_keepalive_item_t      *items;
++
++    /* get upstream connection pools table */
++    lua_pushlightuserdata(L, ngx_http_lua_lightudata_mask(
++                          balancer_keepalive_pools_table_key));
++    lua_rawget(L, LUA_REGISTRYINDEX); /* pools? */
++
++    ngx_http_lua_assert(lua_istable(L, -1));
++
++    size = sizeof(ngx_http_lua_balancer_keepalive_pool_t)
++           + sizeof(ngx_http_lua_balancer_keepalive_item_t) * cpool_size;
++
++    upool = lua_newuserdata(L, size); /* pools upool */
++    if (upool == NULL) {
++        return NGX_ERROR;
++    }
++
++    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, log, 0,
++                   "lua balancer: keepalive create pool, crc32: %ui, "
++                   "size: %ui", cpool_crc32, cpool_size);
++
++    upool->lua_vm = L;
++    upool->crc32 = cpool_crc32;
++    upool->size = cpool_size;
++    upool->connections = 0;
++
++    ngx_queue_init(&upool->cache);
++    ngx_queue_init(&upool->free);
++
++    lua_rawseti(L, -2, cpool_crc32); /* pools */
++    lua_pop(L, 1); /* orig stack */
++
++    items = (ngx_http_lua_balancer_keepalive_item_t *) (&upool->free + 1);
++
++    for (i = 0; i < cpool_size; i++) {
++        ngx_queue_insert_head(&upool->free, &items[i].queue);
++        items[i].cpool = upool;
++    }
++
++    *cpool = upool;
++
++    return NGX_OK;
++}
++
++
++static void
++ngx_http_lua_balancer_get_keepalive_pool(lua_State *L, uint32_t cpool_crc32,
++    ngx_http_lua_balancer_keepalive_pool_t **cpool)
++{
++    ngx_http_lua_balancer_keepalive_pool_t      *upool;
++
++    /* get upstream connection pools table */
++    lua_pushlightuserdata(L, ngx_http_lua_lightudata_mask(
++                          balancer_keepalive_pools_table_key));
++    lua_rawget(L, LUA_REGISTRYINDEX); /* pools? */
++
++    if (lua_isnil(L, -1)) {
++        lua_pop(L, 1); /* orig stack */
++
++        /* create upstream connection pools table */
++        lua_createtable(L, 0, 0); /* pools */
++        lua_pushlightuserdata(L, ngx_http_lua_lightudata_mask(
++                              balancer_keepalive_pools_table_key));
++        lua_pushvalue(L, -2); /* pools pools_table_key pools */
++        lua_rawset(L, LUA_REGISTRYINDEX); /* pools */
++    }
++
++    ngx_http_lua_assert(lua_istable(L, -1));
++
++    lua_rawgeti(L, -1, cpool_crc32); /* pools upool? */
++    upool = lua_touserdata(L, -1);
++    lua_pop(L, 2); /* orig stack */
++
++    *cpool = upool;
++}
++
++
++static void
++ngx_http_lua_balancer_free_keepalive_pool(ngx_log_t *log,
++    ngx_http_lua_balancer_keepalive_pool_t *cpool)
++{
++    lua_State                             *L;
++
++    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, log, 0,
++                   "lua balancer: keepalive free pool %p, crc32: %ui",
++                   cpool, cpool->crc32);
++
++    ngx_http_lua_assert(cpool->connections == 0);
++
++    L = cpool->lua_vm;
++
++    /* get upstream connection pools table */
++    lua_pushlightuserdata(L, ngx_http_lua_lightudata_mask(
++                          balancer_keepalive_pools_table_key));
++    lua_rawget(L, LUA_REGISTRYINDEX); /* pools? */
++
++    if (lua_isnil(L, -1)) {
++        lua_pop(L, 1); /* orig stack */
++        return;
++    }
++
++    ngx_http_lua_assert(lua_istable(L, -1));
++
++    lua_pushnil(L); /* pools nil */
++    lua_rawseti(L, -2, cpool->crc32); /* pools */
++    lua_pop(L, 1); /* orig stack */
++}
++
++
+ static void
+ ngx_http_lua_balancer_notify_peer(ngx_peer_connection_t *pc, void *data,
+     ngx_uint_t type)
+@@ -755,6 +879,10 @@ ngx_http_lua_balancer_notify_peer(ngx_peer_connection_t *pc, void *data,
+ static void
+ ngx_http_lua_balancer_close(ngx_connection_t *c)
+ {
++    ngx_http_lua_balancer_keepalive_item_t     *item;
++
++    item = c->data;
++
+ #if (NGX_HTTP_SSL)
+     if (c->ssl) {
+         c->ssl->no_wait_shutdown = 1;
+@@ -762,9 +890,6 @@ ngx_http_lua_balancer_close(ngx_connection_t *c)
+ 
+         if (ngx_ssl_shutdown(c) == NGX_AGAIN) {
+             c->ssl->handler = ngx_http_lua_balancer_close;
+-            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
+-                           "lua balancer: keepalive shutdown "
+-                           "connection %p failed", c);
+             return;
+         }
+     }
+@@ -773,8 +898,12 @@ ngx_http_lua_balancer_close(ngx_connection_t *c)
+     ngx_destroy_pool(c->pool);
+     ngx_close_connection(c);
+ 
+-    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
+-                   "lua balancer: keepalive closing connection %p", c);
++    item->cpool->connections--;
++
++    ngx_log_debug3(NGX_LOG_DEBUG_HTTP, c->log, 0,
++                   "lua balancer: keepalive closing connection %p, cpool: %p, "
++                   "connections: %ui",
++                   c, item->cpool, item->cpool->connections);
+ }
+ 
+ 
+@@ -789,7 +918,7 @@ ngx_http_lua_balancer_dummy_handler(ngx_event_t *ev)
+ static void
+ ngx_http_lua_balancer_close_handler(ngx_event_t *ev)
+ {
+-    ngx_http_lua_balancer_ka_item_t     *item;
++    ngx_http_lua_balancer_keepalive_item_t     *item;
+ 
+     int                n;
+     char               buf[1];
+@@ -820,8 +949,10 @@ close:
+     ngx_http_lua_balancer_close(c);
+ 
+     ngx_queue_remove(&item->queue);
+-    ngx_queue_remove(&item->hnode);
+-    ngx_queue_insert_head(&item->lscf->balancer.free, &item->queue);
++    ngx_queue_insert_head(&item->cpool->free, &item->queue);
++    if (item->cpool->connections == 0) {
++        ngx_http_lua_balancer_free_keepalive_pool(ev->log, item->cpool);
++    }
+ }
+ 
+ 
+@@ -832,7 +963,7 @@ ngx_http_lua_balancer_set_session(ngx_peer_connection_t *pc, void *data)
+ {
+     ngx_http_lua_balancer_peer_data_t  *bp = data;
+ 
+-    if (bp->sockaddr && bp->socklen) {
++    if (ngx_http_lua_balancer_peer_set(bp)) {
+         /* TODO */
+         return NGX_OK;
+     }
+@@ -846,7 +977,7 @@ ngx_http_lua_balancer_save_session(ngx_peer_connection_t *pc, void *data)
+ {
+     ngx_http_lua_balancer_peer_data_t  *bp = data;
+ 
+-    if (bp->sockaddr && bp->socklen) {
++    if (ngx_http_lua_balancer_peer_set(bp)) {
+         /* TODO */
+         return;
+     }
+@@ -859,9 +990,8 @@ ngx_http_lua_balancer_save_session(ngx_peer_connection_t *pc, void *data)
+ 
+ int
+ ngx_http_lua_ffi_balancer_set_current_peer(ngx_http_request_t *r,
+-    const u_char *addr, size_t addr_len, int port,
+-    const u_char *host, size_t host_len,
+-    char **err)
++    const u_char *addr, size_t addr_len, int port,  unsigned int cpool_crc32,
++    unsigned int cpool_size, char **err)
+ {
+     ngx_url_t              url;
+     ngx_http_lua_ctx_t    *ctx;
+@@ -920,32 +1050,15 @@ ngx_http_lua_ffi_balancer_set_current_peer(ngx_http_request_t *r,
+     if (url.addrs && url.addrs[0].sockaddr) {
+         bp->sockaddr = url.addrs[0].sockaddr;
+         bp->socklen = url.addrs[0].socklen;
+-        bp->addr_text = &url.addrs[0].name;
++        bp->host = &url.addrs[0].name;
+ 
+     } else {
+         *err = "no host allowed";
+         return NGX_ERROR;
+     }
+ 
+-    if (host && host_len) {
+-        bp->host.data = ngx_palloc(r->pool, host_len);
+-        if (bp->host.data == NULL) {
+-            *err = "no memory";
+-            return NGX_ERROR;
+-        }
+-
+-        ngx_memcpy(bp->host.data, host, host_len);
+-        bp->host.len = host_len;
+-
+-#if (NGX_HTTP_SSL)
+-        if (u->ssl) {
+-            u->ssl_name = bp->host;
+-        }
+-#endif
+-
+-    } else {
+-        ngx_str_null(&bp->host);
+-    }
++    bp->cpool_crc32 = (uint32_t) cpool_crc32;
++    bp->cpool_size = (ngx_uint_t) cpool_size;
+ 
+     return NGX_OK;
+ }
+@@ -1050,11 +1163,15 @@ ngx_http_lua_ffi_balancer_enable_keepalive(ngx_http_request_t *r,
+ 
+     bp = (ngx_http_lua_balancer_peer_data_t *) u->peer.data;
+ 
+-    if (!(bp->sockaddr && bp->socklen)) {
++    if (!ngx_http_lua_balancer_peer_set(bp)) {
+         *err = "no current peer set";
+         return NGX_ERROR;
+     }
+ 
++    if (!bp->cpool_crc32) {
++        bp->cpool_crc32 = ngx_crc32_long(bp->host->data, bp->host->len);
++    }
++
+     bp->keepalive_timeout = (ngx_msec_t) timeout;
+     bp->keepalive_requests = (ngx_uint_t) max_requests;
+     bp->keepalive = 1;
+@@ -1375,138 +1492,4 @@ ngx_http_lua_balancer_keepalive(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+     return NGX_CONF_OK;
+ }
+ 
+-
+-#if (NGX_HTTP_SSL)
+-static ngx_int_t
+-ngx_http_lua_upstream_get_ssl_name(ngx_http_request_t *r,
+-    ngx_http_upstream_t *u)
+-{
+-    u_char     *p, *last;
+-    ngx_str_t   name;
+-
+-    if (u->conf->ssl_name) {
+-        if (ngx_http_complex_value(r, u->conf->ssl_name, &name) != NGX_OK) {
+-            return NGX_ERROR;
+-        }
+-
+-    } else {
+-        name = u->ssl_name;
+-    }
+-
+-    if (name.len == 0) {
+-        goto done;
+-    }
+-
+-    /*
+-     * ssl name here may contain port, notably if derived from $proxy_host
+-     * or $http_host; we have to strip it. eg: www.example.com:443
+-     */
+-
+-    p = name.data;
+-    last = name.data + name.len;
+-
+-    if (*p == '[') {
+-        p = ngx_strlchr(p, last, ']');
+-
+-        if (p == NULL) {
+-            p = name.data;
+-        }
+-    }
+-
+-    p = ngx_strlchr(p, last, ':');
+-
+-    if (p != NULL) {
+-        name.len = p - name.data;
+-    }
+-
+-done:
+-
+-    u->ssl_name = name;
+-
+-    return NGX_OK;
+-}
+-#endif
+-
+-
+-static ngx_uint_t
+-ngx_http_lua_balancer_calc_hash(ngx_str_t *name,
+-    struct sockaddr *sockaddr, socklen_t socklen, ngx_addr_t *local)
+-{
+-    ngx_uint_t hash;
+-
+-    hash = ngx_hash_key_lc(name->data, name->len);
+-    hash ^= ngx_hash_key((u_char *) sockaddr, socklen);
+-    if (local != NULL) {
+-        hash ^= ngx_hash_key((u_char *) local->sockaddr, local->socklen);
+-    }
+-
+-    return hash;
+-}
+-
+-
+-static ngx_connection_t *
+-ngx_http_lua_balancer_get_cached_item(ngx_http_lua_srv_conf_t *lscf,
+-    ngx_peer_connection_t *pc, ngx_str_t *name)
+-{
+-    ngx_uint_t                         hash;
+-    ngx_queue_t                       *q;
+-    ngx_queue_t                       *head;
+-    ngx_connection_t                  *c;
+-    struct sockaddr                   *sockaddr;
+-    socklen_t                          socklen;
+-    ngx_addr_t                        *local;
+-    ngx_http_lua_balancer_ka_item_t   *item;
+-
+-    sockaddr = pc->sockaddr;
+-    socklen = pc->socklen;
+-    local = pc->local;
+-
+-    hash = ngx_http_lua_balancer_calc_hash(name, sockaddr, socklen, pc->local);
+-    head = &lscf->balancer.buckets[hash % lscf->balancer.bucket_cnt];
+-
+-    c = NULL;
+-    for (q = ngx_queue_head(head);
+-        q != ngx_queue_sentinel(head);
+-        q = ngx_queue_next(q))
+-    {
+-        item = ngx_queue_data(q, ngx_http_lua_balancer_ka_item_t, hnode);
+-        if (item->hash != hash) {
+-            continue;
+-        }
+-
+-        if (name->len == item->host.len
+-            && ngx_memn2cmp((u_char *) &item->sockaddr,
+-                            (u_char *) sockaddr,
+-                            item->socklen, socklen) == 0
+-            && ngx_strncasecmp(name->data,
+-                               item->host.data, name->len) == 0
+-            && (local == NULL
+-                || ngx_memn2cmp((u_char *) &item->local_sockaddr,
+-                                (u_char *) local->sockaddr,
+-                                socklen, local->socklen) == 0))
+-        {
+-            c = item->connection;
+-            ngx_queue_remove(q);
+-            ngx_queue_remove(&item->queue);
+-            ngx_queue_insert_head(&lscf->balancer.free, &item->queue);
+-            c->idle = 0;
+-            c->sent = 0;
+-            c->log = pc->log;
+-            c->read->log = pc->log;
+-            c->write->log = pc->log;
+-            c->pool->log = pc->log;
+-
+-            if (c->read->timer_set) {
+-                ngx_del_timer(c->read);
+-            }
+-
+-            pc->cached = 1;
+-            pc->connection = c;
+-            return c;
+-        }
+-    }
+-
+-    return NULL;
+-}
+-
+ /* vi:set ft=c ts=4 sw=4 et fdm=marker: */
+diff --git src/ngx_http_lua_common.h src/ngx_http_lua_common.h
+index cc2d36a3..edbd9166 100644
+--- src/ngx_http_lua_common.h
++++ src/ngx_http_lua_common.h
+@@ -359,6 +359,7 @@ struct ngx_http_lua_srv_conf_s {
+         ngx_uint_t                           bucket_cnt;
+         ngx_http_upstream_init_pt            original_init_upstream;
+         ngx_http_upstream_init_peer_pt       original_init_peer;
++        uintptr_t                            data;
+ 
+         ngx_http_lua_srv_conf_handler_pt     handler;
+         ngx_str_t                            src;
+diff --git src/ngx_http_lua_module.c src/ngx_http_lua_module.c
+index 63367f46..6a1baab5 100644
+--- src/ngx_http_lua_module.c
++++ src/ngx_http_lua_module.c
+@@ -1199,6 +1199,7 @@ ngx_http_lua_create_srv_conf(ngx_conf_t *cf)
+      *
+      *      lscf->balancer.original_init_upstream = NULL;
+      *      lscf->balancer.original_init_peer = NULL;
++     *      lscf->balancer.data = NULL;
+      *      lscf->balancer.handler = NULL;
+      *      lscf->balancer.src = { 0, NULL };
+      *      lscf->balancer.chunkname = NULL;

--- a/patch/1.29.2.4/ngx_lua-enable_keepalive.patch
+++ b/patch/1.29.2.4/ngx_lua-enable_keepalive.patch
@@ -130,7 +130,7 @@ index ae0f1380..a51532da 100644
          ngx_memzero(us, sizeof(ngx_http_upstream_server_t));
          ngx_memzero(&url, sizeof(ngx_url_t));
  
-+        /* just an invalid address as a place holder*/
++        /* just an invalid address as a placeholder */
          ngx_str_set(&url.url, "0.0.0.1");
          url.default_port = 80;
  

--- a/patch/1.29.2.4/ngx_lua-enable_keepalive.patch
+++ b/patch/1.29.2.4/ngx_lua-enable_keepalive.patch
@@ -2,7 +2,7 @@ diff --git src/ngx_http_lua_balancer.c src/ngx_http_lua_balancer.c
 index ae0f1380..a51532da 100644
 --- src/ngx_http_lua_balancer.c
 +++ src/ngx_http_lua_balancer.c
-@@ -31,10 +31,39 @@ typedef struct {
+@@ -31,10 +31,40 @@ typedef struct {
  } ngx_http_lua_balancer_ka_item_t; /*balancer keepalive item*/
  
  
@@ -38,6 +38,7 @@ index ae0f1380..a51532da 100644
 +    int                                 last_peer_state;
 +
 +    uint32_t                            cpool_crc32;
++    unsigned                            cpool_set:1;
 +
      void                               *data;
  
@@ -215,7 +216,7 @@ index ae0f1380..a51532da 100644
      ngx_http_lua_balancer_peer_data_t  *bp = data;
  
      ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
-@@ -425,9 +427,12 @@ ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
+@@ -425,9 +427,13 @@ ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
  
      ctx->context = NGX_HTTP_LUA_CONTEXT_BALANCER;
  
@@ -224,6 +225,7 @@ index ae0f1380..a51532da 100644
      bp->socklen = 0;
      bp->more_tries = 0;
 +    bp->cpool_crc32 = 0;
++    bp->cpool_set = 0;
 +    bp->cpool_size = 0;
      bp->keepalive_requests = 0;
      bp->keepalive_timeout = 0;
@@ -682,12 +684,12 @@ index ae0f1380..a51532da 100644
 -    const u_char *addr, size_t addr_len, int port,
 -    const u_char *host, size_t host_len,
 -    char **err)
-+    const u_char *addr, size_t addr_len, int port,  unsigned int cpool_crc32,
-+    unsigned int cpool_size, char **err)
++    const u_char *addr, size_t addr_len, int port, unsigned int cpool_crc32,
++    int cpool_set, unsigned int cpool_size, char **err)
  {
      ngx_url_t              url;
      ngx_http_lua_ctx_t    *ctx;
-@@ -920,32 +1050,15 @@ ngx_http_lua_ffi_balancer_set_current_peer(ngx_http_request_t *r,
+@@ -920,32 +1050,16 @@ ngx_http_lua_ffi_balancer_set_current_peer(ngx_http_request_t *r,
      if (url.addrs && url.addrs[0].sockaddr) {
          bp->sockaddr = url.addrs[0].sockaddr;
          bp->socklen = url.addrs[0].socklen;
@@ -719,11 +721,12 @@ index ae0f1380..a51532da 100644
 -        ngx_str_null(&bp->host);
 -    }
 +    bp->cpool_crc32 = (uint32_t) cpool_crc32;
++    bp->cpool_set = cpool_set ? 1 : 0;
 +    bp->cpool_size = (ngx_uint_t) cpool_size;
  
      return NGX_OK;
  }
-@@ -1050,11 +1163,15 @@ ngx_http_lua_ffi_balancer_enable_keepalive(ngx_http_request_t *r,
+@@ -1050,11 +1163,16 @@ ngx_http_lua_ffi_balancer_enable_keepalive(ngx_http_request_t *r,
  
      bp = (ngx_http_lua_balancer_peer_data_t *) u->peer.data;
  
@@ -733,8 +736,9 @@ index ae0f1380..a51532da 100644
          return NGX_ERROR;
      }
  
-+    if (!bp->cpool_crc32) {
++    if (!bp->cpool_set) {
 +        bp->cpool_crc32 = ngx_crc32_long(bp->host->data, bp->host->len);
++        bp->cpool_set = 1;
 +    }
 +
      bp->keepalive_timeout = (ngx_msec_t) timeout;

--- a/patch/1.29.2.4/ngx_lua-init_worker_coroutine.patch
+++ b/patch/1.29.2.4/ngx_lua-init_worker_coroutine.patch
@@ -1,0 +1,13 @@
+diff --git src/ngx_http_lua_coroutine.c src/ngx_http_lua_coroutine.c
+index 1580c5b2..d0bc045c 100644
+--- src/ngx_http_lua_coroutine.c
++++ src/ngx_http_lua_coroutine.c
+@@ -358,7 +358,7 @@ ngx_http_lua_inject_coroutine_api(ngx_log_t *log, lua_State *L)
+                         "local ctx = raw_ctx(r)\n"
+ #endif
+                         /* ignore header and body filters */
+-                        "if ctx ~= 0x020 and ctx ~= 0x040 then\n"
++                        "if ctx ~= 0x020 and ctx ~= 0x040 and ctx ~= 0x100 then\n"
+                             "return ours(...)\n"
+                         "end\n"
+                     "end\n"

--- a/patch/1.29.2.4/ngx_lua-reject-in-handshake.patch
+++ b/patch/1.29.2.4/ngx_lua-reject-in-handshake.patch
@@ -1,0 +1,38 @@
+diff --git src/ngx_http_lua_ssl_certby.c src/ngx_http_lua_ssl_certby.c
+index 0901f06e..a5714226 100644
+--- src/ngx_http_lua_ssl_certby.c
++++ src/ngx_http_lua_ssl_certby.c
+@@ -1467,9 +1467,16 @@ ngx_http_lua_ssl_verify_callback(int ok, X509_STORE_CTX *x509_store)
+ #endif
+ 
+ 
++static int
++ngx_http_lua_ssl_verify_reject_in_handshake_callback(int ok, X509_STORE_CTX *x509_store)
++{
++    return ok;
++}
++
++
+ int
+ ngx_http_lua_ffi_ssl_verify_client(ngx_http_request_t *r, void *client_certs,
+-    void *trusted_certs, int depth, char **err)
++    void *trusted_certs, int depth, int reject_in_handshake, char **err)
+ {
+ #ifdef LIBRESSL_VERSION_NUMBER
+ 
+@@ -1517,7 +1524,14 @@ ngx_http_lua_ffi_ssl_verify_client(ngx_http_request_t *r, void *client_certs,
+ 
+     /* enable verify */
+ 
+-    SSL_set_verify(ssl_conn, SSL_VERIFY_PEER, ngx_http_lua_ssl_verify_callback);
++    if (reject_in_handshake) {
++        SSL_set_verify(ssl_conn,
++                       SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT ,
++                       ngx_http_lua_ssl_verify_reject_in_handshake_callback);
++
++    } else {
++        SSL_set_verify(ssl_conn, SSL_VERIFY_PEER, ngx_http_lua_ssl_verify_callback);
++    }
+ 
+     /* set depth */
+ 

--- a/patch/1.29.2.4/ngx_lua-request_header_set.patch
+++ b/patch/1.29.2.4/ngx_lua-request_header_set.patch
@@ -1,0 +1,25 @@
+diff --git src/ngx_http_lua_headers.c src/ngx_http_lua_headers.c
+index 85836a1..346ad1a 100644
+--- src/ngx_http_lua_headers.c
++++ src/ngx_http_lua_headers.c
+@@ -15,6 +15,9 @@
+ #include "ngx_http_lua_headers_out.h"
+ #include "ngx_http_lua_headers_in.h"
+ #include "ngx_http_lua_util.h"
++#if (NGX_HTTP_APISIX)
++#include "ngx_http_apisix_module.h"
++#endif
+ 
+ 
+ static int ngx_http_lua_ngx_req_http_version(lua_State *L);
+@@ -1067,6 +1070,10 @@ ngx_http_lua_ffi_req_set_header(ngx_http_request_t *r, const u_char *key,
+     ngx_uint_t                   i;
+     ngx_str_t                    k, v;
+ 
++#if (NGX_HTTP_APISIX)
++    ngx_http_apisix_mark_request_header_set(r);
++#endif
++
+     if (r->connection->fd == (ngx_socket_t) -1) {  /* fake request */
+         return NGX_HTTP_LUA_FFI_BAD_CONTEXT;
+     }

--- a/patch/1.29.2.4/ngx_lua-request_header_set.patch
+++ b/patch/1.29.2.4/ngx_lua-request_header_set.patch
@@ -12,14 +12,25 @@ index 85836a1..346ad1a 100644
  
  
  static int ngx_http_lua_ngx_req_http_version(lua_State *L);
-@@ -1067,6 +1070,10 @@ ngx_http_lua_ffi_req_set_header(ngx_http_request_t *r, const u_char *key,
-     ngx_uint_t                   i;
-     ngx_str_t                    k, v;
- 
+@@ -1106,5 +1109,9 @@ ngx_http_lua_ffi_req_set_header(ngx_http_request_t *r, const u_char *key,
+                 }
+             }
+-
++#if (NGX_HTTP_APISIX)
++            ngx_http_apisix_mark_request_header_set(r);
++#endif
++
+             return NGX_OK;
+         }
++
+@@ -1131,5 +1138,9 @@ ngx_http_lua_ffi_req_set_header(ngx_http_request_t *r, const u_char *key,
+         goto failed;
+     }
+-
 +#if (NGX_HTTP_APISIX)
 +    ngx_http_apisix_mark_request_header_set(r);
 +#endif
 +
-     if (r->connection->fd == (ngx_socket_t) -1) {  /* fake request */
-         return NGX_HTTP_LUA_FFI_BAD_CONTEXT;
-     }
+     return NGX_OK;
++
+ nomem:

--- a/patch/1.29.2.4/ngx_lua-shared_shdict.patch
+++ b/patch/1.29.2.4/ngx_lua-shared_shdict.patch
@@ -1,0 +1,3084 @@
+diff --git config config
+index 0e572c8..a688cf6 100644
+--- config
++++ config
+@@ -269,7 +269,6 @@ HTTP_LUA_SRCS=" \
+             $ngx_addon_dir/src/ngx_http_lua_clfactory.c \
+             $ngx_addon_dir/src/ngx_http_lua_pcrefix.c \
+             $ngx_addon_dir/src/ngx_http_lua_headerfilterby.c \
+-            $ngx_addon_dir/src/ngx_http_lua_shdict.c \
+             $ngx_addon_dir/src/ngx_http_lua_socket_tcp.c \
+             $ngx_addon_dir/src/ngx_http_lua_api.c \
+             $ngx_addon_dir/src/ngx_http_lua_logby.c \
+@@ -334,7 +333,6 @@ HTTP_LUA_DEPS=" \
+             $ngx_addon_dir/src/ngx_http_lua_clfactory.h \
+             $ngx_addon_dir/src/ngx_http_lua_pcrefix.h \
+             $ngx_addon_dir/src/ngx_http_lua_headerfilterby.h \
+-            $ngx_addon_dir/src/ngx_http_lua_shdict.h \
+             $ngx_addon_dir/src/ngx_http_lua_socket_tcp.h \
+             $ngx_addon_dir/src/api/ngx_http_lua_api.h \
+             $ngx_addon_dir/src/ngx_http_lua_logby.h \
+diff --git src/api/ngx_http_lua_api.h src/api/ngx_http_lua_api.h
+index 193c44e..48ab467 100644
+--- src/api/ngx_http_lua_api.h
++++ src/api/ngx_http_lua_api.h
+@@ -51,14 +51,6 @@ ngx_http_request_t *ngx_http_lua_get_request(lua_State *L);
+ ngx_int_t ngx_http_lua_add_package_preload(ngx_conf_t *cf, const char *package,
+     lua_CFunction func);
+ 
+-ngx_int_t ngx_http_lua_shared_dict_get(ngx_shm_zone_t *shm_zone,
+-    u_char *key_data, size_t key_len, ngx_http_lua_value_t *value);
+-
+-ngx_shm_zone_t *ngx_http_lua_find_zone(u_char *name_data, size_t name_len);
+-
+-ngx_shm_zone_t *ngx_http_lua_shared_memory_add(ngx_conf_t *cf, ngx_str_t *name,
+-    size_t size, void *tag);
+-
+ ngx_http_lua_co_ctx_t *ngx_http_lua_get_cur_co_ctx(ngx_http_request_t *r);
+ 
+ void ngx_http_lua_set_cur_co_ctx(ngx_http_request_t *r,
+diff --git src/ngx_http_lua_api.c src/ngx_http_lua_api.c
+index 0d3ec9c..b72f831 100644
+--- src/ngx_http_lua_api.c
++++ src/ngx_http_lua_api.c
+@@ -12,7 +12,6 @@
+ 
+ #include "ngx_http_lua_common.h"
+ #include "api/ngx_http_lua_api.h"
+-#include "ngx_http_lua_shdict.h"
+ #include "ngx_http_lua_util.h"
+ 
+ 
+@@ -34,10 +33,6 @@ ngx_http_lua_get_request(lua_State *L)
+ }
+ 
+ 
+-static ngx_int_t ngx_http_lua_shared_memory_init(ngx_shm_zone_t *shm_zone,
+-    void *data);
+-
+-
+ ngx_int_t
+ ngx_http_lua_add_package_preload(ngx_conf_t *cf, const char *package,
+     lua_CFunction func)
+@@ -83,136 +78,6 @@ ngx_http_lua_add_package_preload(ngx_conf_t *cf, const char *package,
+ }
+ 
+ 
+-ngx_shm_zone_t *
+-ngx_http_lua_shared_memory_add(ngx_conf_t *cf, ngx_str_t *name, size_t size,
+-    void *tag)
+-{
+-    ngx_http_lua_main_conf_t     *lmcf;
+-    ngx_shm_zone_t              **zp;
+-    ngx_shm_zone_t               *zone;
+-    ngx_http_lua_shm_zone_ctx_t  *ctx;
+-    ngx_int_t                     n;
+-
+-    lmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_lua_module);
+-    if (lmcf == NULL) {
+-        return NULL;
+-    }
+-
+-    if (lmcf->shm_zones == NULL) {
+-        lmcf->shm_zones = ngx_palloc(cf->pool, sizeof(ngx_array_t));
+-        if (lmcf->shm_zones == NULL) {
+-            return NULL;
+-        }
+-
+-        if (ngx_array_init(lmcf->shm_zones, cf->pool, 2,
+-                           sizeof(ngx_shm_zone_t *))
+-            != NGX_OK)
+-        {
+-            return NULL;
+-        }
+-    }
+-
+-    zone = ngx_shared_memory_add(cf, name, (size_t) size, tag);
+-    if (zone == NULL) {
+-        return NULL;
+-    }
+-
+-    if (zone->data) {
+-        ctx = (ngx_http_lua_shm_zone_ctx_t *) zone->data;
+-        return &ctx->zone;
+-    }
+-
+-    n = sizeof(ngx_http_lua_shm_zone_ctx_t);
+-
+-    ctx = ngx_pcalloc(cf->pool, n);
+-    if (ctx == NULL) {
+-        return NULL;
+-    }
+-
+-    ctx->lmcf = lmcf;
+-    ctx->log = &cf->cycle->new_log;
+-    ctx->cycle = cf->cycle;
+-
+-    ngx_memcpy(&ctx->zone, zone, sizeof(ngx_shm_zone_t));
+-
+-    zp = ngx_array_push(lmcf->shm_zones);
+-    if (zp == NULL) {
+-        return NULL;
+-    }
+-
+-    *zp = zone;
+-
+-    /* set zone init */
+-    zone->init = ngx_http_lua_shared_memory_init;
+-    zone->data = ctx;
+-
+-    lmcf->requires_shm = 1;
+-
+-    return &ctx->zone;
+-}
+-
+-
+-static ngx_int_t
+-ngx_http_lua_shared_memory_init(ngx_shm_zone_t *shm_zone, void *data)
+-{
+-    ngx_http_lua_shm_zone_ctx_t *octx = data;
+-    ngx_shm_zone_t              *ozone;
+-    void                        *odata;
+-
+-    ngx_int_t                    rc;
+-    volatile ngx_cycle_t        *saved_cycle;
+-    ngx_http_lua_main_conf_t    *lmcf;
+-    ngx_http_lua_shm_zone_ctx_t *ctx;
+-    ngx_shm_zone_t              *zone;
+-
+-    ctx = (ngx_http_lua_shm_zone_ctx_t *) shm_zone->data;
+-    zone = &ctx->zone;
+-
+-    odata = NULL;
+-    if (octx) {
+-        ozone = &octx->zone;
+-        odata = ozone->data;
+-    }
+-
+-    zone->shm = shm_zone->shm;
+-#if (nginx_version >= 1009000)
+-    zone->noreuse = shm_zone->noreuse;
+-#endif
+-
+-    if (zone->init(zone, odata) != NGX_OK) {
+-        return NGX_ERROR;
+-    }
+-
+-    dd("get lmcf");
+-
+-    lmcf = ctx->lmcf;
+-    if (lmcf == NULL) {
+-        return NGX_ERROR;
+-    }
+-
+-    dd("lmcf->lua: %p", lmcf->lua);
+-
+-    lmcf->shm_zones_inited++;
+-
+-    if (lmcf->shm_zones_inited == lmcf->shm_zones->nelts
+-        && lmcf->init_handler && !ngx_test_config)
+-    {
+-        saved_cycle = ngx_cycle;
+-        ngx_cycle = ctx->cycle;
+-
+-        rc = lmcf->init_handler(ctx->log, lmcf, lmcf->lua);
+-
+-        ngx_cycle = saved_cycle;
+-
+-        if (rc != NGX_OK) {
+-            /* an error happened */
+-            return NGX_ERROR;
+-        }
+-    }
+-
+-    return NGX_OK;
+-}
+-
+ 
+ ngx_http_lua_co_ctx_t *
+ ngx_http_lua_get_cur_co_ctx(ngx_http_request_t *r)
+diff --git src/ngx_http_lua_common.h src/ngx_http_lua_common.h
+index 4c94629..5daf3dc 100644
+--- src/ngx_http_lua_common.h
++++ src/ngx_http_lua_common.h
+@@ -23,6 +23,8 @@
+ #include <lualib.h>
+ #include <lauxlib.h>
+ 
++#include "ngx_meta_lua_api.h"
++
+ 
+ #if defined(NDK) && NDK
+ #include <ndk.h>
+@@ -74,6 +76,10 @@ typedef struct {
+ #   error at least nginx 1.6.0 is required but found an older version
+ #endif
+ 
++#if !defined(ngx_meta_lua_version) || ngx_meta_lua_version < 00001
++#   error ngx_meta_lua_module 0.0.1 or above is required
++#endif
++
+ #if LUA_VERSION_NUM != 501
+ #   error unsupported Lua language version
+ #endif
+@@ -178,9 +184,6 @@ typedef struct ngx_http_lua_posted_thread_s  ngx_http_lua_posted_thread_t;
+ typedef struct ngx_http_lua_balancer_peer_data_s
+     ngx_http_lua_balancer_peer_data_t;
+ 
+-typedef ngx_int_t (*ngx_http_lua_main_conf_handler_pt)(ngx_log_t *log,
+-    ngx_http_lua_main_conf_t *lmcf, lua_State *L);
+-
+ typedef ngx_int_t (*ngx_http_lua_srv_conf_handler_pt)(ngx_http_request_t *r,
+     ngx_http_lua_srv_conf_t *lscf, lua_State *L);
+ 
+@@ -237,25 +240,21 @@ struct ngx_http_lua_main_conf_s {
+ #endif
+ #endif
+ 
+-    ngx_array_t         *shm_zones;  /* of ngx_shm_zone_t* */
+-
+-    ngx_array_t         *shdict_zones; /* shm zones of "shdict" */
+-
+     ngx_array_t         *preload_hooks; /* of ngx_http_lua_preload_hook_t */
+ 
+     ngx_flag_t           postponed_to_rewrite_phase_end;
+     ngx_flag_t           postponed_to_access_phase_end;
+     ngx_flag_t           postponed_to_precontent_phase_end;
+ 
+-    ngx_http_lua_main_conf_handler_pt    init_handler;
++    ngx_meta_lua_main_conf_handler_pt    init_handler;
+     ngx_str_t                            init_src;
+     u_char                              *init_chunkname;
+ 
+-    ngx_http_lua_main_conf_handler_pt    init_worker_handler;
++    ngx_meta_lua_main_conf_handler_pt    init_worker_handler;
+     ngx_str_t                            init_worker_src;
+     u_char                              *init_worker_chunkname;
+ 
+-    ngx_http_lua_main_conf_handler_pt    exit_worker_handler;
++    ngx_meta_lua_main_conf_handler_pt    exit_worker_handler;
+     ngx_str_t                            exit_worker_src;
+     u_char                              *exit_worker_chunkname;
+ 
+@@ -286,8 +285,6 @@ struct ngx_http_lua_main_conf_s {
+                      * main conf.
+                      */
+ 
+-    ngx_uint_t                      shm_zones_inited;
+-
+     ngx_http_lua_sema_mm_t         *sema_mm;
+ 
+     ngx_uint_t           malloc_trim_cycle;  /* a cycle is defined as the number
+@@ -317,7 +314,6 @@ struct ngx_http_lua_main_conf_s {
+     unsigned             requires_rewrite:1;
+     unsigned             requires_access:1;
+     unsigned             requires_log:1;
+-    unsigned             requires_shm:1;
+     unsigned             requires_capture_log:1;
+     unsigned             requires_server_rewrite:1;
+ };
+diff --git src/ngx_http_lua_directive.c src/ngx_http_lua_directive.c
+index f42aae9..d427e78 100644
+--- src/ngx_http_lua_directive.c
++++ src/ngx_http_lua_directive.c
+@@ -25,7 +25,6 @@
+ #include "ngx_http_lua_initby.h"
+ #include "ngx_http_lua_initworkerby.h"
+ #include "ngx_http_lua_exitworkerby.h"
+-#include "ngx_http_lua_shdict.h"
+ #include "ngx_http_lua_ssl_certby.h"
+ #include "ngx_http_lua_lex.h"
+ #include "api/ngx_http_lua_api.h"
+@@ -76,91 +75,6 @@ enum {
+ };
+ 
+ 
+-char *
+-ngx_http_lua_shared_dict(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+-{
+-    ngx_http_lua_main_conf_t   *lmcf = conf;
+-
+-    ngx_str_t                  *value, name;
+-    ngx_shm_zone_t             *zone;
+-    ngx_shm_zone_t            **zp;
+-    ngx_http_lua_shdict_ctx_t  *ctx;
+-    ssize_t                     size;
+-
+-    if (lmcf->shdict_zones == NULL) {
+-        lmcf->shdict_zones = ngx_palloc(cf->pool, sizeof(ngx_array_t));
+-        if (lmcf->shdict_zones == NULL) {
+-            return NGX_CONF_ERROR;
+-        }
+-
+-        if (ngx_array_init(lmcf->shdict_zones, cf->pool, 2,
+-                           sizeof(ngx_shm_zone_t *))
+-            != NGX_OK)
+-        {
+-            return NGX_CONF_ERROR;
+-        }
+-    }
+-
+-    value = cf->args->elts;
+-
+-    ctx = NULL;
+-
+-    if (value[1].len == 0) {
+-        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+-                           "invalid lua shared dict name \"%V\"", &value[1]);
+-        return NGX_CONF_ERROR;
+-    }
+-
+-    name = value[1];
+-
+-    size = ngx_parse_size(&value[2]);
+-
+-    if (size <= 8191) {
+-        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+-                           "invalid lua shared dict size \"%V\"", &value[2]);
+-        return NGX_CONF_ERROR;
+-    }
+-
+-    ctx = ngx_pcalloc(cf->pool, sizeof(ngx_http_lua_shdict_ctx_t));
+-    if (ctx == NULL) {
+-        return NGX_CONF_ERROR;
+-    }
+-
+-    ctx->name = name;
+-    ctx->main_conf = lmcf;
+-    ctx->log = &cf->cycle->new_log;
+-
+-    zone = ngx_http_lua_shared_memory_add(cf, &name, (size_t) size,
+-                                          &ngx_http_lua_module);
+-    if (zone == NULL) {
+-        return NGX_CONF_ERROR;
+-    }
+-
+-    if (zone->data) {
+-        ctx = zone->data;
+-
+-        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+-                           "lua_shared_dict \"%V\" is already defined as "
+-                           "\"%V\"", &name, &ctx->name);
+-        return NGX_CONF_ERROR;
+-    }
+-
+-    zone->init = ngx_http_lua_shdict_init_zone;
+-    zone->data = ctx;
+-
+-    zp = ngx_array_push(lmcf->shdict_zones);
+-    if (zp == NULL) {
+-        return NGX_CONF_ERROR;
+-    }
+-
+-    *zp = zone;
+-
+-    lmcf->requires_shm = 1;
+-
+-    return NGX_CONF_OK;
+-}
+-
+-
+ char *
+ ngx_http_lua_code_cache(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+ {
+@@ -196,6 +110,15 @@ ngx_http_lua_load_resty_core(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+ }
+ 
+ 
++char *
++ngx_http_lua_shdict_directive(ngx_conf_t *cf, ngx_command_t *cmd,
++    void *conf)
++{
++    return ngx_meta_lua_shdict_directive_helper(cf,
++                                                &ngx_http_lua_module);
++}
++
++
+ char *
+ ngx_http_lua_package_cpath(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+ {
+@@ -1262,7 +1185,7 @@ ngx_http_lua_init_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
+         return NGX_CONF_ERROR;
+     }
+ 
+-    lmcf->init_handler = (ngx_http_lua_main_conf_handler_pt) cmd->post;
++    lmcf->init_handler = (ngx_meta_lua_main_conf_handler_pt) cmd->post;
+ 
+     if (cmd->post == ngx_http_lua_init_by_file) {
+         name = ngx_http_lua_rebase_path(cf->pool, value[1].data,
+@@ -1333,7 +1256,7 @@ ngx_http_lua_init_worker_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
+ 
+     value = cf->args->elts;
+ 
+-    lmcf->init_worker_handler = (ngx_http_lua_main_conf_handler_pt) cmd->post;
++    lmcf->init_worker_handler = (ngx_meta_lua_main_conf_handler_pt) cmd->post;
+ 
+     if (cmd->post == ngx_http_lua_init_worker_by_file) {
+         name = ngx_http_lua_rebase_path(cf->pool, value[1].data,
+@@ -1401,7 +1324,7 @@ ngx_http_lua_exit_worker_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
+ 
+     value = cf->args->elts;
+ 
+-    lmcf->exit_worker_handler = (ngx_http_lua_main_conf_handler_pt) cmd->post;
++    lmcf->exit_worker_handler = (ngx_meta_lua_main_conf_handler_pt) cmd->post;
+ 
+     if (cmd->post == ngx_http_lua_exit_worker_by_file) {
+         name = ngx_http_lua_rebase_path(cf->pool, value[1].data,
+diff --git src/ngx_http_lua_directive.h src/ngx_http_lua_directive.h
+index 4bec5e3..d91315c 100644
+--- src/ngx_http_lua_directive.h
++++ src/ngx_http_lua_directive.h
+@@ -12,7 +12,7 @@
+ #include "ngx_http_lua_common.h"
+ 
+ 
+-char *ngx_http_lua_shared_dict(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
++char *ngx_http_lua_shdict_directive(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
+ char *ngx_http_lua_package_cpath(ngx_conf_t *cf, ngx_command_t *cmd,
+     void *conf);
+ char *ngx_http_lua_package_path(ngx_conf_t *cf, ngx_command_t *cmd,
+diff --git src/ngx_http_lua_exitworkerby.c src/ngx_http_lua_exitworkerby.c
+index e8f6511..1a9f860 100644
+--- src/ngx_http_lua_exitworkerby.c
++++ src/ngx_http_lua_exitworkerby.c
+@@ -75,7 +75,8 @@ ngx_http_lua_exit_worker(ngx_cycle_t *cycle)
+ 
+     ngx_http_lua_set_req(lmcf->lua, r);
+ 
+-    (void) lmcf->exit_worker_handler(cycle->log, lmcf, lmcf->lua);
++    (void) lmcf->exit_worker_handler(cycle->log, lmcf->exit_worker_src,
++                                     lmcf->lua);
+ 
+     ngx_destroy_pool(c->pool);
+     return;
+@@ -92,20 +93,12 @@ failed:
+ 
+ ngx_int_t
+ ngx_http_lua_exit_worker_by_inline(ngx_log_t *log,
+-    ngx_http_lua_main_conf_t *lmcf, lua_State *L)
++    ngx_str_t init_src, lua_State *L)
+ {
+     int         status;
+-    const char *chunkname;
+ 
+-    if (lmcf->exit_worker_chunkname == NULL) {
+-        chunkname = "=exit_worker_by_lua";
+-
+-    } else {
+-        chunkname = (const char *) lmcf->exit_worker_chunkname;
+-    }
+-
+-    status = luaL_loadbuffer(L, (char *) lmcf->exit_worker_src.data,
+-                             lmcf->exit_worker_src.len, chunkname)
++    status = luaL_loadbuffer(L, (char *) init_src.data,
++                             init_src.len, "=exit_worker_by_lua")
+              || ngx_http_lua_do_call(log, L);
+ 
+     return ngx_http_lua_report(log, L, status, "exit_worker_by_lua");
+@@ -113,12 +106,12 @@ ngx_http_lua_exit_worker_by_inline(ngx_log_t *log,
+ 
+ 
+ ngx_int_t
+-ngx_http_lua_exit_worker_by_file(ngx_log_t *log, ngx_http_lua_main_conf_t *lmcf,
++ngx_http_lua_exit_worker_by_file(ngx_log_t *log, ngx_str_t init_src,
+     lua_State *L)
+ {
+     int         status;
+ 
+-    status = luaL_loadfile(L, (char *) lmcf->exit_worker_src.data)
++    status = luaL_loadfile(L, (char *) init_src.data)
+              || ngx_http_lua_do_call(log, L);
+ 
+     return ngx_http_lua_report(log, L, status, "exit_worker_by_lua_file");
+diff --git src/ngx_http_lua_exitworkerby.h src/ngx_http_lua_exitworkerby.h
+index 3a4274c..ad8f63b 100644
+--- src/ngx_http_lua_exitworkerby.h
++++ src/ngx_http_lua_exitworkerby.h
+@@ -12,10 +12,10 @@
+ 
+ 
+ ngx_int_t ngx_http_lua_exit_worker_by_inline(ngx_log_t *log,
+-    ngx_http_lua_main_conf_t *lmcf, lua_State *L);
++    ngx_str_t init_src, lua_State *L);
+ 
+ ngx_int_t ngx_http_lua_exit_worker_by_file(ngx_log_t *log,
+-    ngx_http_lua_main_conf_t *lmcf, lua_State *L);
++    ngx_str_t init_src, lua_State *L);
+ 
+ void ngx_http_lua_exit_worker(ngx_cycle_t *cycle);
+ 
+diff --git src/ngx_http_lua_headerfilterby.c src/ngx_http_lua_headerfilterby.c
+index 7155355..86c5875 100644
+--- src/ngx_http_lua_headerfilterby.c
++++ src/ngx_http_lua_headerfilterby.c
+@@ -19,7 +19,6 @@
+ #include "ngx_http_lua_string.h"
+ #include "ngx_http_lua_misc.h"
+ #include "ngx_http_lua_consts.h"
+-#include "ngx_http_lua_shdict.h"
+ 
+ 
+ static ngx_http_output_header_filter_pt ngx_http_next_header_filter;
+diff --git src/ngx_http_lua_initby.c src/ngx_http_lua_initby.c
+index 1f956e7..b618311 100644
+--- src/ngx_http_lua_initby.c
++++ src/ngx_http_lua_initby.c
+@@ -14,22 +14,13 @@
+ 
+ 
+ ngx_int_t
+-ngx_http_lua_init_by_inline(ngx_log_t *log, ngx_http_lua_main_conf_t *lmcf,
++ngx_http_lua_init_by_inline(ngx_log_t *log, ngx_str_t init_src,
+     lua_State *L)
+ {
+     int         status;
+-    const char *chunkname;
+ 
+-
+-    if (lmcf->init_chunkname == NULL) {
+-        chunkname = "=init_by_lua";
+-
+-    } else {
+-        chunkname = (const char *) lmcf->init_chunkname;
+-    }
+-
+-    status = luaL_loadbuffer(L, (char *) lmcf->init_src.data,
+-                             lmcf->init_src.len, chunkname)
++    status = luaL_loadbuffer(L, (char *) init_src.data,
++                             init_src.len, "=init_by_lua")
+              || ngx_http_lua_do_call(log, L);
+ 
+     return ngx_http_lua_report(log, L, status, "init_by_lua");
+@@ -37,12 +28,12 @@ ngx_http_lua_init_by_inline(ngx_log_t *log, ngx_http_lua_main_conf_t *lmcf,
+ 
+ 
+ ngx_int_t
+-ngx_http_lua_init_by_file(ngx_log_t *log, ngx_http_lua_main_conf_t *lmcf,
++ngx_http_lua_init_by_file(ngx_log_t *log, ngx_str_t init_src,
+     lua_State *L)
+ {
+     int         status;
+ 
+-    status = luaL_loadfile(L, (char *) lmcf->init_src.data)
++    status = luaL_loadfile(L, (char *) init_src.data)
+              || ngx_http_lua_do_call(log, L);
+ 
+     return ngx_http_lua_report(log, L, status, "init_by_lua_file");
+diff --git src/ngx_http_lua_initby.h src/ngx_http_lua_initby.h
+index 67ac0b6..cbd439a 100644
+--- src/ngx_http_lua_initby.h
++++ src/ngx_http_lua_initby.h
+@@ -12,10 +12,10 @@
+ 
+ 
+ ngx_int_t ngx_http_lua_init_by_inline(ngx_log_t *log,
+-    ngx_http_lua_main_conf_t *lmcf, lua_State *L);
++    ngx_str_t init_src, lua_State *L);
+ 
+ ngx_int_t ngx_http_lua_init_by_file(ngx_log_t *log,
+-    ngx_http_lua_main_conf_t *lmcf, lua_State *L);
++    ngx_str_t init_src, lua_State *L);
+ 
+ 
+ #endif /* _NGX_HTTP_LUA_INITBY_H_INCLUDED_ */
+diff --git src/ngx_http_lua_initworkerby.c src/ngx_http_lua_initworkerby.c
+index 449e604..b76903c 100644
+--- src/ngx_http_lua_initworkerby.c
++++ src/ngx_http_lua_initworkerby.c
+@@ -295,7 +295,8 @@ ngx_http_lua_init_worker(ngx_cycle_t *cycle)
+ 
+     ngx_http_lua_set_req(lmcf->lua, r);
+ 
+-    (void) lmcf->init_worker_handler(cycle->log, lmcf, lmcf->lua);
++    (void) lmcf->init_worker_handler(cycle->log, lmcf->init_worker_src,
++                                     lmcf->lua);
+ 
+     ngx_destroy_pool(c->pool);
+     return NGX_OK;
+@@ -316,20 +317,12 @@ failed:
+ 
+ ngx_int_t
+ ngx_http_lua_init_worker_by_inline(ngx_log_t *log,
+-    ngx_http_lua_main_conf_t *lmcf, lua_State *L)
++    ngx_str_t init_worker_src, lua_State *L)
+ {
+     int         status;
+-    const char *chunkname;
+ 
+-    if (lmcf->init_worker_chunkname == NULL) {
+-        chunkname = "=init_worker_by_lua";
+-
+-    } else {
+-        chunkname = (const char *) lmcf->init_worker_chunkname;
+-    }
+-
+-    status = luaL_loadbuffer(L, (char *) lmcf->init_worker_src.data,
+-                             lmcf->init_worker_src.len, chunkname)
++    status = luaL_loadbuffer(L, (char *) init_worker_src.data,
++                             init_worker_src.len, "=init_worker_by_lua")
+              || ngx_http_lua_do_call(log, L);
+ 
+     return ngx_http_lua_report(log, L, status, "init_worker_by_lua");
+@@ -337,12 +330,12 @@ ngx_http_lua_init_worker_by_inline(ngx_log_t *log,
+ 
+ 
+ ngx_int_t
+-ngx_http_lua_init_worker_by_file(ngx_log_t *log, ngx_http_lua_main_conf_t *lmcf,
+-    lua_State *L)
++ngx_http_lua_init_worker_by_file(ngx_log_t *log,
++    ngx_str_t init_worker_src, lua_State *L)
+ {
+     int         status;
+ 
+-    status = luaL_loadfile(L, (char *) lmcf->init_worker_src.data)
++    status = luaL_loadfile(L, (char *) init_worker_src.data)
+              || ngx_http_lua_do_call(log, L);
+ 
+     return ngx_http_lua_report(log, L, status, "init_worker_by_lua_file");
+diff --git src/ngx_http_lua_initworkerby.h src/ngx_http_lua_initworkerby.h
+index 40b2db0..d4c399c 100644
+--- src/ngx_http_lua_initworkerby.h
++++ src/ngx_http_lua_initworkerby.h
+@@ -12,10 +12,10 @@
+ 
+ 
+ ngx_int_t ngx_http_lua_init_worker_by_inline(ngx_log_t *log,
+-    ngx_http_lua_main_conf_t *lmcf, lua_State *L);
++    ngx_str_t init_worker_src, lua_State *L);
+ 
+ ngx_int_t ngx_http_lua_init_worker_by_file(ngx_log_t *log,
+-    ngx_http_lua_main_conf_t *lmcf, lua_State *L);
++    ngx_str_t init_worker_src, lua_State *L);
+ 
+ ngx_int_t ngx_http_lua_init_worker(ngx_cycle_t *cycle);
+ 
+diff --git src/ngx_http_lua_logby.c src/ngx_http_lua_logby.c
+index b47058b..a31d424 100644
+--- src/ngx_http_lua_logby.c
++++ src/ngx_http_lua_logby.c
+@@ -21,7 +21,6 @@
+ #include "ngx_http_lua_string.h"
+ #include "ngx_http_lua_misc.h"
+ #include "ngx_http_lua_consts.h"
+-#include "ngx_http_lua_shdict.h"
+ #if (NGX_HTTP_LUA_HAVE_MALLOC_TRIM)
+ #include <malloc.h>
+ #endif
+diff --git src/ngx_http_lua_module.c src/ngx_http_lua_module.c
+index fb10bf9..bc68497 100644
+--- src/ngx_http_lua_module.c
++++ src/ngx_http_lua_module.c
+@@ -11,6 +11,7 @@
+ #include "ddebug.h"
+ 
+ 
++#include "ngx_meta_lua_api.h"
+ #include "ngx_http_lua_directive.h"
+ #include "ngx_http_lua_capturefilter.h"
+ #include "ngx_http_lua_contentby.h"
+@@ -125,7 +126,7 @@ static ngx_command_t ngx_http_lua_cmds[] = {
+ 
+     { ngx_string("lua_shared_dict"),
+       NGX_HTTP_MAIN_CONF|NGX_CONF_TAKE2,
+-      ngx_http_lua_shared_dict,
++      ngx_http_lua_shdict_directive,
+       0,
+       0,
+       NULL },
+@@ -747,7 +748,6 @@ ngx_http_lua_init(ngx_conf_t *cf)
+     ngx_int_t                   rc;
+     ngx_array_t                *arr;
+     ngx_http_handler_pt        *h;
+-    volatile ngx_cycle_t       *saved_cycle;
+     ngx_http_core_main_conf_t  *cmcf;
+     ngx_http_lua_main_conf_t   *lmcf;
+     ngx_pool_cleanup_t         *cln;
+@@ -947,18 +947,11 @@ ngx_http_lua_init(ngx_conf_t *cf)
+ 
+         ngx_http_lua_assert(lmcf->lua != NULL);
+ 
+-        if (!lmcf->requires_shm && lmcf->init_handler) {
+-            saved_cycle = ngx_cycle;
+-            ngx_cycle = cf->cycle;
+-
+-            rc = lmcf->init_handler(cf->log, lmcf, lmcf->lua);
+-
+-            ngx_cycle = saved_cycle;
+-
+-            if (rc != NGX_OK) {
+-                /* an error happened */
+-                return NGX_ERROR;
+-            }
++        if (ngx_meta_lua_post_init_handler(cf, lmcf->init_handler,
++                                           lmcf->init_src, lmcf->lua)
++            != NGX_OK)
++        {
++            return NGX_ERROR;
+         }
+ 
+         dd("Lua VM initialized!");
+diff --git src/ngx_http_lua_setby.c src/ngx_http_lua_setby.c
+index 98e8d47..4994ccd 100644
+--- src/ngx_http_lua_setby.c
++++ src/ngx_http_lua_setby.c
+@@ -19,7 +19,6 @@
+ #include "ngx_http_lua_string.h"
+ #include "ngx_http_lua_misc.h"
+ #include "ngx_http_lua_consts.h"
+-#include "ngx_http_lua_shdict.h"
+ #include "ngx_http_lua_util.h"
+ 
+ 
+diff --git src/ngx_http_lua_shdict.c src/ngx_http_lua_shdict.c
+deleted file mode 100644
+index c63eb3c..0000000
+--- src/ngx_http_lua_shdict.c
++++ /dev/null
+@@ -1,2132 +0,0 @@
+-
+-/*
+- * Copyright (C) Yichun Zhang (agentzh)
+- */
+-
+-
+-#ifndef DDEBUG
+-#define DDEBUG 0
+-#endif
+-#include "ddebug.h"
+-
+-
+-#include "ngx_http_lua_shdict.h"
+-#include "ngx_http_lua_util.h"
+-#include "ngx_http_lua_api.h"
+-
+-
+-static int ngx_http_lua_shdict_expire(ngx_http_lua_shdict_ctx_t *ctx,
+-    ngx_uint_t n);
+-static ngx_int_t ngx_http_lua_shdict_lookup(ngx_shm_zone_t *shm_zone,
+-    ngx_uint_t hash, u_char *kdata, size_t klen,
+-    ngx_http_lua_shdict_node_t **sdp);
+-static int ngx_http_lua_shdict_flush_expired(lua_State *L);
+-static int ngx_http_lua_shdict_get_keys(lua_State *L);
+-static int ngx_http_lua_shdict_lpush(lua_State *L);
+-static int ngx_http_lua_shdict_rpush(lua_State *L);
+-static int ngx_http_lua_shdict_push_helper(lua_State *L, int flags);
+-static int ngx_http_lua_shdict_lpop(lua_State *L);
+-static int ngx_http_lua_shdict_rpop(lua_State *L);
+-static int ngx_http_lua_shdict_pop_helper(lua_State *L, int flags);
+-static int ngx_http_lua_shdict_llen(lua_State *L);
+-
+-
+-static ngx_inline ngx_shm_zone_t *ngx_http_lua_shdict_get_zone(lua_State *L,
+-    int index);
+-
+-
+-#define NGX_HTTP_LUA_SHDICT_ADD         0x0001
+-#define NGX_HTTP_LUA_SHDICT_REPLACE     0x0002
+-#define NGX_HTTP_LUA_SHDICT_SAFE_STORE  0x0004
+-
+-
+-#define NGX_HTTP_LUA_SHDICT_LEFT        0x0001
+-#define NGX_HTTP_LUA_SHDICT_RIGHT       0x0002
+-
+-
+-enum {
+-    SHDICT_USERDATA_INDEX = 1,
+-};
+-
+-
+-enum {
+-    SHDICT_TNIL = 0,        /* same as LUA_TNIL */
+-    SHDICT_TBOOLEAN = 1,    /* same as LUA_TBOOLEAN */
+-    SHDICT_TNUMBER = 3,     /* same as LUA_TNUMBER */
+-    SHDICT_TSTRING = 4,     /* same as LUA_TSTRING */
+-    SHDICT_TLIST = 5,
+-};
+-
+-
+-static ngx_inline ngx_queue_t *
+-ngx_http_lua_shdict_get_list_head(ngx_http_lua_shdict_node_t *sd, size_t len)
+-{
+-    return (ngx_queue_t *) ngx_align_ptr(((u_char *) &sd->data + len),
+-                                         NGX_ALIGNMENT);
+-}
+-
+-
+-ngx_int_t
+-ngx_http_lua_shdict_init_zone(ngx_shm_zone_t *shm_zone, void *data)
+-{
+-    ngx_http_lua_shdict_ctx_t  *octx = data;
+-
+-    size_t                      len;
+-    ngx_http_lua_shdict_ctx_t  *ctx;
+-
+-    dd("init zone");
+-
+-    ctx = shm_zone->data;
+-
+-    if (octx) {
+-        ctx->sh = octx->sh;
+-        ctx->shpool = octx->shpool;
+-
+-        return NGX_OK;
+-    }
+-
+-    ctx->shpool = (ngx_slab_pool_t *) shm_zone->shm.addr;
+-
+-    if (shm_zone->shm.exists) {
+-        ctx->sh = ctx->shpool->data;
+-
+-        return NGX_OK;
+-    }
+-
+-    ctx->sh = ngx_slab_alloc(ctx->shpool, sizeof(ngx_http_lua_shdict_shctx_t));
+-    if (ctx->sh == NULL) {
+-        return NGX_ERROR;
+-    }
+-
+-    ctx->shpool->data = ctx->sh;
+-
+-    ngx_rbtree_init(&ctx->sh->rbtree, &ctx->sh->sentinel,
+-                    ngx_http_lua_shdict_rbtree_insert_value);
+-
+-    ngx_queue_init(&ctx->sh->lru_queue);
+-
+-    len = sizeof(" in lua_shared_dict zone \"\"") + shm_zone->shm.name.len;
+-
+-    ctx->shpool->log_ctx = ngx_slab_alloc(ctx->shpool, len);
+-    if (ctx->shpool->log_ctx == NULL) {
+-        return NGX_ERROR;
+-    }
+-
+-    ngx_sprintf(ctx->shpool->log_ctx, " in lua_shared_dict zone \"%V\"%Z",
+-                &shm_zone->shm.name);
+-
+-    ctx->shpool->log_nomem = 0;
+-
+-    return NGX_OK;
+-}
+-
+-
+-void
+-ngx_http_lua_shdict_rbtree_insert_value(ngx_rbtree_node_t *temp,
+-    ngx_rbtree_node_t *node, ngx_rbtree_node_t *sentinel)
+-{
+-    ngx_rbtree_node_t           **p;
+-    ngx_http_lua_shdict_node_t   *sdn, *sdnt;
+-
+-    for ( ;; ) {
+-
+-        if (node->key < temp->key) {
+-
+-            p = &temp->left;
+-
+-        } else if (node->key > temp->key) {
+-
+-            p = &temp->right;
+-
+-        } else { /* node->key == temp->key */
+-
+-            sdn = (ngx_http_lua_shdict_node_t *) &node->color;
+-            sdnt = (ngx_http_lua_shdict_node_t *) &temp->color;
+-
+-            p = ngx_memn2cmp(sdn->data, sdnt->data, sdn->key_len,
+-                             sdnt->key_len) < 0 ? &temp->left : &temp->right;
+-        }
+-
+-        if (*p == sentinel) {
+-            break;
+-        }
+-
+-        temp = *p;
+-    }
+-
+-    *p = node;
+-    node->parent = temp;
+-    node->left = sentinel;
+-    node->right = sentinel;
+-    ngx_rbt_red(node);
+-}
+-
+-
+-static ngx_int_t
+-ngx_http_lua_shdict_lookup(ngx_shm_zone_t *shm_zone, ngx_uint_t hash,
+-    u_char *kdata, size_t klen, ngx_http_lua_shdict_node_t **sdp)
+-{
+-    ngx_int_t                    rc;
+-    ngx_time_t                  *tp;
+-    uint64_t                     now;
+-    int64_t                      ms;
+-    ngx_rbtree_node_t           *node, *sentinel;
+-    ngx_http_lua_shdict_ctx_t   *ctx;
+-    ngx_http_lua_shdict_node_t  *sd;
+-
+-    ctx = shm_zone->data;
+-
+-    node = ctx->sh->rbtree.root;
+-    sentinel = ctx->sh->rbtree.sentinel;
+-
+-    while (node != sentinel) {
+-
+-        if (hash < node->key) {
+-            node = node->left;
+-            continue;
+-        }
+-
+-        if (hash > node->key) {
+-            node = node->right;
+-            continue;
+-        }
+-
+-        /* hash == node->key */
+-
+-        sd = (ngx_http_lua_shdict_node_t *) &node->color;
+-
+-        rc = ngx_memn2cmp(kdata, sd->data, klen, (size_t) sd->key_len);
+-
+-        if (rc == 0) {
+-            *sdp = sd;
+-
+-            dd("node expires: %lld", (long long) sd->expires);
+-
+-            if (sd->expires != 0) {
+-                tp = ngx_timeofday();
+-
+-                now = (uint64_t) tp->sec * 1000 + tp->msec;
+-                ms = sd->expires - now;
+-
+-                dd("time to live: %lld", (long long) ms);
+-
+-                if (ms <= 0) {
+-                    dd("node already expired");
+-                    return NGX_DONE;
+-                }
+-            }
+-
+-            ngx_queue_remove(&sd->queue);
+-            ngx_queue_insert_head(&ctx->sh->lru_queue, &sd->queue);
+-
+-            return NGX_OK;
+-        }
+-
+-        node = (rc < 0) ? node->left : node->right;
+-    }
+-
+-    *sdp = NULL;
+-
+-    return NGX_DECLINED;
+-}
+-
+-
+-static int
+-ngx_http_lua_shdict_expire(ngx_http_lua_shdict_ctx_t *ctx, ngx_uint_t n)
+-{
+-    ngx_time_t                      *tp;
+-    uint64_t                         now;
+-    ngx_queue_t                     *q, *list_queue, *lq;
+-    int64_t                          ms;
+-    ngx_rbtree_node_t               *node;
+-    ngx_http_lua_shdict_node_t      *sd;
+-    int                              freed = 0;
+-    ngx_http_lua_shdict_list_node_t *lnode;
+-
+-    tp = ngx_timeofday();
+-
+-    now = (uint64_t) tp->sec * 1000 + tp->msec;
+-
+-    /*
+-     * n == 1 deletes one or two expired entries
+-     * n == 0 deletes oldest entry by force
+-     *        and one or two zero rate entries
+-     */
+-
+-    while (n < 3) {
+-
+-        if (ngx_queue_empty(&ctx->sh->lru_queue)) {
+-            return freed;
+-        }
+-
+-        q = ngx_queue_last(&ctx->sh->lru_queue);
+-
+-        sd = ngx_queue_data(q, ngx_http_lua_shdict_node_t, queue);
+-
+-        if (n++ != 0) {
+-
+-            if (sd->expires == 0) {
+-                return freed;
+-            }
+-
+-            ms = sd->expires - now;
+-            if (ms > 0) {
+-                return freed;
+-            }
+-        }
+-
+-        if (sd->value_type == SHDICT_TLIST) {
+-            list_queue = ngx_http_lua_shdict_get_list_head(sd, sd->key_len);
+-
+-            for (lq = ngx_queue_head(list_queue);
+-                 lq != ngx_queue_sentinel(list_queue);
+-                 lq = ngx_queue_next(lq))
+-            {
+-                lnode = ngx_queue_data(lq, ngx_http_lua_shdict_list_node_t,
+-                                       queue);
+-
+-                ngx_slab_free_locked(ctx->shpool, lnode);
+-            }
+-        }
+-
+-        ngx_queue_remove(q);
+-
+-        node = (ngx_rbtree_node_t *)
+-                   ((u_char *) sd - offsetof(ngx_rbtree_node_t, color));
+-
+-        ngx_rbtree_delete(&ctx->sh->rbtree, node);
+-
+-        ngx_slab_free_locked(ctx->shpool, node);
+-
+-        freed++;
+-    }
+-
+-    return freed;
+-}
+-
+-
+-void
+-ngx_http_lua_inject_shdict_api(ngx_http_lua_main_conf_t *lmcf, lua_State *L)
+-{
+-    ngx_http_lua_shdict_ctx_t   *ctx;
+-    ngx_uint_t                   i;
+-    ngx_shm_zone_t             **zone;
+-    ngx_shm_zone_t             **zone_udata;
+-
+-    if (lmcf->shdict_zones != NULL) {
+-        lua_createtable(L, 0, lmcf->shdict_zones->nelts /* nrec */);
+-                /* ngx.shared */
+-
+-        lua_createtable(L, 0 /* narr */, 22 /* nrec */); /* shared mt */
+-
+-        lua_pushcfunction(L, ngx_http_lua_shdict_lpush);
+-        lua_setfield(L, -2, "lpush");
+-
+-        lua_pushcfunction(L, ngx_http_lua_shdict_rpush);
+-        lua_setfield(L, -2, "rpush");
+-
+-        lua_pushcfunction(L, ngx_http_lua_shdict_lpop);
+-        lua_setfield(L, -2, "lpop");
+-
+-        lua_pushcfunction(L, ngx_http_lua_shdict_rpop);
+-        lua_setfield(L, -2, "rpop");
+-
+-        lua_pushcfunction(L, ngx_http_lua_shdict_llen);
+-        lua_setfield(L, -2, "llen");
+-
+-        lua_pushcfunction(L, ngx_http_lua_shdict_flush_expired);
+-        lua_setfield(L, -2, "flush_expired");
+-
+-        lua_pushcfunction(L, ngx_http_lua_shdict_get_keys);
+-        lua_setfield(L, -2, "get_keys");
+-
+-        lua_pushvalue(L, -1); /* shared mt mt */
+-        lua_setfield(L, -2, "__index"); /* shared mt */
+-
+-        zone = lmcf->shdict_zones->elts;
+-
+-        for (i = 0; i < lmcf->shdict_zones->nelts; i++) {
+-            ctx = zone[i]->data;
+-
+-            lua_pushlstring(L, (char *) ctx->name.data, ctx->name.len);
+-                /* shared mt key */
+-
+-            lua_createtable(L, 1 /* narr */, 0 /* nrec */);
+-                /* table of zone[i] */
+-            zone_udata = lua_newuserdata(L, sizeof(ngx_shm_zone_t *));
+-                /* shared mt key ud */
+-            *zone_udata = zone[i];
+-            lua_rawseti(L, -2, SHDICT_USERDATA_INDEX); /* {zone[i]} */
+-            lua_pushvalue(L, -3); /* shared mt key ud mt */
+-            lua_setmetatable(L, -2); /* shared mt key ud */
+-            lua_rawset(L, -4); /* shared mt */
+-        }
+-
+-        lua_pop(L, 1); /* shared */
+-
+-    } else {
+-        lua_newtable(L);    /* ngx.shared */
+-    }
+-
+-    lua_setfield(L, -2, "shared");
+-}
+-
+-
+-static ngx_inline ngx_shm_zone_t *
+-ngx_http_lua_shdict_get_zone(lua_State *L, int index)
+-{
+-    ngx_shm_zone_t      *zone;
+-    ngx_shm_zone_t     **zone_udata;
+-
+-    lua_rawgeti(L, index, SHDICT_USERDATA_INDEX);
+-    zone_udata = lua_touserdata(L, -1);
+-    lua_pop(L, 1);
+-
+-    if (zone_udata == NULL) {
+-        return NULL;
+-    }
+-
+-    zone = *zone_udata;
+-    return zone;
+-}
+-
+-
+-static int
+-ngx_http_lua_shdict_flush_expired(lua_State *L)
+-{
+-    ngx_queue_t                     *q, *prev, *list_queue, *lq;
+-    ngx_http_lua_shdict_node_t      *sd;
+-    ngx_http_lua_shdict_ctx_t       *ctx;
+-    ngx_shm_zone_t                  *zone;
+-    ngx_time_t                      *tp;
+-    int                              freed = 0;
+-    int                              attempts = 0;
+-    ngx_rbtree_node_t               *node;
+-    uint64_t                         now;
+-    int                              n;
+-    ngx_http_lua_shdict_list_node_t *lnode;
+-
+-    n = lua_gettop(L);
+-
+-    if (n != 1 && n != 2) {
+-        return luaL_error(L, "expecting 1 or 2 argument(s), but saw %d", n);
+-    }
+-
+-    luaL_checktype(L, 1, LUA_TTABLE);
+-
+-    zone = ngx_http_lua_shdict_get_zone(L, 1);
+-    if (zone == NULL) {
+-        return luaL_error(L, "bad user data for the ngx_shm_zone_t pointer");
+-    }
+-
+-    if (n == 2) {
+-        attempts = luaL_checkint(L, 2);
+-    }
+-
+-    ctx = zone->data;
+-
+-    ngx_shmtx_lock(&ctx->shpool->mutex);
+-
+-    if (ngx_queue_empty(&ctx->sh->lru_queue)) {
+-        ngx_shmtx_unlock(&ctx->shpool->mutex);
+-        lua_pushnumber(L, 0);
+-        return 1;
+-    }
+-
+-    tp = ngx_timeofday();
+-
+-    now = (uint64_t) tp->sec * 1000 + tp->msec;
+-
+-    q = ngx_queue_last(&ctx->sh->lru_queue);
+-
+-    while (q != ngx_queue_sentinel(&ctx->sh->lru_queue)) {
+-        prev = ngx_queue_prev(q);
+-
+-        sd = ngx_queue_data(q, ngx_http_lua_shdict_node_t, queue);
+-
+-        if (sd->expires != 0 && sd->expires <= now) {
+-
+-            if (sd->value_type == SHDICT_TLIST) {
+-                list_queue = ngx_http_lua_shdict_get_list_head(sd, sd->key_len);
+-
+-                for (lq = ngx_queue_head(list_queue);
+-                     lq != ngx_queue_sentinel(list_queue);
+-                     lq = ngx_queue_next(lq))
+-                {
+-                    lnode = ngx_queue_data(lq, ngx_http_lua_shdict_list_node_t,
+-                                           queue);
+-
+-                    ngx_slab_free_locked(ctx->shpool, lnode);
+-                }
+-            }
+-
+-            ngx_queue_remove(q);
+-
+-            node = (ngx_rbtree_node_t *)
+-                ((u_char *) sd - offsetof(ngx_rbtree_node_t, color));
+-
+-            ngx_rbtree_delete(&ctx->sh->rbtree, node);
+-            ngx_slab_free_locked(ctx->shpool, node);
+-            freed++;
+-
+-            if (attempts && freed == attempts) {
+-                break;
+-            }
+-        }
+-
+-        q = prev;
+-    }
+-
+-    ngx_shmtx_unlock(&ctx->shpool->mutex);
+-
+-    lua_pushnumber(L, freed);
+-    return 1;
+-}
+-
+-
+-/*
+- * This trades CPU for memory. This is potentially slow. O(2n)
+- */
+-
+-static int
+-ngx_http_lua_shdict_get_keys(lua_State *L)
+-{
+-    ngx_queue_t                 *q, *prev;
+-    ngx_http_lua_shdict_node_t  *sd;
+-    ngx_http_lua_shdict_ctx_t   *ctx;
+-    ngx_shm_zone_t              *zone;
+-    ngx_time_t                  *tp;
+-    int                          total = 0;
+-    int                          attempts = 1024;
+-    uint64_t                     now;
+-    int                          n;
+-
+-    n = lua_gettop(L);
+-
+-    if (n != 1 && n != 2) {
+-        return luaL_error(L, "expecting 1 or 2 argument(s), "
+-                          "but saw %d", n);
+-    }
+-
+-    luaL_checktype(L, 1, LUA_TTABLE);
+-
+-    zone = ngx_http_lua_shdict_get_zone(L, 1);
+-    if (zone == NULL) {
+-        return luaL_error(L, "bad user data for the ngx_shm_zone_t pointer");
+-    }
+-
+-    if (n == 2) {
+-        attempts = luaL_checkint(L, 2);
+-    }
+-
+-    ctx = zone->data;
+-
+-    ngx_shmtx_lock(&ctx->shpool->mutex);
+-
+-    if (ngx_queue_empty(&ctx->sh->lru_queue)) {
+-        ngx_shmtx_unlock(&ctx->shpool->mutex);
+-        lua_createtable(L, 0, 0);
+-        return 1;
+-    }
+-
+-    tp = ngx_timeofday();
+-
+-    now = (uint64_t) tp->sec * 1000 + tp->msec;
+-
+-    /* first run through: get total number of elements we need to allocate */
+-
+-    q = ngx_queue_last(&ctx->sh->lru_queue);
+-
+-    while (q != ngx_queue_sentinel(&ctx->sh->lru_queue)) {
+-        prev = ngx_queue_prev(q);
+-
+-        sd = ngx_queue_data(q, ngx_http_lua_shdict_node_t, queue);
+-
+-        if (sd->expires == 0 || sd->expires > now) {
+-            total++;
+-            if (attempts && total == attempts) {
+-                break;
+-            }
+-        }
+-
+-        q = prev;
+-    }
+-
+-    lua_createtable(L, total, 0);
+-
+-    /* second run through: add keys to table */
+-
+-    total = 0;
+-    q = ngx_queue_last(&ctx->sh->lru_queue);
+-
+-    while (q != ngx_queue_sentinel(&ctx->sh->lru_queue)) {
+-        prev = ngx_queue_prev(q);
+-
+-        sd = ngx_queue_data(q, ngx_http_lua_shdict_node_t, queue);
+-
+-        if (sd->expires == 0 || sd->expires > now) {
+-            lua_pushlstring(L, (char *) sd->data, sd->key_len);
+-            lua_rawseti(L, -2, ++total);
+-            if (attempts && total == attempts) {
+-                break;
+-            }
+-        }
+-
+-        q = prev;
+-    }
+-
+-    ngx_shmtx_unlock(&ctx->shpool->mutex);
+-
+-    /* table is at top of stack */
+-    return 1;
+-}
+-
+-
+-ngx_int_t
+-ngx_http_lua_shared_dict_get(ngx_shm_zone_t *zone, u_char *key_data,
+-    size_t key_len, ngx_http_lua_value_t *value)
+-{
+-    u_char                      *data;
+-    size_t                       len;
+-    uint32_t                     hash;
+-    ngx_int_t                    rc;
+-    ngx_http_lua_shdict_ctx_t   *ctx;
+-    ngx_http_lua_shdict_node_t  *sd;
+-
+-    if (zone == NULL) {
+-        return NGX_ERROR;
+-    }
+-
+-    hash = ngx_crc32_short(key_data, key_len);
+-
+-    ctx = zone->data;
+-
+-    ngx_shmtx_lock(&ctx->shpool->mutex);
+-
+-    rc = ngx_http_lua_shdict_lookup(zone, hash, key_data, key_len, &sd);
+-
+-    dd("shdict lookup returned %d", (int) rc);
+-
+-    if (rc == NGX_DECLINED || rc == NGX_DONE) {
+-        ngx_shmtx_unlock(&ctx->shpool->mutex);
+-
+-        return rc;
+-    }
+-
+-    /* rc == NGX_OK */
+-
+-    value->type = sd->value_type;
+-
+-    dd("type: %d", (int) value->type);
+-
+-    data = sd->data + sd->key_len;
+-    len = (size_t) sd->value_len;
+-
+-    switch (value->type) {
+-
+-    case SHDICT_TSTRING:
+-
+-        if (value->value.s.data == NULL || value->value.s.len == 0) {
+-            ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0, "no string buffer "
+-                          "initialized");
+-            ngx_shmtx_unlock(&ctx->shpool->mutex);
+-            return NGX_ERROR;
+-        }
+-
+-        if (len > value->value.s.len) {
+-            len = value->value.s.len;
+-
+-        } else {
+-            value->value.s.len = len;
+-        }
+-
+-        ngx_memcpy(value->value.s.data, data, len);
+-        break;
+-
+-    case SHDICT_TNUMBER:
+-
+-        if (len != sizeof(double)) {
+-            ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0, "bad lua number "
+-                          "value size found for key %*s: %lu", key_len,
+-                          key_data, (unsigned long) len);
+-
+-            ngx_shmtx_unlock(&ctx->shpool->mutex);
+-            return NGX_ERROR;
+-        }
+-
+-        ngx_memcpy(&value->value.n, data, len);
+-        break;
+-
+-    case SHDICT_TBOOLEAN:
+-
+-        if (len != sizeof(u_char)) {
+-            ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0, "bad lua boolean "
+-                          "value size found for key %*s: %lu", key_len,
+-                          key_data, (unsigned long) len);
+-
+-            ngx_shmtx_unlock(&ctx->shpool->mutex);
+-            return NGX_ERROR;
+-        }
+-
+-        value->value.b = *data;
+-        break;
+-
+-    default:
+-        ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0, "bad lua value type "
+-                      "found for key %*s: %d", key_len, key_data,
+-                      (int) value->type);
+-
+-        ngx_shmtx_unlock(&ctx->shpool->mutex);
+-        return NGX_ERROR;
+-    }
+-
+-    ngx_shmtx_unlock(&ctx->shpool->mutex);
+-    return NGX_OK;
+-}
+-
+-
+-static int
+-ngx_http_lua_shdict_lpush(lua_State *L)
+-{
+-    return ngx_http_lua_shdict_push_helper(L, NGX_HTTP_LUA_SHDICT_LEFT);
+-}
+-
+-
+-static int
+-ngx_http_lua_shdict_rpush(lua_State *L)
+-{
+-    return ngx_http_lua_shdict_push_helper(L, NGX_HTTP_LUA_SHDICT_RIGHT);
+-}
+-
+-
+-static int
+-ngx_http_lua_shdict_push_helper(lua_State *L, int flags)
+-{
+-    int                              n;
+-    ngx_str_t                        key;
+-    uint32_t                         hash;
+-    ngx_int_t                        rc;
+-    ngx_http_lua_shdict_ctx_t       *ctx;
+-    ngx_http_lua_shdict_node_t      *sd;
+-    ngx_str_t                        value;
+-    int                              value_type;
+-    double                           num;
+-    ngx_rbtree_node_t               *node;
+-    ngx_shm_zone_t                  *zone;
+-    ngx_queue_t                     *queue, *q;
+-    ngx_http_lua_shdict_list_node_t *lnode;
+-
+-    n = lua_gettop(L);
+-
+-    if (n != 3) {
+-        return luaL_error(L, "expecting 3 arguments, "
+-                          "but only seen %d", n);
+-    }
+-
+-    if (lua_type(L, 1) != LUA_TTABLE) {
+-        return luaL_error(L, "bad \"zone\" argument");
+-    }
+-
+-    zone = ngx_http_lua_shdict_get_zone(L, 1);
+-    if (zone == NULL) {
+-        return luaL_error(L, "bad \"zone\" argument");
+-    }
+-
+-    ctx = zone->data;
+-
+-    if (lua_isnil(L, 2)) {
+-        lua_pushnil(L);
+-        lua_pushliteral(L, "nil key");
+-        return 2;
+-    }
+-
+-    key.data = (u_char *) luaL_checklstring(L, 2, &key.len);
+-
+-    if (key.len == 0) {
+-        lua_pushnil(L);
+-        lua_pushliteral(L, "empty key");
+-        return 2;
+-    }
+-
+-    if (key.len > 65535) {
+-        lua_pushnil(L);
+-        lua_pushliteral(L, "key too long");
+-        return 2;
+-    }
+-
+-    hash = ngx_crc32_short(key.data, key.len);
+-
+-    value_type = lua_type(L, 3);
+-
+-    switch (value_type) {
+-
+-    case SHDICT_TSTRING:
+-        value.data = (u_char *) lua_tolstring(L, 3, &value.len);
+-        break;
+-
+-    case SHDICT_TNUMBER:
+-        value.len = sizeof(double);
+-        num = lua_tonumber(L, 3);
+-        value.data = (u_char *) &num;
+-        break;
+-
+-    default:
+-        lua_pushnil(L);
+-        lua_pushliteral(L, "bad value type");
+-        return 2;
+-    }
+-
+-    ngx_shmtx_lock(&ctx->shpool->mutex);
+-
+-#if 1
+-    ngx_http_lua_shdict_expire(ctx, 1);
+-#endif
+-
+-    rc = ngx_http_lua_shdict_lookup(zone, hash, key.data, key.len, &sd);
+-
+-    dd("shdict lookup returned %d", (int) rc);
+-
+-    /* exists but expired */
+-
+-    if (rc == NGX_DONE) {
+-
+-        if (sd->value_type != SHDICT_TLIST) {
+-            /* TODO: reuse when length matched */
+-
+-            ngx_log_debug0(NGX_LOG_DEBUG_HTTP, ctx->log, 0,
+-                           "lua shared dict push: found old entry and value "
+-                           "type not matched, remove it first");
+-
+-            ngx_queue_remove(&sd->queue);
+-
+-            node = (ngx_rbtree_node_t *)
+-                        ((u_char *) sd - offsetof(ngx_rbtree_node_t, color));
+-
+-            ngx_rbtree_delete(&ctx->sh->rbtree, node);
+-
+-            ngx_slab_free_locked(ctx->shpool, node);
+-
+-            dd("go to init_list");
+-            goto init_list;
+-        }
+-
+-        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, ctx->log, 0,
+-                       "lua shared dict push: found old entry and value "
+-                       "type matched, reusing it");
+-
+-        sd->expires = 0;
+-        sd->value_len = 0;
+-        /* free list nodes */
+-
+-        queue = ngx_http_lua_shdict_get_list_head(sd, key.len);
+-
+-        for (q = ngx_queue_head(queue);
+-             q != ngx_queue_sentinel(queue);
+-             q = ngx_queue_next(q))
+-        {
+-            /* TODO: reuse matched size list node */
+-            lnode = ngx_queue_data(q, ngx_http_lua_shdict_list_node_t, queue);
+-            ngx_slab_free_locked(ctx->shpool, lnode);
+-        }
+-
+-        ngx_queue_init(queue);
+-
+-        ngx_queue_remove(&sd->queue);
+-        ngx_queue_insert_head(&ctx->sh->lru_queue, &sd->queue);
+-
+-        dd("go to push_node");
+-        goto push_node;
+-    }
+-
+-    /* exists and not expired */
+-
+-    if (rc == NGX_OK) {
+-
+-        if (sd->value_type != SHDICT_TLIST) {
+-            ngx_shmtx_unlock(&ctx->shpool->mutex);
+-
+-            lua_pushnil(L);
+-            lua_pushliteral(L, "value not a list");
+-            return 2;
+-        }
+-
+-        queue = ngx_http_lua_shdict_get_list_head(sd, key.len);
+-
+-        ngx_queue_remove(&sd->queue);
+-        ngx_queue_insert_head(&ctx->sh->lru_queue, &sd->queue);
+-
+-        dd("go to push_node");
+-        goto push_node;
+-    }
+-
+-    /* rc == NGX_DECLINED, not found */
+-
+-init_list:
+-
+-    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, ctx->log, 0,
+-                   "lua shared dict list: creating a new entry");
+-
+-    /* NOTICE: we assume the begin point aligned in slab, be careful */
+-    n = offsetof(ngx_rbtree_node_t, color)
+-        + offsetof(ngx_http_lua_shdict_node_t, data)
+-        + key.len
+-        + sizeof(ngx_queue_t);
+-
+-    dd("length before aligned: %d", n);
+-
+-    n = (int) (uintptr_t) ngx_align_ptr(n, NGX_ALIGNMENT);
+-
+-    dd("length after aligned: %d", n);
+-
+-    node = ngx_slab_alloc_locked(ctx->shpool, n);
+-
+-    if (node == NULL) {
+-        ngx_shmtx_unlock(&ctx->shpool->mutex);
+-
+-        lua_pushboolean(L, 0);
+-        lua_pushliteral(L, "no memory");
+-        return 2;
+-    }
+-
+-    sd = (ngx_http_lua_shdict_node_t *) &node->color;
+-
+-    queue = ngx_http_lua_shdict_get_list_head(sd, key.len);
+-
+-    node->key = hash;
+-    sd->key_len = (u_short) key.len;
+-
+-    sd->expires = 0;
+-
+-    sd->value_len = 0;
+-
+-    dd("setting value type to %d", (int) SHDICT_TLIST);
+-
+-    sd->value_type = (uint8_t) SHDICT_TLIST;
+-
+-    ngx_memcpy(sd->data, key.data, key.len);
+-
+-    ngx_queue_init(queue);
+-
+-    ngx_rbtree_insert(&ctx->sh->rbtree, node);
+-
+-    ngx_queue_insert_head(&ctx->sh->lru_queue, &sd->queue);
+-
+-push_node:
+-
+-    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, ctx->log, 0,
+-                   "lua shared dict list: creating a new list node");
+-
+-    n = offsetof(ngx_http_lua_shdict_list_node_t, data)
+-        + value.len;
+-
+-    dd("list node length: %d", n);
+-
+-    lnode = ngx_slab_alloc_locked(ctx->shpool, n);
+-
+-    if (lnode == NULL) {
+-
+-        if (sd->value_len == 0) {
+-
+-            ngx_log_debug0(NGX_LOG_DEBUG_HTTP, ctx->log, 0,
+-                           "lua shared dict list: no memory for create"
+-                           " list node and list empty, remove it");
+-
+-            ngx_queue_remove(&sd->queue);
+-
+-            node = (ngx_rbtree_node_t *)
+-                        ((u_char *) sd - offsetof(ngx_rbtree_node_t, color));
+-
+-            ngx_rbtree_delete(&ctx->sh->rbtree, node);
+-
+-            ngx_slab_free_locked(ctx->shpool, node);
+-        }
+-
+-        ngx_shmtx_unlock(&ctx->shpool->mutex);
+-
+-        lua_pushnil(L);
+-        lua_pushliteral(L, "no memory");
+-        return 2;
+-    }
+-
+-    dd("setting list length to %d", sd->value_len + 1);
+-
+-    sd->value_len = sd->value_len + 1;
+-
+-    dd("setting list node value length to %d", (int) value.len);
+-
+-    lnode->value_len = (uint32_t) value.len;
+-
+-    dd("setting list node value type to %d", value_type);
+-
+-    lnode->value_type = (uint8_t) value_type;
+-
+-    ngx_memcpy(lnode->data, value.data, value.len);
+-
+-    if (flags == NGX_HTTP_LUA_SHDICT_LEFT) {
+-        ngx_queue_insert_head(queue, &lnode->queue);
+-
+-    } else {
+-        ngx_queue_insert_tail(queue, &lnode->queue);
+-    }
+-
+-    ngx_shmtx_unlock(&ctx->shpool->mutex);
+-
+-    lua_pushnumber(L, sd->value_len);
+-    return 1;
+-}
+-
+-
+-static int
+-ngx_http_lua_shdict_lpop(lua_State *L)
+-{
+-    return ngx_http_lua_shdict_pop_helper(L, NGX_HTTP_LUA_SHDICT_LEFT);
+-}
+-
+-
+-static int
+-ngx_http_lua_shdict_rpop(lua_State *L)
+-{
+-    return ngx_http_lua_shdict_pop_helper(L, NGX_HTTP_LUA_SHDICT_RIGHT);
+-}
+-
+-
+-static int
+-ngx_http_lua_shdict_pop_helper(lua_State *L, int flags)
+-{
+-    int                              n;
+-    ngx_str_t                        name;
+-    ngx_str_t                        key;
+-    uint32_t                         hash;
+-    ngx_int_t                        rc;
+-    ngx_http_lua_shdict_ctx_t       *ctx;
+-    ngx_http_lua_shdict_node_t      *sd;
+-    ngx_str_t                        value;
+-    int                              value_type;
+-    double                           num;
+-    ngx_rbtree_node_t               *node;
+-    ngx_shm_zone_t                  *zone;
+-    ngx_queue_t                     *queue;
+-    ngx_http_lua_shdict_list_node_t *lnode;
+-
+-    n = lua_gettop(L);
+-
+-    if (n != 2) {
+-        return luaL_error(L, "expecting 2 arguments, "
+-                          "but only seen %d", n);
+-    }
+-
+-    if (lua_type(L, 1) != LUA_TTABLE) {
+-        return luaL_error(L, "bad \"zone\" argument");
+-    }
+-
+-    zone = ngx_http_lua_shdict_get_zone(L, 1);
+-    if (zone == NULL) {
+-        return luaL_error(L, "bad \"zone\" argument");
+-    }
+-
+-    ctx = zone->data;
+-    name = ctx->name;
+-
+-    if (lua_isnil(L, 2)) {
+-        lua_pushnil(L);
+-        lua_pushliteral(L, "nil key");
+-        return 2;
+-    }
+-
+-    key.data = (u_char *) luaL_checklstring(L, 2, &key.len);
+-
+-    if (key.len == 0) {
+-        lua_pushnil(L);
+-        lua_pushliteral(L, "empty key");
+-        return 2;
+-    }
+-
+-    if (key.len > 65535) {
+-        lua_pushnil(L);
+-        lua_pushliteral(L, "key too long");
+-        return 2;
+-    }
+-
+-    hash = ngx_crc32_short(key.data, key.len);
+-
+-    ngx_shmtx_lock(&ctx->shpool->mutex);
+-
+-#if 1
+-    ngx_http_lua_shdict_expire(ctx, 1);
+-#endif
+-
+-    rc = ngx_http_lua_shdict_lookup(zone, hash, key.data, key.len, &sd);
+-
+-    dd("shdict lookup returned %d", (int) rc);
+-
+-    if (rc == NGX_DECLINED || rc == NGX_DONE) {
+-        ngx_shmtx_unlock(&ctx->shpool->mutex);
+-        lua_pushnil(L);
+-        return 1;
+-    }
+-
+-    /* rc == NGX_OK */
+-
+-    if (sd->value_type != SHDICT_TLIST) {
+-        ngx_shmtx_unlock(&ctx->shpool->mutex);
+-
+-        lua_pushnil(L);
+-        lua_pushliteral(L, "value not a list");
+-        return 2;
+-    }
+-
+-    if (sd->value_len <= 0) {
+-        ngx_shmtx_unlock(&ctx->shpool->mutex);
+-
+-        return luaL_error(L, "bad lua list length found for key %s "
+-                          "in shared_dict %s: %lu", key.data, name.data,
+-                          (unsigned long) sd->value_len);
+-    }
+-
+-    queue = ngx_http_lua_shdict_get_list_head(sd, key.len);
+-
+-    if (flags == NGX_HTTP_LUA_SHDICT_LEFT) {
+-        queue = ngx_queue_head(queue);
+-
+-    } else {
+-        queue = ngx_queue_last(queue);
+-    }
+-
+-    lnode = ngx_queue_data(queue, ngx_http_lua_shdict_list_node_t, queue);
+-
+-    value_type = lnode->value_type;
+-
+-    dd("data: %p", lnode->data);
+-    dd("value len: %d", (int) sd->value_len);
+-
+-    value.data = lnode->data;
+-    value.len = (size_t) lnode->value_len;
+-
+-    switch (value_type) {
+-
+-    case SHDICT_TSTRING:
+-
+-        lua_pushlstring(L, (char *) value.data, value.len);
+-        break;
+-
+-    case SHDICT_TNUMBER:
+-
+-        if (value.len != sizeof(double)) {
+-
+-            ngx_shmtx_unlock(&ctx->shpool->mutex);
+-
+-            return luaL_error(L, "bad lua list node number value size found "
+-                              "for key %s in shared_dict %s: %lu", key.data,
+-                              name.data, (unsigned long) value.len);
+-        }
+-
+-        ngx_memcpy(&num, value.data, sizeof(double));
+-
+-        lua_pushnumber(L, num);
+-        break;
+-
+-    default:
+-
+-        ngx_shmtx_unlock(&ctx->shpool->mutex);
+-
+-        return luaL_error(L, "bad list node value type found for key %s in "
+-                          "shared_dict %s: %d", key.data, name.data,
+-                          value_type);
+-    }
+-
+-    ngx_queue_remove(queue);
+-
+-    ngx_slab_free_locked(ctx->shpool, lnode);
+-
+-    if (sd->value_len == 1) {
+-
+-        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, ctx->log, 0,
+-                       "lua shared dict list: empty node after pop, "
+-                       "remove it");
+-
+-        ngx_queue_remove(&sd->queue);
+-
+-        node = (ngx_rbtree_node_t *)
+-                    ((u_char *) sd - offsetof(ngx_rbtree_node_t, color));
+-
+-        ngx_rbtree_delete(&ctx->sh->rbtree, node);
+-
+-        ngx_slab_free_locked(ctx->shpool, node);
+-
+-    } else {
+-        sd->value_len = sd->value_len - 1;
+-
+-        ngx_queue_remove(&sd->queue);
+-        ngx_queue_insert_head(&ctx->sh->lru_queue, &sd->queue);
+-    }
+-
+-    ngx_shmtx_unlock(&ctx->shpool->mutex);
+-
+-    return 1;
+-}
+-
+-
+-static int
+-ngx_http_lua_shdict_llen(lua_State *L)
+-{
+-    int                          n;
+-    ngx_str_t                    key;
+-    uint32_t                     hash;
+-    ngx_int_t                    rc;
+-    ngx_http_lua_shdict_ctx_t   *ctx;
+-    ngx_http_lua_shdict_node_t  *sd;
+-    ngx_shm_zone_t              *zone;
+-
+-    n = lua_gettop(L);
+-
+-    if (n != 2) {
+-        return luaL_error(L, "expecting 2 arguments, "
+-                          "but only seen %d", n);
+-    }
+-
+-    if (lua_type(L, 1) != LUA_TTABLE) {
+-        return luaL_error(L, "bad \"zone\" argument");
+-    }
+-
+-    zone = ngx_http_lua_shdict_get_zone(L, 1);
+-    if (zone == NULL) {
+-        return luaL_error(L, "bad \"zone\" argument");
+-    }
+-
+-    ctx = zone->data;
+-
+-    if (lua_isnil(L, 2)) {
+-        lua_pushnil(L);
+-        lua_pushliteral(L, "nil key");
+-        return 2;
+-    }
+-
+-    key.data = (u_char *) luaL_checklstring(L, 2, &key.len);
+-
+-    if (key.len == 0) {
+-        lua_pushnil(L);
+-        lua_pushliteral(L, "empty key");
+-        return 2;
+-    }
+-
+-    if (key.len > 65535) {
+-        lua_pushnil(L);
+-        lua_pushliteral(L, "key too long");
+-        return 2;
+-    }
+-
+-    hash = ngx_crc32_short(key.data, key.len);
+-
+-    ngx_shmtx_lock(&ctx->shpool->mutex);
+-
+-#if 1
+-    ngx_http_lua_shdict_expire(ctx, 1);
+-#endif
+-
+-    rc = ngx_http_lua_shdict_lookup(zone, hash, key.data, key.len, &sd);
+-
+-    dd("shdict lookup returned %d", (int) rc);
+-
+-    if (rc == NGX_OK) {
+-
+-        if (sd->value_type != SHDICT_TLIST) {
+-            ngx_shmtx_unlock(&ctx->shpool->mutex);
+-
+-            lua_pushnil(L);
+-            lua_pushliteral(L, "value not a list");
+-            return 2;
+-        }
+-
+-        ngx_queue_remove(&sd->queue);
+-        ngx_queue_insert_head(&ctx->sh->lru_queue, &sd->queue);
+-
+-        ngx_shmtx_unlock(&ctx->shpool->mutex);
+-
+-        lua_pushnumber(L, (lua_Number) sd->value_len);
+-        return 1;
+-    }
+-
+-    ngx_shmtx_unlock(&ctx->shpool->mutex);
+-
+-    lua_pushnumber(L, 0);
+-    return 1;
+-}
+-
+-
+-ngx_shm_zone_t *
+-ngx_http_lua_find_zone(u_char *name_data, size_t name_len)
+-{
+-    ngx_str_t                       *name;
+-    ngx_uint_t                       i;
+-    ngx_shm_zone_t                  *zone;
+-    ngx_http_lua_shm_zone_ctx_t     *ctx;
+-    volatile ngx_list_part_t        *part;
+-
+-    part = &ngx_cycle->shared_memory.part;
+-    zone = part->elts;
+-
+-    for (i = 0; /* void */ ; i++) {
+-
+-        if (i >= part->nelts) {
+-            if (part->next == NULL) {
+-                break;
+-            }
+-
+-            part = part->next;
+-            zone = part->elts;
+-            i = 0;
+-        }
+-
+-        name = &zone[i].shm.name;
+-
+-        dd("name: [%.*s] %d", (int) name->len, name->data, (int) name->len);
+-        dd("name2: [%.*s] %d", (int) name_len, name_data, (int) name_len);
+-
+-        if (name->len == name_len
+-            && ngx_strncmp(name->data, name_data, name_len) == 0)
+-        {
+-            ctx = (ngx_http_lua_shm_zone_ctx_t *) zone[i].data;
+-            return &ctx->zone;
+-        }
+-    }
+-
+-    return NULL;
+-}
+-
+-
+-ngx_shm_zone_t *
+-ngx_http_lua_ffi_shdict_udata_to_zone(void *zone_udata)
+-{
+-    if (zone_udata == NULL) {
+-        return NULL;
+-    }
+-
+-    return *(ngx_shm_zone_t **) zone_udata;
+-}
+-
+-
+-int
+-ngx_http_lua_ffi_shdict_store(ngx_shm_zone_t *zone, int op, u_char *key,
+-    size_t key_len, int value_type, u_char *str_value_buf,
+-    size_t str_value_len, double num_value, long exptime, int user_flags,
+-    char **errmsg, int *forcible)
+-{
+-    int                          i, n;
+-    u_char                       c, *p;
+-    uint32_t                     hash;
+-    ngx_int_t                    rc;
+-    ngx_time_t                  *tp;
+-    ngx_queue_t                 *queue, *q;
+-    ngx_rbtree_node_t           *node;
+-    ngx_http_lua_shdict_ctx_t   *ctx;
+-    ngx_http_lua_shdict_node_t  *sd;
+-
+-    dd("exptime: %ld", exptime);
+-
+-    ctx = zone->data;
+-
+-    *forcible = 0;
+-
+-    hash = ngx_crc32_short(key, key_len);
+-
+-    switch (value_type) {
+-
+-    case SHDICT_TSTRING:
+-        /* do nothing */
+-        break;
+-
+-    case SHDICT_TNUMBER:
+-        dd("num value: %lf", num_value);
+-        str_value_buf = (u_char *) &num_value;
+-        str_value_len = sizeof(double);
+-        break;
+-
+-    case SHDICT_TBOOLEAN:
+-        c = num_value ? 1 : 0;
+-        str_value_buf = &c;
+-        str_value_len = sizeof(u_char);
+-        break;
+-
+-    case LUA_TNIL:
+-        if (op & (NGX_HTTP_LUA_SHDICT_ADD|NGX_HTTP_LUA_SHDICT_REPLACE)) {
+-            *errmsg = "attempt to add or replace nil values";
+-            return NGX_ERROR;
+-        }
+-
+-        str_value_buf = NULL;
+-        str_value_len = 0;
+-        break;
+-
+-    default:
+-        *errmsg = "unsupported value type";
+-        return NGX_ERROR;
+-    }
+-
+-    ngx_shmtx_lock(&ctx->shpool->mutex);
+-
+-#if 1
+-    ngx_http_lua_shdict_expire(ctx, 1);
+-#endif
+-
+-    rc = ngx_http_lua_shdict_lookup(zone, hash, key, key_len, &sd);
+-
+-    dd("lookup returns %d", (int) rc);
+-
+-    if (op & NGX_HTTP_LUA_SHDICT_REPLACE) {
+-
+-        if (rc == NGX_DECLINED || rc == NGX_DONE) {
+-            ngx_shmtx_unlock(&ctx->shpool->mutex);
+-            *errmsg = "not found";
+-            return NGX_DECLINED;
+-        }
+-
+-        /* rc == NGX_OK */
+-
+-        goto replace;
+-    }
+-
+-    if (op & NGX_HTTP_LUA_SHDICT_ADD) {
+-
+-        if (rc == NGX_OK) {
+-            ngx_shmtx_unlock(&ctx->shpool->mutex);
+-            *errmsg = "exists";
+-            return NGX_DECLINED;
+-        }
+-
+-        if (rc == NGX_DONE) {
+-            /* exists but expired */
+-
+-            dd("go to replace");
+-            goto replace;
+-        }
+-
+-        /* rc == NGX_DECLINED */
+-
+-        dd("go to insert");
+-        goto insert;
+-    }
+-
+-    if (rc == NGX_OK || rc == NGX_DONE) {
+-
+-        if (value_type == LUA_TNIL) {
+-            goto remove;
+-        }
+-
+-replace:
+-
+-        if (str_value_buf
+-            && str_value_len == (size_t) sd->value_len
+-            && sd->value_type != SHDICT_TLIST)
+-        {
+-
+-            ngx_log_debug0(NGX_LOG_DEBUG_HTTP, ctx->log, 0,
+-                           "lua shared dict set: found old entry and value "
+-                           "size matched, reusing it");
+-
+-            ngx_queue_remove(&sd->queue);
+-            ngx_queue_insert_head(&ctx->sh->lru_queue, &sd->queue);
+-
+-            if (exptime > 0) {
+-                tp = ngx_timeofday();
+-                sd->expires = (uint64_t) tp->sec * 1000 + tp->msec
+-                              + (uint64_t) exptime;
+-
+-            } else {
+-                sd->expires = 0;
+-            }
+-
+-            sd->user_flags = user_flags;
+-
+-            dd("setting value type to %d", value_type);
+-
+-            sd->value_type = (uint8_t) value_type;
+-
+-            ngx_memcpy(sd->data + key_len, str_value_buf, str_value_len);
+-
+-            ngx_shmtx_unlock(&ctx->shpool->mutex);
+-
+-            return NGX_OK;
+-        }
+-
+-        ngx_log_debug0(NGX_LOG_DEBUG_HTTP, ctx->log, 0,
+-                       "lua shared dict set: found old entry but value size "
+-                       "NOT matched, removing it first");
+-
+-remove:
+-
+-        if (sd->value_type == SHDICT_TLIST) {
+-            queue = ngx_http_lua_shdict_get_list_head(sd, key_len);
+-
+-            for (q = ngx_queue_head(queue);
+-                 q != ngx_queue_sentinel(queue);
+-                 q = ngx_queue_next(q))
+-            {
+-                p = (u_char *) ngx_queue_data(q,
+-                                              ngx_http_lua_shdict_list_node_t,
+-                                              queue);
+-
+-                ngx_slab_free_locked(ctx->shpool, p);
+-            }
+-        }
+-
+-        ngx_queue_remove(&sd->queue);
+-
+-        node = (ngx_rbtree_node_t *)
+-                   ((u_char *) sd - offsetof(ngx_rbtree_node_t, color));
+-
+-        ngx_rbtree_delete(&ctx->sh->rbtree, node);
+-
+-        ngx_slab_free_locked(ctx->shpool, node);
+-
+-    }
+-
+-insert:
+-
+-    /* rc == NGX_DECLINED or value size unmatch */
+-
+-    if (str_value_buf == NULL) {
+-        ngx_shmtx_unlock(&ctx->shpool->mutex);
+-        return NGX_OK;
+-    }
+-
+-    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, ctx->log, 0,
+-                   "lua shared dict set: creating a new entry");
+-
+-    n = offsetof(ngx_rbtree_node_t, color)
+-        + offsetof(ngx_http_lua_shdict_node_t, data)
+-        + key_len
+-        + str_value_len;
+-
+-    node = ngx_slab_alloc_locked(ctx->shpool, n);
+-
+-    if (node == NULL) {
+-
+-        if (op & NGX_HTTP_LUA_SHDICT_SAFE_STORE) {
+-            ngx_shmtx_unlock(&ctx->shpool->mutex);
+-
+-            *errmsg = "no memory";
+-            return NGX_ERROR;
+-        }
+-
+-        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, ctx->log, 0,
+-                       "lua shared dict set: overriding non-expired items "
+-                       "due to memory shortage for entry \"%*s\"", key_len,
+-                       key);
+-
+-        for (i = 0; i < 30; i++) {
+-            if (ngx_http_lua_shdict_expire(ctx, 0) == 0) {
+-                break;
+-            }
+-
+-            *forcible = 1;
+-
+-            node = ngx_slab_alloc_locked(ctx->shpool, n);
+-            if (node != NULL) {
+-                goto allocated;
+-            }
+-        }
+-
+-        ngx_shmtx_unlock(&ctx->shpool->mutex);
+-
+-        *errmsg = "no memory";
+-        return NGX_ERROR;
+-    }
+-
+-allocated:
+-
+-    sd = (ngx_http_lua_shdict_node_t *) &node->color;
+-
+-    node->key = hash;
+-    sd->key_len = (u_short) key_len;
+-
+-    if (exptime > 0) {
+-        tp = ngx_timeofday();
+-        sd->expires = (uint64_t) tp->sec * 1000 + tp->msec
+-                      + (uint64_t) exptime;
+-
+-    } else {
+-        sd->expires = 0;
+-    }
+-
+-    sd->user_flags = user_flags;
+-    sd->value_len = (uint32_t) str_value_len;
+-    dd("setting value type to %d", value_type);
+-    sd->value_type = (uint8_t) value_type;
+-
+-    p = ngx_copy(sd->data, key, key_len);
+-    ngx_memcpy(p, str_value_buf, str_value_len);
+-
+-    ngx_rbtree_insert(&ctx->sh->rbtree, node);
+-    ngx_queue_insert_head(&ctx->sh->lru_queue, &sd->queue);
+-    ngx_shmtx_unlock(&ctx->shpool->mutex);
+-
+-    return NGX_OK;
+-}
+-
+-
+-int
+-ngx_http_lua_ffi_shdict_get(ngx_shm_zone_t *zone, u_char *key,
+-    size_t key_len, int *value_type, u_char **str_value_buf,
+-    size_t *str_value_len, double *num_value, int *user_flags,
+-    int get_stale, int *is_stale, char **err)
+-{
+-    ngx_str_t                    name;
+-    uint32_t                     hash;
+-    ngx_int_t                    rc;
+-    ngx_http_lua_shdict_ctx_t   *ctx;
+-    ngx_http_lua_shdict_node_t  *sd;
+-    ngx_str_t                    value;
+-
+-    *err = NULL;
+-
+-    ctx = zone->data;
+-    name = ctx->name;
+-
+-    hash = ngx_crc32_short(key, key_len);
+-
+-#if (NGX_DEBUG)
+-    ngx_log_debug3(NGX_LOG_DEBUG_HTTP, ctx->log, 0,
+-                   "fetching key \"%*s\" in shared dict \"%V\"", key_len,
+-                   key, &name);
+-#endif /* NGX_DEBUG */
+-
+-    ngx_shmtx_lock(&ctx->shpool->mutex);
+-
+-#if 1
+-    if (!get_stale) {
+-        ngx_http_lua_shdict_expire(ctx, 1);
+-    }
+-#endif
+-
+-    rc = ngx_http_lua_shdict_lookup(zone, hash, key, key_len, &sd);
+-
+-    dd("shdict lookup returns %d", (int) rc);
+-
+-    if (rc == NGX_DECLINED || (rc == NGX_DONE && !get_stale)) {
+-        ngx_shmtx_unlock(&ctx->shpool->mutex);
+-        *value_type = LUA_TNIL;
+-        return NGX_OK;
+-    }
+-
+-    /* rc == NGX_OK || (rc == NGX_DONE && get_stale) */
+-
+-    *value_type = sd->value_type;
+-
+-    dd("data: %p", sd->data);
+-    dd("key len: %d", (int) sd->key_len);
+-
+-    value.data = sd->data + sd->key_len;
+-    value.len = (size_t) sd->value_len;
+-
+-    if (*str_value_len < (size_t) value.len) {
+-        if (*value_type == SHDICT_TBOOLEAN) {
+-            ngx_shmtx_unlock(&ctx->shpool->mutex);
+-            return NGX_ERROR;
+-        }
+-
+-        if (*value_type == SHDICT_TSTRING) {
+-            *str_value_buf = malloc(value.len);
+-            if (*str_value_buf == NULL) {
+-                ngx_shmtx_unlock(&ctx->shpool->mutex);
+-                return NGX_ERROR;
+-            }
+-        }
+-    }
+-
+-    switch (*value_type) {
+-
+-    case SHDICT_TSTRING:
+-        *str_value_len = value.len;
+-        ngx_memcpy(*str_value_buf, value.data, value.len);
+-        break;
+-
+-    case SHDICT_TNUMBER:
+-
+-        if (value.len != sizeof(double)) {
+-            ngx_shmtx_unlock(&ctx->shpool->mutex);
+-            ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0,
+-                          "bad lua number value size found for key %*s "
+-                          "in shared_dict %V: %z", key_len, key,
+-                          &name, value.len);
+-            return NGX_ERROR;
+-        }
+-
+-        *str_value_len = value.len;
+-        ngx_memcpy(num_value, value.data, sizeof(double));
+-        break;
+-
+-    case SHDICT_TBOOLEAN:
+-
+-        if (value.len != sizeof(u_char)) {
+-            ngx_shmtx_unlock(&ctx->shpool->mutex);
+-            ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0,
+-                          "bad lua boolean value size found for key %*s "
+-                          "in shared_dict %V: %z", key_len, key, &name,
+-                          value.len);
+-            return NGX_ERROR;
+-        }
+-
+-        ngx_memcpy(*str_value_buf, value.data, value.len);
+-        break;
+-
+-    case SHDICT_TLIST:
+-
+-        ngx_shmtx_unlock(&ctx->shpool->mutex);
+-
+-        *err = "value is a list";
+-        return NGX_ERROR;
+-
+-    default:
+-
+-        ngx_shmtx_unlock(&ctx->shpool->mutex);
+-        ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0,
+-                      "bad value type found for key %*s in "
+-                      "shared_dict %V: %d", key_len, key, &name,
+-                      *value_type);
+-        return NGX_ERROR;
+-    }
+-
+-    *user_flags = sd->user_flags;
+-    dd("user flags: %d", *user_flags);
+-
+-    ngx_shmtx_unlock(&ctx->shpool->mutex);
+-
+-    if (get_stale) {
+-
+-        /* always return value, flags, stale */
+-
+-        *is_stale = (rc == NGX_DONE);
+-        return NGX_OK;
+-    }
+-
+-    return NGX_OK;
+-}
+-
+-
+-int
+-ngx_http_lua_ffi_shdict_incr(ngx_shm_zone_t *zone, u_char *key,
+-    size_t key_len, double *value, char **err, int has_init, double init,
+-    long init_ttl, int *forcible)
+-{
+-    int                          i, n;
+-    uint32_t                     hash;
+-    ngx_int_t                    rc;
+-    ngx_time_t                  *tp = NULL;
+-    ngx_http_lua_shdict_ctx_t   *ctx;
+-    ngx_http_lua_shdict_node_t  *sd;
+-    double                       num;
+-    ngx_rbtree_node_t           *node;
+-    u_char                      *p;
+-    ngx_queue_t                 *queue, *q;
+-
+-    if (init_ttl > 0) {
+-        tp = ngx_timeofday();
+-    }
+-
+-    ctx = zone->data;
+-
+-    *forcible = 0;
+-
+-    hash = ngx_crc32_short(key, key_len);
+-
+-    dd("looking up key %.*s in shared dict %.*s", (int) key_len, key,
+-       (int) ctx->name.len, ctx->name.data);
+-
+-    ngx_shmtx_lock(&ctx->shpool->mutex);
+-#if 1
+-    ngx_http_lua_shdict_expire(ctx, 1);
+-#endif
+-    rc = ngx_http_lua_shdict_lookup(zone, hash, key, key_len, &sd);
+-
+-    dd("shdict lookup returned %d", (int) rc);
+-
+-    if (rc == NGX_DECLINED || rc == NGX_DONE) {
+-        if (!has_init) {
+-            ngx_shmtx_unlock(&ctx->shpool->mutex);
+-            *err = "not found";
+-            return NGX_ERROR;
+-        }
+-
+-        /* add value */
+-        num = *value + init;
+-
+-        if (rc == NGX_DONE) {
+-
+-            /* found an expired item */
+-
+-            if ((size_t) sd->value_len == sizeof(double)
+-                && sd->value_type != SHDICT_TLIST)
+-            {
+-                ngx_log_debug0(NGX_LOG_DEBUG_HTTP, ctx->log, 0,
+-                               "lua shared dict incr: found old entry and "
+-                               "value size matched, reusing it");
+-
+-                ngx_queue_remove(&sd->queue);
+-                ngx_queue_insert_head(&ctx->sh->lru_queue, &sd->queue);
+-
+-                dd("go to setvalue");
+-                goto setvalue;
+-            }
+-
+-            dd("go to remove");
+-            goto remove;
+-        }
+-
+-        dd("go to insert");
+-        goto insert;
+-    }
+-
+-    /* rc == NGX_OK */
+-
+-    if (sd->value_type != SHDICT_TNUMBER || sd->value_len != sizeof(double)) {
+-        ngx_shmtx_unlock(&ctx->shpool->mutex);
+-        *err = "not a number";
+-        return NGX_ERROR;
+-    }
+-
+-    ngx_queue_remove(&sd->queue);
+-    ngx_queue_insert_head(&ctx->sh->lru_queue, &sd->queue);
+-
+-    dd("setting value type to %d", (int) sd->value_type);
+-
+-    p = sd->data + key_len;
+-
+-    ngx_memcpy(&num, p, sizeof(double));
+-    num += *value;
+-
+-    ngx_memcpy(p, (double *) &num, sizeof(double));
+-
+-    ngx_shmtx_unlock(&ctx->shpool->mutex);
+-
+-    *value = num;
+-    return NGX_OK;
+-
+-remove:
+-
+-    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, ctx->log, 0,
+-                   "lua shared dict incr: found old entry but value size "
+-                   "NOT matched, removing it first");
+-
+-    if (sd->value_type == SHDICT_TLIST) {
+-        queue = ngx_http_lua_shdict_get_list_head(sd, key_len);
+-
+-        for (q = ngx_queue_head(queue);
+-             q != ngx_queue_sentinel(queue);
+-             q = ngx_queue_next(q))
+-        {
+-            p = (u_char *) ngx_queue_data(q, ngx_http_lua_shdict_list_node_t,
+-                                          queue);
+-
+-            ngx_slab_free_locked(ctx->shpool, p);
+-        }
+-    }
+-
+-    ngx_queue_remove(&sd->queue);
+-
+-    node = (ngx_rbtree_node_t *)
+-               ((u_char *) sd - offsetof(ngx_rbtree_node_t, color));
+-
+-    ngx_rbtree_delete(&ctx->sh->rbtree, node);
+-
+-    ngx_slab_free_locked(ctx->shpool, node);
+-
+-insert:
+-
+-    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, ctx->log, 0,
+-                   "lua shared dict incr: creating a new entry");
+-
+-    n = offsetof(ngx_rbtree_node_t, color)
+-        + offsetof(ngx_http_lua_shdict_node_t, data)
+-        + key_len
+-        + sizeof(double);
+-
+-    node = ngx_slab_alloc_locked(ctx->shpool, n);
+-
+-    if (node == NULL) {
+-
+-        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, ctx->log, 0,
+-                       "lua shared dict incr: overriding non-expired items "
+-                       "due to memory shortage for entry \"%*s\"", key_len,
+-                       key);
+-
+-        for (i = 0; i < 30; i++) {
+-            if (ngx_http_lua_shdict_expire(ctx, 0) == 0) {
+-                break;
+-            }
+-
+-            *forcible = 1;
+-
+-            node = ngx_slab_alloc_locked(ctx->shpool, n);
+-            if (node != NULL) {
+-                goto allocated;
+-            }
+-        }
+-
+-        ngx_shmtx_unlock(&ctx->shpool->mutex);
+-
+-        *err = "no memory";
+-        return NGX_ERROR;
+-    }
+-
+-allocated:
+-
+-    sd = (ngx_http_lua_shdict_node_t *) &node->color;
+-
+-    node->key = hash;
+-
+-    sd->key_len = (u_short) key_len;
+-
+-    sd->value_len = (uint32_t) sizeof(double);
+-
+-    ngx_rbtree_insert(&ctx->sh->rbtree, node);
+-
+-    ngx_queue_insert_head(&ctx->sh->lru_queue, &sd->queue);
+-
+-setvalue:
+-
+-    sd->user_flags = 0;
+-
+-    if (init_ttl > 0) {
+-        sd->expires = (uint64_t) tp->sec * 1000 + tp->msec
+-                      + (uint64_t) init_ttl;
+-
+-    } else {
+-        sd->expires = 0;
+-    }
+-
+-    dd("setting value type to %d", LUA_TNUMBER);
+-
+-    sd->value_type = (uint8_t) LUA_TNUMBER;
+-
+-    p = ngx_copy(sd->data, key, key_len);
+-    ngx_memcpy(p, (double *) &num, sizeof(double));
+-
+-    ngx_shmtx_unlock(&ctx->shpool->mutex);
+-
+-    *value = num;
+-    return NGX_OK;
+-}
+-
+-
+-int
+-ngx_http_lua_ffi_shdict_flush_all(ngx_shm_zone_t *zone)
+-{
+-    ngx_queue_t                 *q;
+-    ngx_http_lua_shdict_node_t  *sd;
+-    ngx_http_lua_shdict_ctx_t   *ctx;
+-
+-    ctx = zone->data;
+-
+-    ngx_shmtx_lock(&ctx->shpool->mutex);
+-
+-    for (q = ngx_queue_head(&ctx->sh->lru_queue);
+-         q != ngx_queue_sentinel(&ctx->sh->lru_queue);
+-         q = ngx_queue_next(q))
+-    {
+-        sd = ngx_queue_data(q, ngx_http_lua_shdict_node_t, queue);
+-        sd->expires = 1;
+-    }
+-
+-    ngx_http_lua_shdict_expire(ctx, 0);
+-
+-    ngx_shmtx_unlock(&ctx->shpool->mutex);
+-
+-    return NGX_OK;
+-}
+-
+-
+-static ngx_int_t
+-ngx_http_lua_shdict_peek(ngx_shm_zone_t *shm_zone, ngx_uint_t hash,
+-    u_char *kdata, size_t klen, ngx_http_lua_shdict_node_t **sdp)
+-{
+-    ngx_int_t                    rc;
+-    ngx_rbtree_node_t           *node, *sentinel;
+-    ngx_http_lua_shdict_ctx_t   *ctx;
+-    ngx_http_lua_shdict_node_t  *sd;
+-
+-    ctx = shm_zone->data;
+-
+-    node = ctx->sh->rbtree.root;
+-    sentinel = ctx->sh->rbtree.sentinel;
+-
+-    while (node != sentinel) {
+-
+-        if (hash < node->key) {
+-            node = node->left;
+-            continue;
+-        }
+-
+-        if (hash > node->key) {
+-            node = node->right;
+-            continue;
+-        }
+-
+-        /* hash == node->key */
+-
+-        sd = (ngx_http_lua_shdict_node_t *) &node->color;
+-
+-        rc = ngx_memn2cmp(kdata, sd->data, klen, (size_t) sd->key_len);
+-
+-        if (rc == 0) {
+-            *sdp = sd;
+-
+-            return NGX_OK;
+-        }
+-
+-        node = (rc < 0) ? node->left : node->right;
+-    }
+-
+-    *sdp = NULL;
+-
+-    return NGX_DECLINED;
+-}
+-
+-
+-long
+-ngx_http_lua_ffi_shdict_get_ttl(ngx_shm_zone_t *zone, u_char *key,
+-    size_t key_len)
+-{
+-    uint32_t                     hash;
+-    uint64_t                     now;
+-    uint64_t                     expires;
+-    ngx_int_t                    rc;
+-    ngx_time_t                  *tp;
+-    ngx_http_lua_shdict_ctx_t   *ctx;
+-    ngx_http_lua_shdict_node_t  *sd;
+-
+-    ctx = zone->data;
+-    hash = ngx_crc32_short(key, key_len);
+-
+-    ngx_shmtx_lock(&ctx->shpool->mutex);
+-
+-    rc = ngx_http_lua_shdict_peek(zone, hash, key, key_len, &sd);
+-
+-    if (rc == NGX_DECLINED) {
+-        ngx_shmtx_unlock(&ctx->shpool->mutex);
+-
+-        return NGX_DECLINED;
+-    }
+-
+-    /* rc == NGX_OK */
+-
+-    expires = sd->expires;
+-
+-    ngx_shmtx_unlock(&ctx->shpool->mutex);
+-
+-    if (expires == 0) {
+-        return 0;
+-    }
+-
+-    tp = ngx_timeofday();
+-    now = (uint64_t) tp->sec * 1000 + tp->msec;
+-
+-    return expires - now;
+-}
+-
+-
+-int
+-ngx_http_lua_ffi_shdict_set_expire(ngx_shm_zone_t *zone, u_char *key,
+-    size_t key_len, long exptime)
+-{
+-    uint32_t                     hash;
+-    ngx_int_t                    rc;
+-    ngx_time_t                  *tp = NULL;
+-    ngx_http_lua_shdict_ctx_t   *ctx;
+-    ngx_http_lua_shdict_node_t  *sd;
+-
+-    if (exptime > 0) {
+-        tp = ngx_timeofday();
+-    }
+-
+-    ctx = zone->data;
+-    hash = ngx_crc32_short(key, key_len);
+-
+-    ngx_shmtx_lock(&ctx->shpool->mutex);
+-
+-    rc = ngx_http_lua_shdict_peek(zone, hash, key, key_len, &sd);
+-
+-    if (rc == NGX_DECLINED) {
+-        ngx_shmtx_unlock(&ctx->shpool->mutex);
+-
+-        return NGX_DECLINED;
+-    }
+-
+-    /* rc == NGX_OK */
+-
+-    if (exptime > 0) {
+-        sd->expires = (uint64_t) tp->sec * 1000 + tp->msec
+-                      + (uint64_t) exptime;
+-
+-    } else {
+-        sd->expires = 0;
+-    }
+-
+-    ngx_shmtx_unlock(&ctx->shpool->mutex);
+-
+-    return NGX_OK;
+-}
+-
+-
+-size_t
+-ngx_http_lua_ffi_shdict_capacity(ngx_shm_zone_t *zone)
+-{
+-    return zone->shm.size;
+-}
+-
+-
+-#if (nginx_version >= 1011007)
+-size_t
+-ngx_http_lua_ffi_shdict_free_space(ngx_shm_zone_t *zone)
+-{
+-    size_t                       bytes;
+-    ngx_http_lua_shdict_ctx_t   *ctx;
+-
+-    ctx = zone->data;
+-
+-    ngx_shmtx_lock(&ctx->shpool->mutex);
+-    bytes = ctx->shpool->pfree * ngx_pagesize;
+-    ngx_shmtx_unlock(&ctx->shpool->mutex);
+-
+-    return bytes;
+-}
+-#endif
+-
+-
+-#if (NGX_DARWIN)
+-int
+-ngx_http_lua_ffi_shdict_get_macos(ngx_http_lua_shdict_get_params_t *p)
+-{
+-    return ngx_http_lua_ffi_shdict_get(p->zone,
+-                                       (u_char *) p->key, p->key_len,
+-                                       p->value_type, p->str_value_buf,
+-                                       p->str_value_len, p->num_value,
+-                                       p->user_flags, p->get_stale,
+-                                       p->is_stale, p->errmsg);
+-}
+-
+-
+-int
+-ngx_http_lua_ffi_shdict_store_macos(ngx_http_lua_shdict_store_params_t *p)
+-{
+-    return ngx_http_lua_ffi_shdict_store(p->zone, p->op,
+-                                         (u_char *) p->key, p->key_len,
+-                                         p->value_type,
+-                                         (u_char *) p->str_value_buf,
+-                                         p->str_value_len, p->num_value,
+-                                         p->exptime, p->user_flags,
+-                                         p->errmsg, p->forcible);
+-}
+-
+-
+-int
+-ngx_http_lua_ffi_shdict_incr_macos(ngx_http_lua_shdict_incr_params_t *p)
+-{
+-    return ngx_http_lua_ffi_shdict_incr(p->zone, (u_char *) p->key, p->key_len,
+-                                        p->num_value, p->errmsg,
+-                                        p->has_init, p->init, p->init_ttl,
+-                                        p->forcible);
+-}
+-#endif
+-
+-
+-/* vi:set ft=c ts=4 sw=4 et fdm=marker: */
+diff --git src/ngx_http_lua_shdict.h src/ngx_http_lua_shdict.h
+deleted file mode 100644
+index 67dd4d4..0000000
+--- src/ngx_http_lua_shdict.h
++++ /dev/null
+@@ -1,113 +0,0 @@
+-
+-/*
+- * Copyright (C) Yichun Zhang (agentzh)
+- */
+-
+-
+-#ifndef _NGX_HTTP_LUA_SHDICT_H_INCLUDED_
+-#define _NGX_HTTP_LUA_SHDICT_H_INCLUDED_
+-
+-
+-#include "ngx_http_lua_common.h"
+-
+-
+-typedef struct {
+-    u_char                       color;
+-    uint8_t                      value_type;
+-    u_short                      key_len;
+-    uint32_t                     value_len;
+-    uint64_t                     expires;
+-    ngx_queue_t                  queue;
+-    uint32_t                     user_flags;
+-    u_char                       data[1];
+-} ngx_http_lua_shdict_node_t;
+-
+-
+-typedef struct {
+-    ngx_queue_t                  queue;
+-    uint32_t                     value_len;
+-    uint8_t                      value_type;
+-    u_char                       data[1];
+-} ngx_http_lua_shdict_list_node_t;
+-
+-
+-typedef struct {
+-    ngx_rbtree_t                  rbtree;
+-    ngx_rbtree_node_t             sentinel;
+-    ngx_queue_t                   lru_queue;
+-} ngx_http_lua_shdict_shctx_t;
+-
+-
+-typedef struct {
+-    ngx_http_lua_shdict_shctx_t  *sh;
+-    ngx_slab_pool_t              *shpool;
+-    ngx_str_t                     name;
+-    ngx_http_lua_main_conf_t     *main_conf;
+-    ngx_log_t                    *log;
+-} ngx_http_lua_shdict_ctx_t;
+-
+-
+-typedef struct {
+-    ngx_log_t                   *log;
+-    ngx_http_lua_main_conf_t    *lmcf;
+-    ngx_cycle_t                 *cycle;
+-    ngx_shm_zone_t               zone;
+-} ngx_http_lua_shm_zone_ctx_t;
+-
+-
+-#if (NGX_DARWIN)
+-typedef struct {
+-    void                  *zone;
+-    const unsigned char   *key;
+-    size_t                 key_len;
+-    int                   *value_type;
+-    unsigned char        **str_value_buf;
+-    size_t                *str_value_len;
+-    double                *num_value;
+-    int                   *user_flags;
+-    int                    get_stale;
+-    int                   *is_stale;
+-    char                 **errmsg;
+-} ngx_http_lua_shdict_get_params_t;
+-
+-
+-typedef struct {
+-    void                  *zone;
+-    int                    op;
+-    const unsigned char   *key;
+-    size_t                 key_len;
+-    int                    value_type;
+-    const unsigned char   *str_value_buf;
+-    size_t                 str_value_len;
+-    double                 num_value;
+-    long                   exptime;
+-    int                    user_flags;
+-    char                 **errmsg;
+-    int                   *forcible;
+-} ngx_http_lua_shdict_store_params_t;
+-
+-
+-typedef struct {
+-    void                  *zone;
+-    const unsigned char   *key;
+-    size_t                 key_len;
+-    double                *num_value;
+-    char                 **errmsg;
+-    int                    has_init;
+-    double                 init;
+-    long                   init_ttl;
+-    int                   *forcible;
+-} ngx_http_lua_shdict_incr_params_t;
+-#endif
+-
+-
+-ngx_int_t ngx_http_lua_shdict_init_zone(ngx_shm_zone_t *shm_zone, void *data);
+-void ngx_http_lua_shdict_rbtree_insert_value(ngx_rbtree_node_t *temp,
+-    ngx_rbtree_node_t *node, ngx_rbtree_node_t *sentinel);
+-void ngx_http_lua_inject_shdict_api(ngx_http_lua_main_conf_t *lmcf,
+-    lua_State *L);
+-
+-
+-#endif /* _NGX_HTTP_LUA_SHDICT_H_INCLUDED_ */
+-
+-/* vi:set ft=c ts=4 sw=4 et fdm=marker: */
+diff --git src/ngx_http_lua_util.c src/ngx_http_lua_util.c
+index 8fd2656..0e5385e 100644
+--- src/ngx_http_lua_util.c
++++ src/ngx_http_lua_util.c
+@@ -12,6 +12,7 @@
+ 
+ 
+ #include "nginx.h"
++#include "ngx_meta_lua_api.h"
+ #include "ngx_http_lua_directive.h"
+ #include "ngx_http_lua_util.h"
+ #include "ngx_http_lua_exception.h"
+@@ -28,7 +29,6 @@
+ #include "ngx_http_lua_string.h"
+ #include "ngx_http_lua_misc.h"
+ #include "ngx_http_lua_consts.h"
+-#include "ngx_http_lua_shdict.h"
+ #include "ngx_http_lua_coroutine.h"
+ #include "ngx_http_lua_socket_tcp.h"
+ #include "ngx_http_lua_socket_udp.h"
+@@ -117,7 +117,7 @@ static ngx_int_t ngx_http_lua_handle_rewrite_jump(lua_State *L,
+ static int ngx_http_lua_thread_traceback(lua_State *L, lua_State *co,
+     ngx_http_lua_co_ctx_t *coctx);
+ static void ngx_http_lua_inject_ngx_api(lua_State *L,
+-    ngx_http_lua_main_conf_t *lmcf, ngx_log_t *log);
++    ngx_cycle_t *cycle, ngx_http_lua_main_conf_t *lmcf, ngx_log_t *log);
+ static void ngx_http_lua_inject_arg_api(lua_State *L);
+ static int ngx_http_lua_param_set(lua_State *L);
+ static ngx_int_t ngx_http_lua_output_filter(ngx_http_request_t *r,
+@@ -817,13 +817,13 @@ ngx_http_lua_init_globals(lua_State *L, ngx_cycle_t *cycle,
+     ngx_http_lua_inject_ndk_api(L);
+ #endif /* defined(NDK) && NDK */
+ 
+-    ngx_http_lua_inject_ngx_api(L, lmcf, log);
++    ngx_http_lua_inject_ngx_api(L, cycle, lmcf, log);
+ }
+ 
+ 
+ static void
+-ngx_http_lua_inject_ngx_api(lua_State *L, ngx_http_lua_main_conf_t *lmcf,
+-    ngx_log_t *log)
++ngx_http_lua_inject_ngx_api(lua_State *L, ngx_cycle_t *cycle,
++    ngx_http_lua_main_conf_t *lmcf, ngx_log_t *log)
+ {
+     lua_createtable(L, 0 /* narr */, 115 /* nrec */);    /* ngx.* */
+ 
+@@ -845,7 +845,7 @@ ngx_http_lua_inject_ngx_api(lua_State *L, ngx_http_lua_main_conf_t *lmcf,
+     ngx_http_lua_inject_req_api(log, L);
+     ngx_http_lua_inject_resp_header_api(L);
+     ngx_http_lua_create_headers_metatable(log, L);
+-    ngx_http_lua_inject_shdict_api(lmcf, L);
++    ngx_meta_lua_inject_shdict_api(L, cycle, &ngx_http_lua_module);
+     ngx_http_lua_inject_socket_tcp_api(log, L);
+     ngx_http_lua_inject_socket_udp_api(log, L);
+     ngx_http_lua_inject_uthread_api(log, L);
+diff --git src/ngx_http_lua_util.h src/ngx_http_lua_util.h
+index faea7a0..4c81ac5 100644
+--- src/ngx_http_lua_util.h
++++ src/ngx_http_lua_util.h
+@@ -334,7 +334,9 @@ ngx_http_lua_create_ctx(ngx_http_request_t *r)
+         ngx_http_lua_assert(L != NULL);
+ 
+         if (lmcf->init_handler) {
+-            if (lmcf->init_handler(r->connection->log, lmcf, L) != NGX_OK) {
++            if (lmcf->init_handler(r->connection->log, lmcf->init_src, L)
++                != NGX_OK)
++            {
+                 /* an error happened */
+                 return NULL;
+             }
+diff --git src/ngx_http_lua_worker_thread.c src/ngx_http_lua_worker_thread.c
+index 3820d63..06d12f2 100644
+--- src/ngx_http_lua_worker_thread.c
++++ src/ngx_http_lua_worker_thread.c
+@@ -12,11 +12,11 @@
+ #include "ddebug.h"
+ 
+ 
++#include "ngx_meta_lua_api.h"
+ #include "ngx_http_lua_worker_thread.h"
+ #include "ngx_http_lua_util.h"
+ #include "ngx_http_lua_string.h"
+ #include "ngx_http_lua_config.h"
+-#include "ngx_http_lua_shdict.h"
+ 
+ #ifndef STRINGIFY
+ #define TOSTRING(x)  #x
+@@ -154,7 +154,7 @@ ngx_http_lua_get_task_ctx(lua_State *L, ngx_http_request_t *r)
+         lua_newtable(vm);    /* ngx.* */
+         ngx_http_lua_inject_string_api(vm);
+         ngx_http_lua_inject_config_api(vm);
+-        ngx_http_lua_inject_shdict_api(lmcf, vm);
++        ngx_meta_lua_inject_shdict_api(vm, lmcf->cycle, &ngx_http_lua_module);
+         lua_setglobal(vm, "ngx");
+ 
+         lua_getglobal(vm, "require");

--- a/patch/1.29.2.4/ngx_lua-skip_filter.patch
+++ b/patch/1.29.2.4/ngx_lua-skip_filter.patch
@@ -1,0 +1,54 @@
+diff --git src/ngx_http_lua_bodyfilterby.c src/ngx_http_lua_bodyfilterby.c
+index 9024889..88af761 100644
+--- src/ngx_http_lua_bodyfilterby.c
++++ src/ngx_http_lua_bodyfilterby.c
+@@ -22,6 +22,9 @@
+ #include "ngx_http_lua_misc.h"
+ #include "ngx_http_lua_consts.h"
+ #include "ngx_http_lua_output.h"
++#if (NGX_HTTP_APISIX)
++#include "ngx_http_apisix_module.h"
++#endif
+ 
+ 
+ static void ngx_http_lua_body_filter_by_lua_env(lua_State *L,
+@@ -241,6 +244,12 @@ ngx_http_lua_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
+     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                    "lua body filter for user lua code, uri \"%V\"", &r->uri);
+ 
++#if (NGX_HTTP_APISIX)
++    if (ngx_http_apisix_is_body_filter_by_lua_skipped(r)) {
++        return ngx_http_next_body_filter(r, in);
++    }
++#endif
++
+     llcf = ngx_http_get_module_loc_conf(r, ngx_http_lua_module);
+ 
+     if (llcf->body_filter_handler == NULL || r->header_only) {
+diff --git src/ngx_http_lua_headerfilterby.c src/ngx_http_lua_headerfilterby.c
+index ed0c3a6..5f04992 100644
+--- src/ngx_http_lua_headerfilterby.c
++++ src/ngx_http_lua_headerfilterby.c
+@@ -19,6 +19,9 @@
+ #include "ngx_http_lua_string.h"
+ #include "ngx_http_lua_misc.h"
+ #include "ngx_http_lua_consts.h"
++#if (NGX_HTTP_APISIX)
++#include "ngx_http_apisix_module.h"
++#endif
+ 
+ 
+ static ngx_http_output_header_filter_pt ngx_http_next_header_filter;
+@@ -80,6 +83,12 @@ ngx_http_lua_header_filter_by_chunk(lua_State *L, ngx_http_request_t *r)
+ #endif
+     ngx_http_lua_ctx_t          *ctx;
+ 
++#if (NGX_HTTP_APISIX)
++    if (ngx_http_apisix_is_header_filter_by_lua_skipped(r)) {
++        return NGX_OK;
++    }
++#endif
++
+     ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
+     if (ctx->exited) {
+         old_exit_code = ctx->exit_code;

--- a/patch/1.29.2.4/ngx_lua-ssl_session_hostname.patch
+++ b/patch/1.29.2.4/ngx_lua-ssl_session_hostname.patch
@@ -1,0 +1,51 @@
+diff --git src/ngx_http_lua_ssl_certby.c src/ngx_http_lua_ssl_certby.c
+index 72a651bd..7db28e10 100644
+--- src/ngx_http_lua_ssl_certby.c
++++ src/ngx_http_lua_ssl_certby.c
+@@ -870,6 +870,46 @@ ngx_http_lua_ffi_ssl_server_name(ngx_http_request_t *r, char **name,
+ }
+ 
+ 
++int
++ngx_http_lua_ffi_ssl_session_hostname(ngx_http_request_t *r, char **name,
++    size_t *namelen, char **err)
++{
++    ngx_ssl_conn_t          *ssl_conn;
++
++    if (r->connection == NULL || r->connection->ssl == NULL) {
++        *err = "bad request";
++        return NGX_ERROR;
++    }
++
++    ssl_conn = r->connection->ssl->connection;
++    if (ssl_conn == NULL) {
++        *err = "bad ssl conn";
++        return NGX_ERROR;
++    }
++
++#if (defined(TLS1_3_VERSION)                                                   \
++     && !defined(LIBRESSL_VERSION_NUMBER) && !defined(OPENSSL_IS_BORINGSSL))
++
++    /*
++     * SSL_SESSION_get0_hostname() is only available in OpenSSL 1.1.1+,
++     * but servername being negotiated in every TLSv1.3 handshake
++     * is only returned in OpenSSL 1.1.1+ as well
++     */
++
++    *name = (char *) SSL_SESSION_get0_hostname(SSL_get0_session(ssl_conn));
++
++    if (*name) {
++        *namelen = ngx_strlen(*name);
++        return NGX_OK;
++    }
++#endif
++
++    *name = "";
++    *namelen = 0;
++    return NGX_OK;
++}
++
++
+ int
+ ngx_http_lua_ffi_ssl_server_port(ngx_http_request_t *r,
+     unsigned short *server_port, char **err)

--- a/patch/1.29.2.4/ngx_lua-tlshandshake.patch
+++ b/patch/1.29.2.4/ngx_lua-tlshandshake.patch
@@ -1,0 +1,200 @@
+diff --git src/ngx_http_lua_socket_tcp.c src/ngx_http_lua_socket_tcp.c
+index 230679f..106bd76 100644
+--- src/ngx_http_lua_socket_tcp.c
++++ src/ngx_http_lua_socket_tcp.c
+@@ -23,8 +23,8 @@ static int ngx_http_lua_socket_tcp(lua_State *L);
+ static int ngx_http_lua_socket_tcp_bind(lua_State *L);
+ static int ngx_http_lua_socket_tcp_connect(lua_State *L);
+ #if (NGX_HTTP_SSL)
+-static void ngx_http_lua_ssl_handshake_handler(ngx_connection_t *c);
+-static int ngx_http_lua_ssl_handshake_retval_handler(ngx_http_request_t *r,
++static void ngx_http_lua_tls_handshake_handler(ngx_connection_t *c);
++static int ngx_http_lua_tls_handshake_retval_handler(ngx_http_request_t *r,
+     ngx_http_lua_socket_tcp_upstream_t *u, lua_State *L);
+ #endif
+ static int ngx_http_lua_socket_tcp_receive(lua_State *L);
+@@ -1632,7 +1632,7 @@ ngx_http_lua_socket_tcp_check_busy(ngx_http_request_t *r,
+ 
+ 
+ int
+-ngx_http_lua_ffi_socket_tcp_sslhandshake(ngx_http_request_t *r,
++ngx_http_lua_ffi_socket_tcp_tlshandshake(ngx_http_request_t *r,
+     ngx_http_lua_socket_tcp_upstream_t *u, ngx_ssl_session_t *sess,
+     int enable_session_reuse, ngx_str_t *server_name, int verify,
+     int ocsp_status_req, STACK_OF(X509) *chain, EVP_PKEY *pkey,
+@@ -1687,7 +1687,7 @@ ngx_http_lua_ffi_socket_tcp_sslhandshake(ngx_http_request_t *r,
+ 
+         u->ssl_session_reuse = enable_session_reuse;
+ 
+-        (void) ngx_http_lua_ssl_handshake_retval_handler(r, u, NULL);
++        (void) ngx_http_lua_tls_handshake_retval_handler(r, u, NULL);
+ 
+         return NGX_OK;
+     }
+@@ -1713,12 +1713,12 @@ ngx_http_lua_ffi_socket_tcp_sslhandshake(ngx_http_request_t *r,
+ 
+     if (sess != NULL) {
+         if (ngx_ssl_set_session(c, sess) != NGX_OK) {
+-            *errmsg = "ssl set session failed";
++            *errmsg = "tls set session failed";
+             return NGX_ERROR;
+         }
+ 
+         ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
+-                       "lua ssl set session: %p", sess);
++                       "lua tls set session: %p", sess);
+ 
+     } else {
+         u->ssl_session_reuse = enable_session_reuse;
+@@ -1736,13 +1736,13 @@ ngx_http_lua_ffi_socket_tcp_sslhandshake(ngx_http_request_t *r,
+         x509 = sk_X509_value(chain, 0);
+         if (x509 == NULL) {
+             ERR_clear_error();
+-            *errmsg = "ssl fetch client certificate from chain failed";
++            *errmsg = "tls fetch client certificate from chain failed";
+             return NGX_ERROR;
+         }
+ 
+         if (SSL_use_certificate(ssl_conn, x509) == 0) {
+             ERR_clear_error();
+-            *errmsg = "ssl set client certificate failed";
++            *errmsg = "tls set client certificate failed";
+             return NGX_ERROR;
+         }
+ 
+@@ -1752,28 +1752,28 @@ ngx_http_lua_ffi_socket_tcp_sslhandshake(ngx_http_request_t *r,
+             x509 = sk_X509_value(chain, i);
+             if (x509 == NULL) {
+                 ERR_clear_error();
+-                *errmsg = "ssl fetch client intermediate certificate from "
++                *errmsg = "tls fetch client intermediate certificate from "
+                           "chain failed";
+                 return NGX_ERROR;
+             }
+ 
+             if (SSL_add1_chain_cert(ssl_conn, x509) == 0) {
+                 ERR_clear_error();
+-                *errmsg = "ssl set client intermediate certificate failed";
++                *errmsg = "tls set client intermediate certificate failed";
+                 return NGX_ERROR;
+             }
+         }
+ 
+         if (SSL_use_PrivateKey(ssl_conn, pkey) == 0) {
+             ERR_clear_error();
+-            *errmsg = "ssl set client private key failed";
++            *errmsg = "tls set client private key failed";
+             return NGX_ERROR;
+         }
+     }
+ 
+     if (server_name != NULL && server_name->data != NULL) {
+         ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+-                       "lua ssl server name: \"%V\"", server_name);
++                       "lua tls server name: \"%V\"", server_name);
+ 
+ #ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
+         if (SSL_set_tlsext_host_name(c->ssl->connection,
+@@ -1858,13 +1858,13 @@ new_ssl_name:
+         ngx_add_timer(c->read, u->connect_timeout);
+ 
+         u->conn_waiting = 1;
+-        u->write_prepare_retvals = ngx_http_lua_ssl_handshake_retval_handler;
++        u->write_prepare_retvals = ngx_http_lua_tls_handshake_retval_handler;
+ 
+         ngx_http_lua_cleanup_pending_operation(coctx);
+         coctx->cleanup = ngx_http_lua_coctx_cleanup;
+         coctx->data = u;
+ 
+-        c->ssl->handler = ngx_http_lua_ssl_handshake_handler;
++        c->ssl->handler = ngx_http_lua_tls_handshake_handler;
+ 
+         if (ctx->entered_content_phase) {
+             r->write_event_handler = ngx_http_lua_content_wev_handler;
+@@ -1876,7 +1876,7 @@ new_ssl_name:
+         return NGX_AGAIN;
+     }
+ 
+-    ngx_http_lua_ssl_handshake_handler(c);
++    ngx_http_lua_tls_handshake_handler(c);
+ 
+     if (rc == NGX_ERROR) {
+         *errmsg = u->error_ret;
+@@ -1888,7 +1888,7 @@ new_ssl_name:
+ 
+ 
+ static void
+-ngx_http_lua_ssl_handshake_handler(ngx_connection_t *c)
++ngx_http_lua_tls_handshake_handler(ngx_connection_t *c)
+ {
+     int                          waiting;
+     ngx_int_t                    rc;
+@@ -1933,7 +1933,7 @@ ngx_http_lua_ssl_handshake_handler(ngx_connection_t *c)
+ 
+                 llcf = ngx_http_get_module_loc_conf(r, ngx_http_lua_module);
+                 if (llcf->log_socket_errors) {
+-                    ngx_log_error(NGX_LOG_ERR, u->peer.log, 0, "lua ssl "
++                    ngx_log_error(NGX_LOG_ERR, u->peer.log, 0, "lua tls "
+                                   "certificate verify error: (%d: %s)",
+                                   rc, u->error_ret);
+                 }
+@@ -1950,7 +1950,7 @@ ngx_http_lua_ssl_handshake_handler(ngx_connection_t *c)
+ 
+                 llcf = ngx_http_get_module_loc_conf(r, ngx_http_lua_module);
+                 if (llcf->log_socket_errors) {
+-                    ngx_log_error(NGX_LOG_ERR, u->peer.log, 0, "lua ssl "
++                    ngx_log_error(NGX_LOG_ERR, u->peer.log, 0, "lua tls "
+                                   "certificate does not match host \"%V\"",
+                                   &u->ssl_name);
+                 }
+@@ -1965,7 +1965,7 @@ ngx_http_lua_ssl_handshake_handler(ngx_connection_t *c)
+             ngx_http_lua_socket_handle_conn_success(r, u);
+ 
+         } else {
+-            (void) ngx_http_lua_ssl_handshake_retval_handler(r, u, NULL);
++            (void) ngx_http_lua_tls_handshake_retval_handler(r, u, NULL);
+         }
+ 
+         if (waiting) {
+@@ -1994,12 +1994,12 @@ failed:
+ 
+ 
+ int
+-ngx_http_lua_ffi_socket_tcp_get_sslhandshake_result(ngx_http_request_t *r,
++ngx_http_lua_ffi_socket_tcp_get_tlshandshake_result(ngx_http_request_t *r,
+     ngx_http_lua_socket_tcp_upstream_t *u, ngx_ssl_session_t **sess,
+     const char **errmsg, int *openssl_error_code)
+ {
+     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+-                   "lua cosocket get SSL handshake result for upstream: %p", u);
++                   "lua cosocket get TLS handshake result for upstream: %p", u);
+ 
+     if (u->error_ret != NULL) {
+         *errmsg = u->error_ret;
+@@ -2015,7 +2015,7 @@ ngx_http_lua_ffi_socket_tcp_get_sslhandshake_result(ngx_http_request_t *r,
+ 
+ 
+ static int
+-ngx_http_lua_ssl_handshake_retval_handler(ngx_http_request_t *r,
++ngx_http_lua_tls_handshake_retval_handler(ngx_http_request_t *r,
+     ngx_http_lua_socket_tcp_upstream_t *u, lua_State *L)
+ {
+     ngx_connection_t            *c;
+@@ -2035,7 +2035,7 @@ ngx_http_lua_ssl_handshake_retval_handler(ngx_http_request_t *r,
+         u->ssl_session_ret = ssl_session;
+ 
+         ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
+-                       "lua ssl save session: %p", ssl_session);
++                       "lua tls save session: %p", ssl_session);
+     }
+ 
+     return 0;
+@@ -2043,7 +2043,7 @@ ngx_http_lua_ssl_handshake_retval_handler(ngx_http_request_t *r,
+ 
+ 
+ void
+-ngx_http_lua_ffi_ssl_free_session(ngx_ssl_session_t *sess)
++ngx_http_lua_ffi_tls_free_session(ngx_ssl_session_t *sess)
+ {
+     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, ngx_cycle->log, 0,
+                    "lua ssl free session: %p", sess);

--- a/patch/1.29.2.4/ngx_stream_lua-expose_request_struct.patch
+++ b/patch/1.29.2.4/ngx_stream_lua-expose_request_struct.patch
@@ -1,0 +1,15 @@
+diff --git src/api/ngx_stream_lua_api.h src/api/ngx_stream_lua_api.h
+index ba1fbd5..fce57e0 100644
+--- src/api/ngx_stream_lua_api.h
++++ src/api/ngx_stream_lua_api.h
+@@ -20,6 +20,10 @@
+ #include <ngx_core.h>
+ 
+ 
++#if (NGX_STREAM_APISIX)
++#include <ngx_stream.h>
++#include "../ngx_stream_lua_request.h"
++#endif
+ 
+ 
+ #include <lua.h>

--- a/patch/1.29.2.4/ngx_stream_lua-reject-in-handshake.patch
+++ b/patch/1.29.2.4/ngx_stream_lua-reject-in-handshake.patch
@@ -1,0 +1,40 @@
+diff --git src/ngx_stream_lua_ssl_certby.c src/ngx_stream_lua_ssl_certby.c
+index a34e187..e4cdb1a 100644
+--- src/ngx_stream_lua_ssl_certby.c
++++ src/ngx_stream_lua_ssl_certby.c
+@@ -1470,9 +1470,16 @@ ngx_stream_lua_ssl_verify_callback(int ok, X509_STORE_CTX *x509_store)
+ #endif
+ 
+ 
++static int
++ngx_stream_lua_ssl_verify_reject_in_handshake_callback(int ok, X509_STORE_CTX *x509_store)
++{
++    return ok;
++}
++
++
+ int
+ ngx_stream_lua_ffi_ssl_verify_client(ngx_stream_lua_request_t *r,
+-    void *client_cert, void *trusted_certs, int depth, char **err)
++    void *client_cert, void *trusted_certs, int depth, int reject_in_handshake, char **err)
+ {
+ #ifdef LIBRESSL_VERSION_NUMBER
+ 
+@@ -1421,8 +1428,15 @@ ngx_stream_lua_ffi_ssl_verify_client(ngx_stream_lua_request_t *r,
+ 
+     /* enable verify */
+ 
+-    SSL_set_verify(ssl_conn, SSL_VERIFY_PEER,
+-                   ngx_stream_lua_ssl_verify_callback);
++    if (reject_in_handshake) {
++        SSL_set_verify(ssl_conn,
++                       SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT ,
++                       ngx_stream_lua_ssl_verify_reject_in_handshake_callback);
++
++    } else {
++        SSL_set_verify(ssl_conn, SSL_VERIFY_PEER,
++                       ngx_stream_lua_ssl_verify_callback);
++    }
+ 
+     /* set depth */
+ 

--- a/patch/1.29.2.4/ngx_stream_lua-shared_shdict.patch
+++ b/patch/1.29.2.4/ngx_stream_lua-shared_shdict.patch
@@ -1,0 +1,780 @@
+diff --git config config
+index 8db9062..c7b7f35 100644
+--- config
++++ config
+@@ -260,7 +260,6 @@ STREAM_LUA_SRCS=" \
+                 $ngx_addon_dir/src/ngx_stream_lua_ctx.c \
+                 $ngx_addon_dir/src/ngx_stream_lua_regex.c \
+                 $ngx_addon_dir/src/ngx_stream_lua_script.c \
+-                $ngx_addon_dir/src/ngx_stream_lua_shdict.c \
+                 $ngx_addon_dir/src/ngx_stream_lua_variable.c \
+                 $ngx_addon_dir/src/ngx_stream_lua_timer.c \
+                 $ngx_addon_dir/src/ngx_stream_lua_config.c \
+@@ -305,7 +304,6 @@ STREAM_LUA_DEPS=" \
+                 $ngx_addon_dir/src/ngx_stream_lua_phase.h \
+                 $ngx_addon_dir/src/ngx_stream_lua_ctx.h \
+                 $ngx_addon_dir/src/ngx_stream_lua_script.h \
+-                $ngx_addon_dir/src/ngx_stream_lua_shdict.h \
+                 $ngx_addon_dir/src/ngx_stream_lua_timer.h \
+                 $ngx_addon_dir/src/ngx_stream_lua_config.h \
+                 $ngx_addon_dir/src/api/ngx_stream_lua_api.h \
+diff --git src/api/ngx_stream_lua_api.h src/api/ngx_stream_lua_api.h
+index ba1fbd5..bb8ca8e 100644
+--- src/api/ngx_stream_lua_api.h
++++ src/api/ngx_stream_lua_api.h
+@@ -57,15 +57,6 @@ lua_State *ngx_stream_lua_get_global_state(ngx_conf_t *cf);
+ ngx_int_t ngx_stream_lua_add_package_preload(ngx_conf_t *cf,
+     const char *package, lua_CFunction func);
+ 
+-ngx_int_t ngx_stream_lua_shared_dict_get(ngx_shm_zone_t *shm_zone,
+-    u_char *key_data, size_t key_len, ngx_stream_lua_value_t *value);
+-
+-ngx_shm_zone_t *ngx_stream_lua_find_zone(u_char *name_data,
+-    size_t name_len);
+-
+-ngx_shm_zone_t *ngx_stream_lua_shared_memory_add(ngx_conf_t *cf,
+-    ngx_str_t *name, size_t size, void *tag);
+-
+ 
+ #endif /* _NGX_STREAM_LUA_API_H_INCLUDED_ */
+ 
+diff --git src/ngx_stream_lua_api.c src/ngx_stream_lua_api.c
+index cf01b36..fcc685c 100644
+--- src/ngx_stream_lua_api.c
++++ src/ngx_stream_lua_api.c
+@@ -28,7 +28,6 @@
+ 
+ #include "ngx_stream_lua_common.h"
+ #include "api/ngx_stream_lua_api.h"
+-#include "ngx_stream_lua_shdict.h"
+ #include "ngx_stream_lua_util.h"
+ 
+ 
+@@ -43,10 +42,6 @@ ngx_stream_lua_get_global_state(ngx_conf_t *cf)
+ }
+ 
+ 
+-static ngx_int_t ngx_stream_lua_shared_memory_init(ngx_shm_zone_t *shm_zone,
+-    void *data);
+-
+-
+ ngx_int_t
+ ngx_stream_lua_add_package_preload(ngx_conf_t *cf, const char *package,
+     lua_CFunction func)
+@@ -93,138 +88,6 @@ ngx_stream_lua_add_package_preload(ngx_conf_t *cf, const char *package,
+     return NGX_OK;
+ }
+ 
+-
+-ngx_shm_zone_t *
+-ngx_stream_lua_shared_memory_add(ngx_conf_t *cf, ngx_str_t *name,
+-    size_t size, void *tag)
+-{
+-    ngx_stream_lua_main_conf_t           *lmcf;
+-    ngx_stream_lua_shm_zone_ctx_t        *ctx;
+-
+-    ngx_shm_zone_t              **zp;
+-    ngx_shm_zone_t               *zone;
+-    ngx_int_t                     n;
+-
+-    lmcf = ngx_stream_conf_get_module_main_conf(cf, ngx_stream_lua_module);
+-    if (lmcf == NULL) {
+-        return NULL;
+-    }
+-
+-    if (lmcf->shm_zones == NULL) {
+-        lmcf->shm_zones = ngx_palloc(cf->pool, sizeof(ngx_array_t));
+-        if (lmcf->shm_zones == NULL) {
+-            return NULL;
+-        }
+-
+-        if (ngx_array_init(lmcf->shm_zones, cf->pool, 2,
+-                           sizeof(ngx_shm_zone_t *))
+-            != NGX_OK)
+-        {
+-            return NULL;
+-        }
+-    }
+-
+-    zone = ngx_shared_memory_add(cf, name, (size_t) size, tag);
+-    if (zone == NULL) {
+-        return NULL;
+-    }
+-
+-    if (zone->data) {
+-        ctx = (ngx_stream_lua_shm_zone_ctx_t *) zone->data;
+-        return &ctx->zone;
+-    }
+-
+-    n = sizeof(ngx_stream_lua_shm_zone_ctx_t);
+-
+-    ctx = ngx_pcalloc(cf->pool, n);
+-    if (ctx == NULL) {
+-        return NULL;
+-    }
+-
+-    ctx->lmcf = lmcf;
+-    ctx->log = &cf->cycle->new_log;
+-    ctx->cycle = cf->cycle;
+-
+-    ngx_memcpy(&ctx->zone, zone, sizeof(ngx_shm_zone_t));
+-
+-    zp = ngx_array_push(lmcf->shm_zones);
+-    if (zp == NULL) {
+-        return NULL;
+-    }
+-
+-    *zp = zone;
+-
+-    /* set zone init */
+-    zone->init = ngx_stream_lua_shared_memory_init;
+-    zone->data = ctx;
+-
+-    lmcf->requires_shm = 1;
+-
+-    return &ctx->zone;
+-}
+-
+-
+-static ngx_int_t
+-ngx_stream_lua_shared_memory_init(ngx_shm_zone_t *shm_zone, void *data)
+-{
+-    ngx_stream_lua_shm_zone_ctx_t       *octx = data;
+-    ngx_stream_lua_main_conf_t          *lmcf;
+-    ngx_stream_lua_shm_zone_ctx_t       *ctx;
+-
+-    ngx_shm_zone_t              *ozone;
+-    void                        *odata;
+-    ngx_int_t                    rc;
+-    volatile ngx_cycle_t        *saved_cycle;
+-    ngx_shm_zone_t              *zone;
+-
+-    ctx = (ngx_stream_lua_shm_zone_ctx_t *) shm_zone->data;
+-    zone = &ctx->zone;
+-
+-    odata = NULL;
+-    if (octx) {
+-        ozone = &octx->zone;
+-        odata = ozone->data;
+-    }
+-
+-    zone->shm = shm_zone->shm;
+-#if defined(nginx_version) && nginx_version >= 1009000
+-    zone->noreuse = shm_zone->noreuse;
+-#endif
+-
+-    if (zone->init(zone, odata) != NGX_OK) {
+-        return NGX_ERROR;
+-    }
+-
+-    dd("get lmcf");
+-
+-    lmcf = ctx->lmcf;
+-    if (lmcf == NULL) {
+-        return NGX_ERROR;
+-    }
+-
+-    dd("lmcf->lua: %p", lmcf->lua);
+-
+-    lmcf->shm_zones_inited++;
+-
+-    if (lmcf->shm_zones_inited == lmcf->shm_zones->nelts
+-        && lmcf->init_handler && !ngx_test_config)
+-    {
+-        saved_cycle = ngx_cycle;
+-        ngx_cycle = ctx->cycle;
+-
+-        rc = lmcf->init_handler(ctx->log, lmcf, lmcf->lua);
+-
+-        ngx_cycle = saved_cycle;
+-
+-        if (rc != NGX_OK) {
+-            /* an error happened */
+-            return NGX_ERROR;
+-        }
+-    }
+-
+-    return NGX_OK;
+-}
+-
+ 
+ #if (NGX_LINUX)
+ int
+diff --git src/ngx_stream_lua_common.h src/ngx_stream_lua_common.h
+index f76229e..ec65afb 100644
+--- src/ngx_stream_lua_common.h
++++ src/ngx_stream_lua_common.h
+@@ -31,6 +31,8 @@
+ #include <lualib.h>
+ #include <lauxlib.h>
+ 
++#include "ngx_meta_lua_api.h"
++
+ 
+ #include "ngx_stream_lua_request.h"
+ 
+@@ -56,6 +58,11 @@
+ #endif
+ 
+ 
++#if !defined(ngx_meta_lua_version) || ngx_meta_lua_version < 00001
++#   error ngx_meta_lua_module 0.0.1 or above is required
++#endif
++
++
+ 
+ 
+ #if LUA_VERSION_NUM != 501
+@@ -162,8 +169,6 @@ typedef struct ngx_stream_lua_balancer_peer_data_s
+ typedef struct ngx_stream_lua_sema_mm_s  ngx_stream_lua_sema_mm_t;
+ 
+ 
+-typedef ngx_int_t (*ngx_stream_lua_main_conf_handler_pt)(ngx_log_t *log,
+-    ngx_stream_lua_main_conf_t *lmcf, lua_State *L);
+ typedef ngx_int_t (*ngx_stream_lua_srv_conf_handler_pt)(
+     ngx_stream_lua_request_t *r, ngx_stream_lua_srv_conf_t *lscf, lua_State *L);
+ 
+@@ -214,10 +219,10 @@ struct ngx_stream_lua_main_conf_s {
+ 
+     ngx_flag_t           postponed_to_preread_phase_end;
+ 
+-    ngx_stream_lua_main_conf_handler_pt          init_handler;
++    ngx_meta_lua_main_conf_handler_pt          init_handler;
+     ngx_str_t                                    init_src;
+ 
+-    ngx_stream_lua_main_conf_handler_pt          init_worker_handler;
++    ngx_meta_lua_main_conf_handler_pt          init_worker_handler;
+     ngx_str_t                                    init_worker_src;
+ 
+     ngx_stream_lua_balancer_peer_data_t          *balancer_peer_data;
+@@ -227,8 +232,6 @@ struct ngx_stream_lua_main_conf_s {
+                      * data pointer in the main conf.
+                      */
+ 
+-    ngx_uint_t                      shm_zones_inited;
+-
+     ngx_stream_lua_sema_mm_t               *sema_mm;
+ 
+     ngx_uint_t           malloc_trim_cycle;  /* a cycle is defined as the number
+@@ -241,7 +244,6 @@ struct ngx_stream_lua_main_conf_s {
+     unsigned             requires_preread:1;
+ 
+     unsigned             requires_log:1;
+-    unsigned             requires_shm:1;
+     unsigned             requires_capture_log:1;
+ };
+ 
+diff --git src/ngx_stream_lua_directive.c src/ngx_stream_lua_directive.c
+index 5580106..04fed32 100644
+--- src/ngx_stream_lua_directive.c
++++ src/ngx_stream_lua_directive.c
+@@ -27,7 +27,6 @@
+ #include "ngx_stream_lua_logby.h"
+ #include "ngx_stream_lua_initby.h"
+ #include "ngx_stream_lua_initworkerby.h"
+-#include "ngx_stream_lua_shdict.h"
+ #include "ngx_stream_lua_lex.h"
+ #include "ngx_stream_lua_log.h"
+ #include "ngx_stream_lua_log_ringbuf.h"
+@@ -69,90 +68,6 @@ enum {
+ };
+ 
+ 
+-char *
+-ngx_stream_lua_shared_dict(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+-{
+-    ngx_stream_lua_main_conf_t         *lmcf = conf;
+-    ngx_str_t                          *value, name;
+-    ngx_shm_zone_t                     *zone;
+-    ngx_shm_zone_t                    **zp;
+-    ngx_stream_lua_shdict_ctx_t        *ctx;
+-    ssize_t                             size;
+-
+-    if (lmcf->shdict_zones == NULL) {
+-        lmcf->shdict_zones = ngx_palloc(cf->pool, sizeof(ngx_array_t));
+-        if (lmcf->shdict_zones == NULL) {
+-            return NGX_CONF_ERROR;
+-        }
+-
+-        if (ngx_array_init(lmcf->shdict_zones, cf->pool, 2,
+-                           sizeof(ngx_shm_zone_t *))
+-            != NGX_OK)
+-        {
+-            return NGX_CONF_ERROR;
+-        }
+-    }
+-
+-    value = cf->args->elts;
+-
+-    ctx = NULL;
+-
+-    if (value[1].len == 0) {
+-        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+-                           "invalid lua shared dict name \"%V\"", &value[1]);
+-        return NGX_CONF_ERROR;
+-    }
+-
+-    name = value[1];
+-
+-    size = ngx_parse_size(&value[2]);
+-
+-    if (size <= 8191) {
+-        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+-                           "invalid lua shared dict size \"%V\"", &value[2]);
+-        return NGX_CONF_ERROR;
+-    }
+-
+-    ctx = ngx_pcalloc(cf->pool, sizeof(ngx_stream_lua_shdict_ctx_t));
+-    if (ctx == NULL) {
+-        return NGX_CONF_ERROR;
+-    }
+-
+-    ctx->name = name;
+-    ctx->main_conf = lmcf;
+-    ctx->log = &cf->cycle->new_log;
+-
+-    zone = ngx_stream_lua_shared_memory_add(cf, &name, (size_t) size,
+-                                            &ngx_stream_lua_module);
+-    if (zone == NULL) {
+-        return NGX_CONF_ERROR;
+-    }
+-
+-    if (zone->data) {
+-        ctx = zone->data;
+-
+-        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+-                           "lua_shared_dict \"%V\" is already defined as "
+-                           "\"%V\"", &name, &ctx->name);
+-        return NGX_CONF_ERROR;
+-    }
+-
+-    zone->init = ngx_stream_lua_shdict_init_zone;
+-    zone->data = ctx;
+-
+-    zp = ngx_array_push(lmcf->shdict_zones);
+-    if (zp == NULL) {
+-        return NGX_CONF_ERROR;
+-    }
+-
+-    *zp = zone;
+-
+-    lmcf->requires_shm = 1;
+-
+-    return NGX_CONF_OK;
+-}
+-
+-
+ char *
+ ngx_stream_lua_code_cache(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+ {
+@@ -190,6 +105,15 @@ ngx_stream_lua_load_resty_core(ngx_conf_t *cf, ngx_command_t *cmd,
+ }
+ 
+ 
++char *
++ngx_stream_lua_shdict_directive(ngx_conf_t *cf, ngx_command_t *cmd,
++    void *conf)
++{
++    return ngx_meta_lua_shdict_directive_helper(cf,
++                                                &ngx_stream_lua_module);
++}
++
++
+ char *
+ ngx_stream_lua_package_cpath(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+ {
+@@ -646,7 +570,7 @@ ngx_stream_lua_init_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
+         return NGX_CONF_ERROR;
+     }
+ 
+-    lmcf->init_handler = (ngx_stream_lua_main_conf_handler_pt) cmd->post;
++    lmcf->init_handler = (ngx_meta_lua_main_conf_handler_pt) cmd->post;
+ 
+     if (cmd->post == ngx_stream_lua_init_by_file) {
+         name = ngx_stream_lua_rebase_path(cf->pool, value[1].data,
+@@ -707,7 +631,7 @@ ngx_stream_lua_init_worker_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
+ 
+     value = cf->args->elts;
+ 
+-    lmcf->init_worker_handler = (ngx_stream_lua_main_conf_handler_pt) cmd->post;
++    lmcf->init_worker_handler = (ngx_meta_lua_main_conf_handler_pt) cmd->post;
+ 
+     if (cmd->post == ngx_stream_lua_init_worker_by_file) {
+         name = ngx_stream_lua_rebase_path(cf->pool, value[1].data,
+diff --git src/ngx_stream_lua_directive.h src/ngx_stream_lua_directive.h
+index 6b36bb1..fa469b6 100644
+--- src/ngx_stream_lua_directive.h
++++ src/ngx_stream_lua_directive.h
+@@ -20,7 +20,7 @@
+ #include "ngx_stream_lua_common.h"
+ 
+ 
+-char *ngx_stream_lua_shared_dict(ngx_conf_t *cf, ngx_command_t *cmd,
++char *ngx_stream_lua_shdict_directive(ngx_conf_t *cf, ngx_command_t *cmd,
+     void *conf);
+ char *ngx_stream_lua_package_cpath(ngx_conf_t *cf, ngx_command_t *cmd,
+     void *conf);
+diff --git src/ngx_stream_lua_initby.c src/ngx_stream_lua_initby.c
+index c6bbf0d..98e3c6f 100644
+--- src/ngx_stream_lua_initby.c
++++ src/ngx_stream_lua_initby.c
+@@ -22,13 +22,13 @@
+ 
+ 
+ ngx_int_t
+-ngx_stream_lua_init_by_inline(ngx_log_t *log, ngx_stream_lua_main_conf_t *lmcf,
++ngx_stream_lua_init_by_inline(ngx_log_t *log, ngx_str_t init_src,
+     lua_State *L)
+ {
+     int         status;
+ 
+-    status = luaL_loadbuffer(L, (char *) lmcf->init_src.data,
+-                             lmcf->init_src.len, "=init_by_lua")
++    status = luaL_loadbuffer(L, (char *) init_src.data, init_src.len,
++                             "=init_by_lua")
+              || ngx_stream_lua_do_call(log, L);
+ 
+     return ngx_stream_lua_report(log, L, status, "init_by_lua");
+@@ -36,12 +36,12 @@ ngx_stream_lua_init_by_inline(ngx_log_t *log, ngx_stream_lua_main_conf_t *lmcf,
+ 
+ 
+ ngx_int_t
+-ngx_stream_lua_init_by_file(ngx_log_t *log, ngx_stream_lua_main_conf_t *lmcf,
++ngx_stream_lua_init_by_file(ngx_log_t *log, ngx_str_t init_src,
+     lua_State *L)
+ {
+     int         status;
+ 
+-    status = luaL_loadfile(L, (char *) lmcf->init_src.data)
++    status = luaL_loadfile(L, (char *) init_src.data)
+              || ngx_stream_lua_do_call(log, L);
+ 
+     return ngx_stream_lua_report(log, L, status, "init_by_lua_file");
+diff --git src/ngx_stream_lua_initby.h src/ngx_stream_lua_initby.h
+index f2e2c40..060ee41 100644
+--- src/ngx_stream_lua_initby.h
++++ src/ngx_stream_lua_initby.h
+@@ -20,10 +20,10 @@
+ 
+ 
+ ngx_int_t ngx_stream_lua_init_by_inline(ngx_log_t *log,
+-    ngx_stream_lua_main_conf_t *lmcf, lua_State *L);
++    ngx_str_t init_src, lua_State *L);
+ 
+ ngx_int_t ngx_stream_lua_init_by_file(ngx_log_t *log,
+-    ngx_stream_lua_main_conf_t *lmcf, lua_State *L);
++    ngx_str_t init_src, lua_State *L);
+ 
+ 
+ #endif /* _NGX_STREAM_LUA_INITBY_H_INCLUDED_ */
+diff --git src/ngx_stream_lua_initworkerby.c src/ngx_stream_lua_initworkerby.c
+index 786ba34..b50e2fe 100644
+--- src/ngx_stream_lua_initworkerby.c
++++ src/ngx_stream_lua_initworkerby.c
+@@ -305,7 +305,8 @@ ngx_stream_lua_init_worker(ngx_cycle_t *cycle)
+ 
+     ngx_stream_lua_set_req(lmcf->lua, r);
+ 
+-    (void) lmcf->init_worker_handler(cycle->log, lmcf, lmcf->lua);
++    (void) lmcf->init_worker_handler(cycle->log, lmcf->init_worker_src,
++                                     lmcf->lua);
+ 
+     ngx_destroy_pool(c->pool);
+     return NGX_OK;
+@@ -326,12 +327,12 @@ failed:
+ 
+ ngx_int_t
+ ngx_stream_lua_init_worker_by_inline(ngx_log_t *log,
+-    ngx_stream_lua_main_conf_t *lmcf, lua_State *L)
++    ngx_str_t init_worker_src, lua_State *L)
+ {
+     int         status;
+ 
+-    status = luaL_loadbuffer(L, (char *) lmcf->init_worker_src.data,
+-                             lmcf->init_worker_src.len, "=init_worker_by_lua")
++    status = luaL_loadbuffer(L, (char *) init_worker_src.data,
++                             init_worker_src.len, "=init_worker_by_lua")
+              || ngx_stream_lua_do_call(log, L);
+ 
+     return ngx_stream_lua_report(log, L, status, "init_worker_by_lua");
+@@ -340,11 +341,11 @@ ngx_stream_lua_init_worker_by_inline(ngx_log_t *log,
+ 
+ ngx_int_t
+ ngx_stream_lua_init_worker_by_file(ngx_log_t *log,
+-    ngx_stream_lua_main_conf_t *lmcf, lua_State *L)
++    ngx_str_t init_worker_src, lua_State *L)
+ {
+     int         status;
+ 
+-    status = luaL_loadfile(L, (char *) lmcf->init_worker_src.data)
++    status = luaL_loadfile(L, (char *) init_worker_src.data)
+              || ngx_stream_lua_do_call(log, L);
+ 
+     return ngx_stream_lua_report(log, L, status, "init_worker_by_lua_file");
+diff --git src/ngx_stream_lua_initworkerby.h src/ngx_stream_lua_initworkerby.h
+index 43f6de3..53a443a 100644
+--- src/ngx_stream_lua_initworkerby.h
++++ src/ngx_stream_lua_initworkerby.h
+@@ -20,10 +20,10 @@
+ 
+ 
+ ngx_int_t ngx_stream_lua_init_worker_by_inline(ngx_log_t *log,
+-    ngx_stream_lua_main_conf_t *lmcf, lua_State *L);
++    ngx_str_t init_worker_src, lua_State *L);
+ 
+ ngx_int_t ngx_stream_lua_init_worker_by_file(ngx_log_t *log,
+-    ngx_stream_lua_main_conf_t *lmcf, lua_State *L);
++    ngx_str_t init_worker_src, lua_State *L);
+ 
+ ngx_int_t ngx_stream_lua_init_worker(ngx_cycle_t *cycle);
+ 
+diff --git src/ngx_stream_lua_module.c src/ngx_stream_lua_module.c
+index f7dca96..60a0b9e 100644
+--- src/ngx_stream_lua_module.c
++++ src/ngx_stream_lua_module.c
+@@ -19,6 +19,7 @@
+ #include "ddebug.h"
+ 
+ 
++#include "ngx_meta_lua_api.h"
+ #include "ngx_stream_lua_directive.h"
+ #include "ngx_stream_lua_contentby.h"
+ #include "ngx_stream_lua_util.h"
+@@ -116,7 +117,7 @@ static ngx_command_t ngx_stream_lua_cmds[] = {
+ 
+     { ngx_string("lua_shared_dict"),
+       NGX_STREAM_MAIN_CONF|NGX_CONF_TAKE2,
+-      ngx_stream_lua_shared_dict,
++      ngx_stream_lua_shdict_directive,
+       0,
+       0,
+       NULL },
+@@ -514,7 +515,6 @@ static ngx_int_t
+ ngx_stream_lua_init(ngx_conf_t *cf)
+ {
+     ngx_int_t                           rc;
+-    volatile ngx_cycle_t               *saved_cycle;
+     ngx_array_t                        *arr;
+     ngx_pool_cleanup_t                 *cln;
+ 
+@@ -644,18 +644,11 @@ ngx_stream_lua_init(ngx_conf_t *cf)
+ 
+         ngx_stream_lua_assert(lmcf->lua != NULL);
+ 
+-        if (!lmcf->requires_shm && lmcf->init_handler) {
+-            saved_cycle = ngx_cycle;
+-            ngx_cycle = cf->cycle;
+-
+-            rc = lmcf->init_handler(cf->log, lmcf, lmcf->lua);
+-
+-            ngx_cycle = saved_cycle;
+-
+-            if (rc != NGX_OK) {
+-                /* an error happened */
+-                return NGX_ERROR;
+-            }
++        if (ngx_meta_lua_post_init_handler(cf, lmcf->init_handler,
++                                           lmcf->init_src, lmcf->lua)
++            != NGX_OK)
++        {
++            return NGX_ERROR;
+         }
+ 
+         dd("Lua VM initialized!");
+diff --git src/ngx_stream_lua_shdict.h src/ngx_stream_lua_shdict.h
+deleted file mode 100644
+index 3554764..0000000
+--- src/ngx_stream_lua_shdict.h
++++ /dev/null
+@@ -1,121 +0,0 @@
+-
+-/*
+- * !!! DO NOT EDIT DIRECTLY !!!
+- * This file was automatically generated from the following template:
+- *
+- * src/subsys/ngx_subsys_lua_shdict.h.tt2
+- */
+-
+-
+-/*
+- * Copyright (C) Yichun Zhang (agentzh)
+- */
+-
+-
+-#ifndef _NGX_STREAM_LUA_SHDICT_H_INCLUDED_
+-#define _NGX_STREAM_LUA_SHDICT_H_INCLUDED_
+-
+-
+-#include "ngx_stream_lua_common.h"
+-
+-
+-typedef struct {
+-    u_char                       color;
+-    uint8_t                      value_type;
+-    u_short                      key_len;
+-    uint32_t                     value_len;
+-    uint64_t                     expires;
+-    ngx_queue_t                  queue;
+-    uint32_t                     user_flags;
+-    u_char                       data[1];
+-} ngx_stream_lua_shdict_node_t;
+-
+-
+-typedef struct {
+-    ngx_queue_t                  queue;
+-    uint32_t                     value_len;
+-    uint8_t                      value_type;
+-    u_char                       data[1];
+-} ngx_stream_lua_shdict_list_node_t;
+-
+-
+-typedef struct {
+-    ngx_rbtree_t                  rbtree;
+-    ngx_rbtree_node_t             sentinel;
+-    ngx_queue_t                   lru_queue;
+-} ngx_stream_lua_shdict_shctx_t;
+-
+-
+-typedef struct {
+-    ngx_stream_lua_shdict_shctx_t       *sh;
+-    ngx_slab_pool_t                     *shpool;
+-    ngx_str_t                            name;
+-    ngx_stream_lua_main_conf_t          *main_conf;
+-    ngx_log_t                           *log;
+-} ngx_stream_lua_shdict_ctx_t;
+-
+-
+-typedef struct {
+-    ngx_log_t                           *log;
+-    ngx_stream_lua_main_conf_t          *lmcf;
+-    ngx_cycle_t                         *cycle;
+-    ngx_shm_zone_t                       zone;
+-} ngx_stream_lua_shm_zone_ctx_t;
+-
+-
+-#if (NGX_DARWIN)
+-typedef struct {
+-    void                  *zone;
+-    const unsigned char   *key;
+-    size_t                 key_len;
+-    int                   *value_type;
+-    unsigned char        **str_value_buf;
+-    size_t                *str_value_len;
+-    double                *num_value;
+-    int                   *user_flags;
+-    int                    get_stale;
+-    int                   *is_stale;
+-    char                 **errmsg;
+-} ngx_stream_lua_shdict_get_params_t;
+-
+-
+-typedef struct {
+-    void                  *zone;
+-    int                    op;
+-    const unsigned char   *key;
+-    size_t                 key_len;
+-    int                    value_type;
+-    const unsigned char   *str_value_buf;
+-    size_t                 str_value_len;
+-    double                 num_value;
+-    long                   exptime;
+-    int                    user_flags;
+-    char                 **errmsg;
+-    int                   *forcible;
+-} ngx_stream_lua_shdict_store_params_t;
+-
+-
+-typedef struct {
+-    void                  *zone;
+-    const unsigned char   *key;
+-    size_t                 key_len;
+-    double                *num_value;
+-    char                 **errmsg;
+-    int                    has_init;
+-    double                 init;
+-    long                   init_ttl;
+-    int                   *forcible;
+-} ngx_stream_lua_shdict_incr_params_t;
+-#endif
+-
+-
+-ngx_int_t ngx_stream_lua_shdict_init_zone(ngx_shm_zone_t *shm_zone, void *data);
+-void ngx_stream_lua_shdict_rbtree_insert_value(ngx_rbtree_node_t *temp,
+-    ngx_rbtree_node_t *node, ngx_rbtree_node_t *sentinel);
+-void ngx_stream_lua_inject_shdict_api(ngx_stream_lua_main_conf_t *lmcf,
+-    lua_State *L);
+-
+-
+-#endif /* _NGX_STREAM_LUA_SHDICT_H_INCLUDED_ */
+-
+-/* vi:set ft=c ts=4 sw=4 et fdm=marker: */
+diff --git src/ngx_stream_lua_util.c src/ngx_stream_lua_util.c
+index e79f18e..8a24031 100644
+--- src/ngx_stream_lua_util.c
++++ src/ngx_stream_lua_util.c
+@@ -20,6 +20,7 @@
+ 
+ 
+ #include "nginx.h"
++#include "ngx_meta_lua_api.h"
+ #include "ngx_stream_lua_directive.h"
+ #include "ngx_stream_lua_util.h"
+ #include "ngx_stream_lua_exception.h"
+@@ -31,7 +32,6 @@
+ #include "ngx_stream_lua_string.h"
+ #include "ngx_stream_lua_misc.h"
+ #include "ngx_stream_lua_consts.h"
+-#include "ngx_stream_lua_shdict.h"
+ #include "ngx_stream_lua_coroutine.h"
+ #include "ngx_stream_lua_socket_tcp.h"
+ #include "ngx_stream_lua_socket_udp.h"
+@@ -102,7 +102,7 @@ static ngx_int_t ngx_stream_lua_handle_exit(lua_State *L,
+ static int ngx_stream_lua_thread_traceback(lua_State *L, lua_State *co,
+     ngx_stream_lua_co_ctx_t *coctx);
+ static void ngx_stream_lua_inject_ngx_api(lua_State *L,
+-    ngx_stream_lua_main_conf_t *lmcf, ngx_log_t *log);
++    ngx_cycle_t *cycle, ngx_stream_lua_main_conf_t *lmcf, ngx_log_t *log);
+ static ngx_int_t ngx_stream_lua_output_filter(ngx_stream_lua_request_t *r,
+     ngx_chain_t *in);
+ static void ngx_stream_lua_finalize_threads(ngx_stream_lua_request_t *r,
+@@ -501,13 +501,13 @@ ngx_stream_lua_init_globals(lua_State *L, ngx_cycle_t *cycle,
+                    "lua initializing lua globals");
+ 
+ 
+-    ngx_stream_lua_inject_ngx_api(L, lmcf, log);
++    ngx_stream_lua_inject_ngx_api(L, cycle, lmcf, log);
+ }
+ 
+ 
+ static void
+-ngx_stream_lua_inject_ngx_api(lua_State *L, ngx_stream_lua_main_conf_t *lmcf,
+-    ngx_log_t *log)
++ngx_stream_lua_inject_ngx_api(lua_State *L, ngx_cycle_t *cycle,
++    ngx_stream_lua_main_conf_t *lmcf, ngx_log_t *log)
+ {
+     lua_createtable(L, 0 /* narr */, 113 /* nrec */);    /* ngx.* */
+ 
+@@ -529,7 +529,7 @@ ngx_stream_lua_inject_ngx_api(lua_State *L, ngx_stream_lua_main_conf_t *lmcf,
+     ngx_stream_lua_inject_req_api(log, L);
+ 
+ 
+-    ngx_stream_lua_inject_shdict_api(lmcf, L);
++    ngx_meta_lua_inject_shdict_api(L, cycle, &ngx_stream_lua_module);
+     ngx_stream_lua_inject_socket_tcp_api(log, L);
+     ngx_stream_lua_inject_socket_udp_api(log, L);
+     ngx_stream_lua_inject_uthread_api(log, L);
+diff --git src/ngx_stream_lua_util.h src/ngx_stream_lua_util.h
+index 3ea872d..fac430a 100644
+--- src/ngx_stream_lua_util.h
++++ src/ngx_stream_lua_util.h
+@@ -363,7 +363,9 @@ ngx_stream_lua_create_ctx(ngx_stream_session_t *r)
+         ngx_stream_lua_assert(L != NULL);
+ 
+         if (lmcf->init_handler) {
+-            if (lmcf->init_handler(r->connection->log, lmcf, L) != NGX_OK) {
++            if (lmcf->init_handler(r->connection->log, lmcf->init_src, L)
++                != NGX_OK)
++            {
+                 /* an error happened */
+                 return NULL;
+             }

--- a/patch/1.29.2.4/ngx_stream_lua-ssl_session_hostname.patch
+++ b/patch/1.29.2.4/ngx_stream_lua-ssl_session_hostname.patch
@@ -1,0 +1,51 @@
+diff --git src/ngx_stream_lua_ssl_certby.c src/ngx_stream_lua_ssl_certby.c
+index a34e187..0f65d82 100644
+--- src/ngx_stream_lua_ssl_certby.c
++++ src/ngx_stream_lua_ssl_certby.c
+@@ -884,6 +884,46 @@ ngx_stream_lua_ffi_ssl_server_name(ngx_stream_lua_request_t *r, char **name,
+ }
+ 
+ 
++int
++ngx_stream_lua_ffi_ssl_session_hostname(ngx_stream_lua_request_t *r, char **name,
++    size_t *namelen, char **err)
++{
++    ngx_ssl_conn_t          *ssl_conn;
++
++    if (r->connection == NULL || r->connection->ssl == NULL) {
++        *err = "bad request";
++        return NGX_ERROR;
++    }
++
++    ssl_conn = r->connection->ssl->connection;
++    if (ssl_conn == NULL) {
++        *err = "bad ssl conn";
++        return NGX_ERROR;
++    }
++
++#if (defined(TLS1_3_VERSION)                                                   \
++     && !defined(LIBRESSL_VERSION_NUMBER) && !defined(OPENSSL_IS_BORINGSSL))
++
++    /*
++     * SSL_SESSION_get0_hostname() is only available in OpenSSL 1.1.1+,
++     * but servername being negotiated in every TLSv1.3 handshake
++     * is only returned in OpenSSL 1.1.1+ as well
++     */
++
++    *name = (char *) SSL_SESSION_get0_hostname(SSL_get0_session(ssl_conn));
++
++    if (*name) {
++        *namelen = ngx_strlen(*name);
++        return NGX_OK;
++    }
++#endif
++
++    *name = "";
++    *namelen = 0;
++    return NGX_OK;
++}
++
++
+ int
+ ngx_stream_lua_ffi_ssl_server_port(ngx_stream_lua_request_t *r,
+     unsigned short *server_port, char **err)

--- a/patch/1.29.2.4/ngx_stream_lua-tlshandshake.patch
+++ b/patch/1.29.2.4/ngx_stream_lua-tlshandshake.patch
@@ -1,0 +1,902 @@
+diff --git src/ngx_stream_lua_socket_tcp.c src/ngx_stream_lua_socket_tcp.c
+--- src/ngx_stream_lua_socket_tcp.c
++++ src/ngx_stream_lua_socket_tcp.c
+@@ -31,7 +31,6 @@
+ static int ngx_stream_lua_socket_tcp_bind(lua_State *L);
+ static int ngx_stream_lua_socket_tcp_connect(lua_State *L);
+ #if (NGX_STREAM_SSL)
+-static int ngx_stream_lua_socket_tcp_sslhandshake(lua_State *L);
+ static int ngx_stream_lua_socket_tcp_serversslhandshake(lua_State *L);
+ static int ngx_stream_lua_socket_tcp_get_ssl_session(lua_State *L);
+ #endif
+@@ -369,9 +368,6 @@
+ 
+ #if (NGX_STREAM_SSL)
+ 
+-    lua_pushcfunction(L, ngx_stream_lua_socket_tcp_sslhandshake);
+-    lua_setfield(L, -2, "sslhandshake");
+-
+     lua_pushcfunction(L, ngx_stream_lua_socket_tcp_get_ssl_session);
+     lua_setfield(L, -2, "getsslsession");
+ #endif
+@@ -1849,64 +1845,73 @@
+ }
+ 
+ 
+-static int
+-ngx_stream_lua_socket_tcp_sslhandshake(lua_State *L)
+-{
+-    int                      n, top;
+-    ngx_int_t                rc;
+-    ngx_str_t                name = ngx_null_string;
+-    ngx_connection_t        *c;
+-    ngx_ssl_session_t      **psession;
+-
+-    ngx_stream_lua_request_t                    *r;
+-    ngx_stream_lua_ctx_t                        *ctx;
+-    ngx_stream_lua_co_ctx_t                     *coctx;
+-    ngx_stream_lua_socket_tcp_upstream_t        *u;
+ 
+-    /* Lua function arguments: self [,session] [,host] [,verify]
+-       [,send_status_req] */
++static const char *
++ngx_stream_lua_socket_tcp_check_busy(ngx_stream_lua_request_t *r,
++    ngx_stream_lua_socket_tcp_upstream_t *u, unsigned int ops)
++{
++    if ((ops & SOCKET_OP_CONNECT) && u->conn_waiting) {
++        return "socket busy connecting";
++    }
+ 
+-    n = lua_gettop(L);
+-    if (n < 1 || n > 5) {
+-        return luaL_error(L, "ngx.socket sslhandshake: expecting 1 ~ 5 "
+-                          "arguments (including the object), but seen %d", n);
++    if ((ops & SOCKET_OP_READ) && u->read_waiting) {
++        return "socket busy reading";
+     }
+ 
+-    r = ngx_stream_lua_get_req(L);
+-    if (r == NULL) {
+-        return luaL_error(L, "no request found");
++    if ((ops & SOCKET_OP_WRITE)
++        && (u->write_waiting
++            || (u->raw_downstream && r->connection->buffered)))
++    {
++        return "socket busy writing";
+     }
+ 
+-    ngx_log_debug0(NGX_LOG_DEBUG_STREAM, r->connection->log, 0,
+-                   "stream lua tcp socket ssl handshake");
++    return NULL;
++}
+ 
+-    luaL_checktype(L, 1, LUA_TTABLE);
+ 
+-    lua_rawgeti(L, 1, SOCKET_CTX_INDEX);
+-    u = lua_touserdata(L, -1);
++int
++ngx_stream_lua_ffi_socket_tcp_tlshandshake(ngx_stream_lua_request_t *r,
++    ngx_stream_lua_socket_tcp_upstream_t *u, ngx_ssl_session_t *sess,
++    int enable_session_reuse, ngx_str_t *server_name, int verify,
++    int ocsp_status_req, STACK_OF(X509) *chain, EVP_PKEY *pkey,
++    const char **errmsg)
++{
++    ngx_int_t                  rc, i;
++    ngx_connection_t          *c;
++    ngx_stream_lua_ctx_t      *ctx;
++    ngx_stream_lua_co_ctx_t   *coctx;
++    const char                *busy_msg;
++    ngx_ssl_conn_t            *ssl_conn;
++    X509                      *x509;
++
++    ngx_log_debug0(NGX_LOG_DEBUG_STREAM, r->connection->log, 0,
++                   "stream lua tcp socket tls handshake");
+ 
+     if (u == NULL
+         || u->peer.connection == NULL
+         || u->read_closed
+         || u->write_closed)
+     {
+-        lua_pushnil(L);
+-        lua_pushliteral(L, "closed");
+-        return 2;
++        *errmsg = "closed";
++        return NGX_ERROR;
+     }
+ 
+     if (u->request != r) {
+-        return luaL_error(L, "bad request");
++        *errmsg = "bad request";
++        return NGX_ERROR;
+     }
+ 
+-    ngx_stream_lua_socket_check_busy_connecting(r, u, L);
+-    ngx_stream_lua_socket_check_busy_reading(r, u, L);
+-    ngx_stream_lua_socket_check_busy_writing(r, u, L);
++    busy_msg = ngx_stream_lua_socket_tcp_check_busy(r, u, SOCKET_OP_CONNECT
++                                                    | SOCKET_OP_READ
++                                                    | SOCKET_OP_WRITE);
++    if (busy_msg != NULL) {
++        *errmsg = busy_msg;
++        return NGX_ERROR;
++    }
+ 
+     if (u->raw_downstream || u->body_downstream) {
+-        lua_pushnil(L);
+-        lua_pushliteral(L, "not supported for downstream");
+-        return 2;
++        *errmsg = "not supported for downstream sockets";
++        return NGX_ERROR;
+     }
+ 
+     c = u->peer.connection;
+@@ -1914,126 +1919,150 @@
+     u->ssl_session_reuse = 1;
+ 
+     if (c->ssl && c->ssl->handshaked) {
+-        switch (lua_type(L, 2)) {
+-        case LUA_TUSERDATA:
+-            lua_pushvalue(L, 2);
+-            break;
++        if (sess != NULL) {
++            return NGX_DONE;
++        }
+ 
+-        case LUA_TBOOLEAN:
+-            if (!lua_toboolean(L, 2)) {
+-                /* avoid generating the ssl session */
+-                lua_pushboolean(L, 1);
+-                break;
+-            }
+-            /* fall through */
++        u->ssl_session_reuse = enable_session_reuse;
+ 
+-        default:
+-            ngx_stream_lua_ssl_handshake_retval_handler(r, u, L);
+-            break;
+-        }
++        (void) ngx_stream_lua_ssl_handshake_retval_handler(r, u, NULL);
+ 
+-        return 1;
++        return NGX_OK;
+     }
+ 
+     if (ngx_ssl_create_connection(u->conf->ssl, c,
+                                   NGX_SSL_BUFFER|NGX_SSL_CLIENT)
+         != NGX_OK)
+     {
+-        lua_pushnil(L);
+-        lua_pushliteral(L, "failed to create ssl connection");
+-        return 2;
++        *errmsg = "failed to create ssl connection";
++        return NGX_ERROR;
+     }
+ 
++    ssl_conn = c->ssl->connection;
++
+     ctx = ngx_stream_lua_get_module_ctx(r, ngx_stream_lua_module);
+     if (ctx == NULL) {
+-        return luaL_error(L, "no ctx found");
++        return NGX_STREAM_LUA_FFI_NO_REQ_CTX;
+     }
+ 
+     coctx = ctx->cur_co_ctx;
+ 
+     c->sendfile = 0;
+ 
+-    if (n >= 2) {
+-        if (lua_type(L, 2) == LUA_TBOOLEAN) {
+-            u->ssl_session_reuse = lua_toboolean(L, 2);
++    if (sess != NULL) {
++        if (ngx_ssl_set_session(c, sess) != NGX_OK) {
++            *errmsg = "tls set session failed";
++            return NGX_ERROR;
++        }
+ 
+-        } else {
+-            psession = lua_touserdata(L, 2);
++        ngx_log_debug1(NGX_LOG_DEBUG_STREAM, c->log, 0,
++                       "stream lua tls set session: %p", sess);
+ 
+-            if (psession != NULL && *psession != NULL) {
+-                if (ngx_ssl_set_session(c, *psession) != NGX_OK) {
+-                    lua_pushnil(L);
+-                    lua_pushliteral(L, "lua ssl set session failed");
+-                    return 2;
+-                }
++    } else {
++        u->ssl_session_reuse = enable_session_reuse;
++    }
++
++    if (chain != NULL) {
++        ngx_stream_lua_assert(pkey != NULL); /* ensured by resty.core */
+ 
+-                ngx_log_debug1(NGX_LOG_DEBUG_STREAM, c->log, 0,
+-                               "stream lua ssl set session: %p", *psession);
++        if (sk_X509_num(chain) < 1) {
++            ERR_clear_error();
++            *errmsg = "invalid client certificate chain";
++            return NGX_ERROR;
++        }
++
++        x509 = sk_X509_value(chain, 0);
++        if (x509 == NULL) {
++            ERR_clear_error();
++            *errmsg = "tls fetch client certificate from chain failed";
++            return NGX_ERROR;
++        }
++
++        if (SSL_use_certificate(ssl_conn, x509) == 0) {
++            ERR_clear_error();
++            *errmsg = "tls set client certificate failed";
++            return NGX_ERROR;
++        }
++
++        /* read rest of the chain */
++
++        for (i = 1; i < (ngx_int_t) sk_X509_num(chain); i++) {
++            x509 = sk_X509_value(chain, i);
++            if (x509 == NULL) {
++                ERR_clear_error();
++                *errmsg = "tls fetch client intermediate certificate from "
++                          "chain failed";
++                return NGX_ERROR;
++            }
++
++            if (SSL_add1_chain_cert(ssl_conn, x509) == 0) {
++                ERR_clear_error();
++                *errmsg = "tls set client intermediate certificate failed";
++                return NGX_ERROR;
+             }
+         }
+ 
+-        if (n >= 3) {
+-            name.data = (u_char *) lua_tolstring(L, 3, &name.len);
++        if (SSL_use_PrivateKey(ssl_conn, pkey) == 0) {
++            ERR_clear_error();
++            *errmsg = "tls set client private key failed";
++            return NGX_ERROR;
++        }
++    }
+ 
+-            if (name.data) {
+-                ngx_log_debug2(NGX_LOG_DEBUG_STREAM, r->connection->log, 0,
+-                               "stream lua ssl server name: \"%*s\"", name.len,
+-                               name.data);
++    if (server_name != NULL && server_name->data != NULL) {
++        ngx_log_debug1(NGX_LOG_DEBUG_STREAM, r->connection->log, 0,
++                       "stream lua tls server name: \"%V\"", server_name);
+ 
+ #ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
+-
+-                if (SSL_set_tlsext_host_name(c->ssl->connection,
+-                                             (char *) name.data)
+-                    == 0)
+-                {
+-                    lua_pushnil(L);
+-                    lua_pushliteral(L, "SSL_set_tlsext_host_name failed");
+-                    return 2;
+-                }
++        if (SSL_set_tlsext_host_name(c->ssl->connection,
++                                     (char *) server_name->data)
++            == 0)
++        {
++            *errmsg = "SSL_set_tlsext_host_name failed";
++            return NGX_ERROR;
++        }
+ 
+ #else
++        *errmsg = "no TLS extension support";
++        return NGX_ERROR;
++#endif
++    }
+ 
+-               ngx_log_debug0(NGX_LOG_DEBUG_STREAM, c->log, 0,
+-                              "lua socket SNI disabled because the current "
+-                              "version of OpenSSL lacks the support");
++    u->ssl_verify = verify;
+ 
+-#endif
+-            }
++    if (u->ssl_trusted_store) {
++        if (SSL_set1_verify_cert_store(ssl_conn, u->ssl_trusted_store) == 0) {
++            ERR_clear_error();
++            *errmsg = "SSL_set1_verify_cert_store() failed";
++            return NGX_ERROR;
++        }
+ 
+-            if (n >= 4) {
+-                u->ssl_verify = lua_toboolean(L, 4);
++        u->ssl_trusted_store = NULL;
++    }
+ 
+-                if (n >= 5) {
+-                    if (lua_toboolean(L, 5)) {
++    if (ocsp_status_req) {
+ #ifdef NGX_STREAM_LUA_USE_OCSP
+-                        if (SSL_set_tlsext_status_type(c->ssl->connection,
+-                            TLSEXT_STATUSTYPE_ocsp) != 1)
+-                        {
+-                            return luaL_error(L,
+-                                              "failed to enable OCSP stapling");
+-                        }
++        SSL_set_tlsext_status_type(c->ssl->connection,
++                                   TLSEXT_STATUSTYPE_ocsp);
++
+ #else
+-                        return luaL_error(L, "no OCSP support");
++        *errmsg = "no OCSP support";
++        return NGX_ERROR;
+ #endif
+-                    }
+-                }
+-            }
+-        }
+     }
+ 
+-    dd("found sni name: %.*s %p", (int) name.len, name.data, name.data);
+-
+-    if (name.len == 0) {
++    if (server_name == NULL || server_name->len == 0) {
+         u->ssl_name.len = 0;
+ 
+     } else {
+         if (u->ssl_name.data) {
+             /* buffer already allocated */
+ 
+-            if (u->ssl_name.len >= name.len) {
++            if (u->ssl_name.len >= server_name->len) {
+                 /* reuse it */
+-                ngx_memcpy(u->ssl_name.data, name.data, name.len);
+-                u->ssl_name.len = name.len;
++                ngx_memcpy(u->ssl_name.data, server_name->data,
++                           server_name->len);
++                u->ssl_name.len = server_name->len;
+ 
+             } else {
+                 ngx_free(u->ssl_name.data);
+@@ -2044,46 +2073,24 @@
+ 
+ new_ssl_name:
+ 
+-            u->ssl_name.data = ngx_alloc(name.len, ngx_cycle->log);
++            u->ssl_name.data = ngx_alloc(server_name->len, ngx_cycle->log);
+             if (u->ssl_name.data == NULL) {
+                 u->ssl_name.len = 0;
+-
+-                lua_pushnil(L);
+-                lua_pushliteral(L, "no memory");
+-                return 2;
++                *errmsg = "no memory";
++                return NGX_ERROR;
+             }
+ 
+-            ngx_memcpy(u->ssl_name.data, name.data, name.len);
+-            u->ssl_name.len = name.len;
++            ngx_memcpy(u->ssl_name.data, server_name->data, server_name->len);
++            u->ssl_name.len = server_name->len;
+         }
+     }
+ 
+     u->write_co_ctx = coctx;
+ 
+-#if 0
+-#ifdef NGX_STREAM_LUA_USE_OCSP
+-    SSL_set_tlsext_status_type(c->ssl->connection, TLSEXT_STATUSTYPE_ocsp);
+-#endif
+-#endif
+-
+-    if (u->ssl_trusted_store) {
+-        if (SSL_set1_verify_cert_store(c->ssl->connection,
+-                                       u->ssl_trusted_store)
+-            == 0)
+-        {
+-            ERR_clear_error();
+-
+-            lua_pushnil(L);
+-            lua_pushliteral(L, "SSL_set1_verify_cert_store() failed");
+-            return 2;
+-        }
+-
+-        u->ssl_trusted_store = NULL;
+-    }
+-
+     rc = ngx_ssl_handshake(c);
+ 
+-    dd("ngx_ssl_handshake returned %d", (int) rc);
++    ngx_log_debug1(NGX_LOG_DEBUG_STREAM, r->connection->log, 0,
++                   "ngx_ssl_handshake returned: %d", rc);
+ 
+     if (rc == NGX_AGAIN) {
+         if (c->write->timer_set) {
+@@ -2108,27 +2115,31 @@
+             r->write_event_handler = ngx_stream_lua_core_run_phases;
+         }
+ 
+-        return lua_yield(L, 0);
++        return NGX_AGAIN;
+     }
+ 
+-    top = lua_gettop(L);
+     ngx_stream_lua_ssl_handshake_handler(c);
+-    return lua_gettop(L) - top;
++
++    if (rc == NGX_ERROR) {
++        *errmsg = u->error_ret;
++        return NGX_ERROR;
++    }
++
++    return NGX_OK;
+ }
+ 
+ 
+ static void
+ ngx_stream_lua_ssl_handshake_handler(ngx_connection_t *c)
+ {
+-    const char                  *err;
+     int                          waiting;
+-    lua_State                   *L;
+     ngx_int_t                    rc;
++    ngx_connection_t            *dc;  /* downstream connection */
+     ngx_stream_lua_request_t    *r;
++    ngx_stream_lua_ctx_t        *ctx;
++    ngx_stream_lua_loc_conf_t   *llcf;
+ 
+-    ngx_stream_lua_ctx_t                        *ctx;
+-    ngx_stream_lua_loc_conf_t                   *llcf;
+-    ngx_stream_lua_socket_tcp_upstream_t        *u;
++    ngx_stream_lua_socket_tcp_upstream_t  *u;
+ 
+     u = c->data;
+     r = u->request;
+@@ -2143,11 +2154,10 @@
+ 
+     waiting = u->conn_waiting;
+ 
+-    L = u->write_co_ctx->co;
++    dc = r->connection;
+ 
+     if (c->read->timedout) {
+-        lua_pushnil(L);
+-        lua_pushliteral(L, "timeout");
++        u->error_ret = "timeout";
+         goto failed;
+     }
+ 
+@@ -2156,37 +2166,35 @@
+     }
+ 
+     if (c->ssl->handshaked) {
+-
+         if (u->ssl_verify) {
+             rc = SSL_get_verify_result(c->ssl->connection);
+ 
+             if (rc != X509_V_OK) {
+-                lua_pushnil(L);
+-                err = lua_pushfstring(L, "%d: %s", (int) rc,
+-                                      X509_verify_cert_error_string(rc));
++                u->error_ret = X509_verify_cert_error_string(rc);
++                u->openssl_error_code_ret = rc;
+ 
+                 llcf = ngx_stream_lua_get_module_loc_conf(r,
+-                                                         ngx_stream_lua_module);
++                                                          ngx_stream_lua_module);
+                 if (llcf->log_socket_errors) {
+-                    ngx_log_error(NGX_LOG_ERR, u->peer.log, 0, "stream lua ssl "
+-                                  "certificate verify error: (%s)", err);
++                    ngx_log_error(NGX_LOG_ERR, u->peer.log, 0, "stream lua tls "
++                                  "certificate verify error: (%d: %s)",
++                                  rc, u->error_ret);
+                 }
+ 
+                 goto failed;
+             }
+ 
+-#if defined(nginx_version) && nginx_version >= 1007000
++#if (nginx_version >= 1007000)
+ 
+             if (u->ssl_name.len
+                 && ngx_ssl_check_host(c, &u->ssl_name) != NGX_OK)
+             {
+-                lua_pushnil(L);
+-                lua_pushliteral(L, "certificate host mismatch");
++                u->error_ret = "certificate host mismatch";
+ 
+                 llcf = ngx_stream_lua_get_module_loc_conf(r,
+-                                                         ngx_stream_lua_module);
++                                                          ngx_stream_lua_module);
+                 if (llcf->log_socket_errors) {
+-                    ngx_log_error(NGX_LOG_ERR, u->peer.log, 0, "stream lua ssl "
++                    ngx_log_error(NGX_LOG_ERR, u->peer.log, 0, "stream lua tls "
+                                   "certificate does not match host \"%V\"",
+                                   &u->ssl_name);
+                 }
+@@ -2201,198 +2209,76 @@
+             ngx_stream_lua_socket_handle_conn_success(r, u);
+ 
+         } else {
+-            (void) ngx_stream_lua_ssl_handshake_retval_handler(r, u, L);
++            (void) ngx_stream_lua_ssl_handshake_retval_handler(r, u, NULL);
+         }
+ 
+-
+         return;
+     }
+ 
+-    lua_pushnil(L);
+-    lua_pushliteral(L, "handshake failed");
++    u->error_ret = "handshake failed";
+ 
+ failed:
+ 
+     if (waiting) {
+         u->write_prepare_retvals =
+-                                ngx_stream_lua_socket_conn_error_retval_handler;
++            ngx_stream_lua_socket_conn_error_retval_handler;
+         ngx_stream_lua_socket_handle_conn_error(r, u,
+                                                 NGX_STREAM_LUA_SOCKET_FT_SSL);
+ 
+-
+     } else {
+-        (void) ngx_stream_lua_socket_conn_error_retval_handler(r, u, L);
++        u->ft_type |= NGX_STREAM_LUA_SOCKET_FT_SSL;
++
++        (void) ngx_stream_lua_socket_conn_error_retval_handler(r, u, NULL);
+     }
+ }
+ 
+ 
+-static int
+-ngx_stream_lua_ssl_handshake_retval_handler(ngx_stream_lua_request_t *r,
+-    ngx_stream_lua_socket_tcp_upstream_t *u, lua_State *L)
++int
++ngx_stream_lua_ffi_socket_tcp_get_tlshandshake_result(ngx_stream_lua_request_t *r,
++    ngx_stream_lua_socket_tcp_upstream_t *u, ngx_ssl_session_t **sess,
++    const char **errmsg, int *openssl_error_code)
+ {
+-    ngx_connection_t            *c;
+-    ngx_ssl_session_t           *ssl_session, **ud;
+-
+-    if (!u->ssl_session_reuse) {
+-        lua_pushboolean(L, 1);
+-        return 1;
+-    }
+-
+-    ud = lua_newuserdata(L, sizeof(ngx_ssl_session_t *));
+-
+-    c = u->peer.connection;
+-
+-    ssl_session = ngx_ssl_get_session(c);
+-    if (ssl_session == NULL) {
+-        *ud = NULL;
+-
+-    } else {
+-        *ud = ssl_session;
++    ngx_log_debug1(NGX_LOG_DEBUG_STREAM, r->connection->log, 0,
++                   "stream lua cosocket get TLS handshake result for upstream: %p", u);
+ 
+-       ngx_log_debug1(NGX_LOG_DEBUG_STREAM, c->log, 0,
+-                      "stream lua ssl save session: %p", ssl_session);
++    if (u->error_ret != NULL) {
++        *errmsg = u->error_ret;
++        *openssl_error_code = u->openssl_error_code_ret;
+ 
+-        /* set up the __gc metamethod */
+-        lua_pushlightuserdata(L, ngx_stream_lua_lightudata_mask(
+-                              ssl_session_metatable_key));
+-        lua_rawget(L, LUA_REGISTRYINDEX);
+-        lua_setmetatable(L, -2);
++        return NGX_ERROR;
+     }
+ 
+-    return 1;
++    *sess = u->ssl_session_ret;
++
++    return NGX_OK;
+ }
+ 
+ 
+ static int
+-ngx_stream_lua_socket_tcp_serversslhandshake(lua_State *L)
++ngx_stream_lua_ssl_handshake_retval_handler(ngx_stream_lua_request_t *r,
++    ngx_stream_lua_socket_tcp_upstream_t *u, lua_State *L)
+ {
+-    int                      n, top;
+-    ngx_int_t                rc;
+-    ngx_connection_t        *c;
+-
+-    ngx_stream_lua_request_t                    *r;
+-    ngx_stream_lua_ctx_t                        *ctx;
+-    ngx_stream_lua_co_ctx_t                     *coctx;
+-    ngx_stream_lua_socket_tcp_upstream_t        *u;
+-#if !defined (freenginx)
+-    ngx_stream_ssl_srv_conf_t                   *sscf;
+-#endif
+-
+-    /* Lua function arguments: self */
+-
+-    n = lua_gettop(L);
+-    if (n != 1) {
+-        return luaL_error(L, "ngx.socket serversslhandshake: expecting 1 "
+-                          "argument (the object), but seen %d", n);
+-    }
+-
+-    r = ngx_stream_lua_get_req(L);
+-    if (r == NULL) {
+-        return luaL_error(L, "no request found");
+-    }
+-
+-    ngx_log_debug0(NGX_LOG_DEBUG_STREAM, r->connection->log, 0,
+-                   "stream lua tcp socket server ssl handshake");
+-
+-    luaL_checktype(L, 1, LUA_TTABLE);
+-
+-    lua_rawgeti(L, 1, SOCKET_CTX_INDEX);
+-    u = lua_touserdata(L, -1);
+-
+-    if (u == NULL
+-        || u->peer.connection == NULL
+-        || u->read_closed
+-        || u->write_closed)
+-    {
+-        lua_pushnil(L);
+-        lua_pushliteral(L, "closed");
+-        return 2;
+-    }
+-
+-    if (u->request != r) {
+-        return luaL_error(L, "bad request");
+-    }
+-
+-    ngx_stream_lua_socket_check_busy_connecting(r, u, L);
+-    ngx_stream_lua_socket_check_busy_reading(r, u, L);
+-    ngx_stream_lua_socket_check_busy_writing(r, u, L);
+-
+-    if (!u->raw_downstream && !u->body_downstream) {
+-        lua_pushnil(L);
+-        lua_pushliteral(L, "only supported for downstream socket");
+-        return 2;
+-    }
+-
+-    /* For downstream sockets, the connection is r->connection */
+-    c = r->connection;
+-
+-    if (c->ssl && c->ssl->handshaked) {
+-        /* SSL handshake already completed, return session info */
+-        ngx_stream_lua_ssl_handshake_session_info(c, L);
+-        return 1;
+-    }
+-
+-#if !defined (freenginx)
+-    sscf = ngx_stream_get_module_srv_conf(r->session, ngx_stream_ssl_module);
+-
+-    if (sscf == NULL || sscf->ssl.ctx == NULL) {
+-        lua_pushnil(L);
+-        lua_pushliteral(L, "ssl not configured for this server");
+-        return 2;
+-    }
+-
+-    if (ngx_ssl_create_connection(&sscf->ssl, c, NGX_SSL_BUFFER) != NGX_OK) {
+-        lua_pushnil(L);
+-        lua_pushliteral(L, "failed to create ssl connection");
+-        return 2;
+-    }
+-#endif
++    ngx_connection_t            *c;
++    ngx_ssl_session_t           *ssl_session;
+ 
+-    ctx = ngx_stream_lua_get_module_ctx(r, ngx_stream_lua_module);
+-    if (ctx == NULL) {
+-        return luaL_error(L, "no ctx found");
++    if (!u->ssl_session_reuse) {
++        return 0;
+     }
+ 
+-    coctx = ctx->cur_co_ctx;
+-
+-    c->sendfile = 0;
+-
+-    u->write_co_ctx = coctx;
+-
+-    rc = ngx_ssl_handshake(c);
+-
+-    dd("ngx_ssl_handshake returned %d", (int) rc);
+-
+-    if (rc == NGX_AGAIN) {
+-        if (c->write->timer_set) {
+-            ngx_del_timer(c->write);
+-        }
+-
+-        ngx_add_timer(c->read, u->read_timeout);
+-
+-        u->conn_waiting = 1;
+-        u->write_prepare_retvals
+-            = ngx_stream_lua_server_ssl_handshake_retval_handler;
+-
+-        ngx_stream_lua_cleanup_pending_operation(coctx);
+-        coctx->cleanup = ngx_stream_lua_coctx_cleanup;
+-        coctx->data = u;
+-
+-        c->ssl->handler = ngx_stream_lua_server_ssl_handshake_handler;
++    c = u->peer.connection;
+ 
+-        if (ctx->entered_content_phase) {
+-            r->write_event_handler = ngx_stream_lua_content_wev_handler;
++    ssl_session = ngx_ssl_get_session(c);
++    if (ssl_session == NULL) {
++        u->ssl_session_ret = NULL;
+ 
+-        } else {
+-            r->write_event_handler = ngx_stream_lua_core_run_phases;
+-        }
++    } else {
++        u->ssl_session_ret = ssl_session;
+ 
+-        return lua_yield(L, 0);
++        ngx_log_debug1(NGX_LOG_DEBUG_STREAM, c->log, 0,
++                       "stream lua tls save session: %p", ssl_session);
+     }
+ 
+-    top = lua_gettop(L);
+-    ngx_stream_lua_server_ssl_handshake_handler(c);
+-    return lua_gettop(L) - top;
++    return 0;
+ }
+ 
+ 
+diff --git src/ngx_stream_lua_socket_tcp.c src/ngx_stream_lua_socket_tcp.c
+--- src/ngx_stream_lua_socket_tcp.c
++++ src/ngx_stream_lua_socket_tcp.c
+@@ -2316,6 +2316,139 @@
+     return 0;
+ }
+ 
++static int
++ngx_stream_lua_socket_tcp_serversslhandshake(lua_State *L)
++{
++    int                      n, top;
++    ngx_int_t                rc;
++    ngx_connection_t        *c;
++
++    ngx_stream_lua_request_t                    *r;
++    ngx_stream_lua_ctx_t                        *ctx;
++    ngx_stream_lua_co_ctx_t                     *coctx;
++    ngx_stream_lua_socket_tcp_upstream_t        *u;
++#if !defined (freenginx)
++    ngx_stream_ssl_srv_conf_t                   *sscf;
++#endif
++
++    /* Lua function arguments: self */
++
++    n = lua_gettop(L);
++    if (n != 1) {
++        return luaL_error(L, "ngx.socket serversslhandshake: expecting 1 "
++                          "argument (the object), but seen %d", n);
++    }
++
++    r = ngx_stream_lua_get_req(L);
++    if (r == NULL) {
++        return luaL_error(L, "no request found");
++    }
++
++    ngx_log_debug0(NGX_LOG_DEBUG_STREAM, r->connection->log, 0,
++                   "stream lua tcp socket server ssl handshake");
++
++    luaL_checktype(L, 1, LUA_TTABLE);
++
++    lua_rawgeti(L, 1, SOCKET_CTX_INDEX);
++    u = lua_touserdata(L, -1);
++
++    if (u == NULL
++        || u->peer.connection == NULL
++        || u->read_closed
++        || u->write_closed)
++    {
++        lua_pushnil(L);
++        lua_pushliteral(L, "closed");
++        return 2;
++    }
++
++    if (u->request != r) {
++        return luaL_error(L, "bad request");
++    }
++
++    ngx_stream_lua_socket_check_busy_connecting(r, u, L);
++    ngx_stream_lua_socket_check_busy_reading(r, u, L);
++    ngx_stream_lua_socket_check_busy_writing(r, u, L);
++
++    if (!u->raw_downstream && !u->body_downstream) {
++        lua_pushnil(L);
++        lua_pushliteral(L, "only supported for downstream socket");
++        return 2;
++    }
++
++    /* For downstream sockets, the connection is r->connection */
++    c = r->connection;
++
++    if (c->ssl && c->ssl->handshaked) {
++        /* SSL handshake already completed, return session info */
++        ngx_stream_lua_ssl_handshake_session_info(c, L);
++        return 1;
++    }
++
++#if !defined (freenginx)
++    sscf = ngx_stream_get_module_srv_conf(r->session, ngx_stream_ssl_module);
++
++    if (sscf == NULL || sscf->ssl.ctx == NULL) {
++        lua_pushnil(L);
++        lua_pushliteral(L, "ssl not configured for this server");
++        return 2;
++    }
++
++    if (ngx_ssl_create_connection(&sscf->ssl, c, NGX_SSL_BUFFER) != NGX_OK) {
++        lua_pushnil(L);
++        lua_pushliteral(L, "failed to create ssl connection");
++        return 2;
++    }
++#endif
++
++    ctx = ngx_stream_lua_get_module_ctx(r, ngx_stream_lua_module);
++    if (ctx == NULL) {
++        return luaL_error(L, "no ctx found");
++    }
++
++    coctx = ctx->cur_co_ctx;
++
++    c->sendfile = 0;
++
++    u->write_co_ctx = coctx;
++
++    rc = ngx_ssl_handshake(c);
++
++    dd("ngx_ssl_handshake returned %d", (int) rc);
++
++    if (rc == NGX_AGAIN) {
++        if (c->write->timer_set) {
++            ngx_del_timer(c->write);
++        }
++
++        ngx_add_timer(c->read, u->read_timeout);
++
++        u->conn_waiting = 1;
++        u->write_prepare_retvals
++            = ngx_stream_lua_server_ssl_handshake_retval_handler;
++
++        ngx_stream_lua_cleanup_pending_operation(coctx);
++        coctx->cleanup = ngx_stream_lua_coctx_cleanup;
++        coctx->data = u;
++
++        c->ssl->handler = ngx_stream_lua_server_ssl_handshake_handler;
++
++        if (ctx->entered_content_phase) {
++            r->write_event_handler = ngx_stream_lua_content_wev_handler;
++
++        } else {
++            r->write_event_handler = ngx_stream_lua_core_run_phases;
++        }
++
++        return lua_yield(L, 0);
++    }
++
++    top = lua_gettop(L);
++    ngx_stream_lua_server_ssl_handshake_handler(c);
++    return lua_gettop(L) - top;
++}
++
++
+ 
+ static void
+ ngx_stream_lua_server_ssl_handshake_handler(ngx_connection_t *c)
+diff --git src/ngx_stream_lua_socket_tcp.h src/ngx_stream_lua_socket_tcp.h
+--- src/ngx_stream_lua_socket_tcp.h
++++ src/ngx_stream_lua_socket_tcp.h
+@@ -138,6 +138,9 @@
+     char                             host[COSOCKET_HOST_LEN];
+ #if (NGX_STREAM_SSL)
+     ngx_str_t                        ssl_name;
++    ngx_ssl_session_t               *ssl_session_ret;
++    const char                      *error_ret;
++    int                              openssl_error_code_ret;
+     X509_STORE                      *ssl_trusted_store;
+ #endif
+ 

--- a/patch/1.29.2.4/ngx_stream_lua-tlshandshake.patch
+++ b/patch/1.29.2.4/ngx_stream_lua-tlshandshake.patch
@@ -747,10 +747,20 @@ diff --git src/ngx_stream_lua_socket_tcp.c src/ngx_stream_lua_socket_tcp.c
 diff --git src/ngx_stream_lua_socket_tcp.c src/ngx_stream_lua_socket_tcp.c
 --- src/ngx_stream_lua_socket_tcp.c
 +++ src/ngx_stream_lua_socket_tcp.c
-@@ -2316,6 +2316,139 @@
+@@ -2316,6 +2316,149 @@
      return 0;
  }
  
++void
++ngx_stream_lua_ffi_tls_free_session(ngx_ssl_session_t *sess)
++{
++    ngx_log_debug1(NGX_LOG_DEBUG_STREAM, ngx_cycle->log, 0,
++                   "stream lua tls free session: %p", sess);
++
++    ngx_ssl_free_session(sess);
++}
++
++
 +static int
 +ngx_stream_lua_socket_tcp_serversslhandshake(lua_State *L)
 +{

--- a/patch/1.29.2.4/ngx_stream_lua-tlshandshake.patch
+++ b/patch/1.29.2.4/ngx_stream_lua-tlshandshake.patch
@@ -409,7 +409,7 @@ diff --git src/ngx_stream_lua_socket_tcp.c src/ngx_stream_lua_socket_tcp.c
  
      if (rc == NGX_AGAIN) {
          if (c->write->timer_set) {
-@@ -2108,27 +2115,31 @@
+@@ -2108,27 +2115,30 @@
              r->write_event_handler = ngx_stream_lua_core_run_phases;
          }
  
@@ -437,7 +437,6 @@ diff --git src/ngx_stream_lua_socket_tcp.c src/ngx_stream_lua_socket_tcp.c
      int                          waiting;
 -    lua_State                   *L;
      ngx_int_t                    rc;
-+    ngx_connection_t            *dc;  /* downstream connection */
      ngx_stream_lua_request_t    *r;
 +    ngx_stream_lua_ctx_t        *ctx;
 +    ngx_stream_lua_loc_conf_t   *llcf;
@@ -449,12 +448,11 @@ diff --git src/ngx_stream_lua_socket_tcp.c src/ngx_stream_lua_socket_tcp.c
  
      u = c->data;
      r = u->request;
-@@ -2143,11 +2154,10 @@
+@@ -2143,11 +2154,9 @@
  
      waiting = u->conn_waiting;
  
 -    L = u->write_co_ctx->co;
-+    dc = r->connection;
  
      if (c->read->timedout) {
 -        lua_pushnil(L);

--- a/patch/1.29.2.4/ngx_stream_lua-xrpc.patch
+++ b/patch/1.29.2.4/ngx_stream_lua-xrpc.patch
@@ -1,0 +1,845 @@
+diff --git src/ngx_stream_lua_input_filters.c src/ngx_stream_lua_input_filters.c
+index 159185c..83ff85f 100644
+--- src/ngx_stream_lua_input_filters.c
++++ src/ngx_stream_lua_input_filters.c
+@@ -144,3 +144,64 @@ ngx_stream_lua_read_line(ngx_buf_t *src, ngx_chain_t *buf_in,
+ 
+     return NGX_AGAIN;
+ }
++
++
++ngx_int_t
++ngx_stream_lua_read_line_within_bytes(ngx_buf_t *src, ngx_chain_t *buf_in,
++     size_t *rest, ssize_t bytes, ngx_log_t *log)
++{
++    u_char                      *dst;
++    u_char                       c;
++#if (NGX_DEBUG)
++    u_char                      *begin;
++#endif
++
++#if (NGX_DEBUG)
++    begin = src->pos;
++#endif
++
++    if (bytes == 0) {
++        return NGX_ERROR;
++    }
++
++    if ((size_t) bytes >= *rest) {
++        bytes = *rest;
++    }
++
++    dst = buf_in->buf->last;
++
++    while (bytes--) {
++
++        (*rest)--;
++        dst++;
++        c = *src->pos++;
++
++        switch (c) {
++        case '\n':
++            ngx_log_debug2(NGX_LOG_DEBUG_STREAM, log, 0,
++                           "stream lua read the final line part: "
++                           "\"%*s\"", src->pos - 1 - begin, begin);
++
++            buf_in->buf->last = dst;
++
++            return NGX_OK;
++
++        default:
++            break;
++        }
++    }
++
++#if (NGX_DEBUG)
++    ngx_log_debug2(NGX_LOG_DEBUG_STREAM, log, 0,
++                   "stream lua read partial line data: %*s",
++                   dst - begin, begin);
++#endif
++
++    buf_in->buf->last = dst;
++
++    if (*rest == 0) {
++        return NGX_DONE;
++    }
++
++    return NGX_AGAIN;
++}
+diff --git src/ngx_stream_lua_input_filters.h src/ngx_stream_lua_input_filters.h
+index e65d572..25175a5 100644
+--- src/ngx_stream_lua_input_filters.h
++++ src/ngx_stream_lua_input_filters.h
+@@ -31,6 +31,8 @@ ngx_int_t ngx_stream_lua_read_any(ngx_buf_t *src, ngx_chain_t *buf_in,
+ ngx_int_t ngx_stream_lua_read_line(ngx_buf_t *src, ngx_chain_t *buf_in,
+     ssize_t bytes, ngx_log_t *log);
+ 
++ngx_int_t ngx_stream_lua_read_line_within_bytes(ngx_buf_t *src, ngx_chain_t *buf_in,
++     size_t *max, ssize_t bytes, ngx_log_t *log);
+ 
+ #endif /* _NGX_STREAM_LUA_INPUT_FILTERS_H_INCLUDED_ */
+ 
+diff --git src/ngx_stream_lua_socket_tcp.c src/ngx_stream_lua_socket_tcp.c
+index 57f389d..6855e37 100644
+--- src/ngx_stream_lua_socket_tcp.c
++++ src/ngx_stream_lua_socket_tcp.c
+@@ -237,6 +237,41 @@ enum {
+     }
+ 
+ 
++#define ngx_stream_lua_ffi_socket_check_busy_connecting(r, u, errbuf,        \
++                                                        errbuf_size)         \
++    if ((u)->conn_waiting) {                                                 \
++        *errbuf_size = ngx_snprintf((errbuf), *(errbuf_size),                \
++                                    "socket busy connecting")                \
++                       - (errbuf);                                           \
++        return NGX_ERROR;                                                    \
++    }
++
++
++#define ngx_stream_lua_ffi_socket_check_busy_reading(r, u, errbuf,           \
++                                                     errbuf_size)            \
++    if ((u)->read_waiting) {                                                 \
++        *errbuf_size = ngx_snprintf((errbuf), *(errbuf_size),                \
++                                    "socket busy reading")                   \
++                       - (errbuf);                                           \
++        return NGX_ERROR;                                                    \
++    }
++
++
++#define ngx_stream_lua_ffi_socket_check_busy_writing(r, u, errbuf,           \
++                                                     errbuf_size)            \
++    if ((u)->write_waiting) {                                                \
++        *errbuf_size = ngx_snprintf((errbuf), *(errbuf_size),                \
++                                    "socket busy writing")                   \
++                       - (errbuf);                                           \
++    }                                                                        \
++    if ((u)->raw_downstream                                                  \
++        && ((r)->connection->buffered))                                      \
++    {                                                                        \
++        *errbuf_size = ngx_snprintf((errbuf), *(errbuf_size),                \
++                                    "socket busy writing")                   \
++                       - (errbuf);                                           \
++    }
++
+ 
+ static char ngx_stream_lua_raw_req_socket_metatable_key;
+ static char ngx_stream_lua_tcp_socket_metatable_key;
+@@ -2573,6 +2608,31 @@ ngx_stream_lua_socket_read_any(void *data, ssize_t bytes)
+ }
+ 
+ 
++static ngx_int_t
++ngx_stream_lua_socket_read_line_within_bytes(void *data, ssize_t bytes)
++{
++    ngx_int_t                                        rc;
++    ngx_stream_lua_socket_tcp_upstream_t            *u = data;
++
++    ngx_log_debug0(NGX_LOG_DEBUG_STREAM, u->request->connection->log, 0,
++                   "stream lua tcp socket read line within bytes");
++
++    rc = ngx_stream_lua_read_line_within_bytes(&u->buffer, u->buf_in, &u->rest, bytes,
++                                               u->request->connection->log);
++    if (rc == NGX_ERROR) {
++        u->ft_type |= NGX_STREAM_LUA_SOCKET_FT_CLOSED;
++        return NGX_ERROR;
++    }
++
++    if (rc == NGX_DONE) {
++        u->ft_type |= NGX_STREAM_LUA_SOCKET_FT_TRUNCATED;
++        return NGX_ERROR;
++    }
++
++    return rc;
++}
++
++
+ static ngx_int_t
+ ngx_stream_lua_socket_tcp_read(ngx_stream_lua_request_t *r,
+     ngx_stream_lua_socket_tcp_upstream_t *u)
+@@ -5971,6 +6031,672 @@ static ngx_int_t ngx_stream_lua_socket_insert_buffer(
+ }
+ 
+ 
++static void
++ngx_stream_lua_ffi_socket_reset_buf(ngx_stream_lua_ctx_t *ctx,
++    ngx_stream_lua_socket_tcp_upstream_t *u)
++{
++    ngx_chain_t             *cl = u->bufs_in;
++    ngx_chain_t            **ll = NULL;
++
++    if (cl == NULL) {
++        return;
++    }
++
++    if (cl->next) {
++        ll = &cl->next;
++    }
++
++    if (ll) {
++        *ll = ctx->free_recv_bufs;
++        ctx->free_recv_bufs = u->bufs_in;
++        u->bufs_in = u->buf_in;
++    }
++
++    if (u->buffer.pos == u->buffer.last) {
++        u->buffer.pos = u->buffer.start;
++        u->buffer.last = u->buffer.pos;
++    }
++
++    if (u->bufs_in) {
++        u->buf_in->buf->last = u->buffer.pos;
++        u->buf_in->buf->pos = u->buffer.pos;
++    }
++}
++
++
++void
++ngx_stream_lua_ffi_socket_tcp_reset_read_buf(ngx_stream_lua_request_t *r,
++    ngx_stream_lua_socket_tcp_upstream_t *u)
++{
++    ngx_stream_lua_ctx_t    *ctx;
++
++    ctx = ngx_stream_lua_get_module_ctx(r, ngx_stream_lua_module);
++    ngx_stream_lua_ffi_socket_reset_buf(ctx, u);
++}
++
++
++static int
++ngx_stream_lua_socket_tcp_dummy_retval_handler(ngx_stream_lua_request_t *r,
++    ngx_stream_lua_socket_tcp_upstream_t *u, lua_State *L)
++{
++    return 0;
++}
++
++
++static ngx_int_t
++ngx_stream_lua_ffi_socket_push_res(ngx_stream_lua_request_t *r,
++    ngx_stream_lua_ctx_t *ctx, ngx_stream_lua_socket_tcp_upstream_t *u,
++    u_char **buf, size_t len, size_t *actual_len)
++{
++    dd("bufs_in: %p, buf_in: %p", u->bufs_in, u->buf_in);
++
++    ngx_log_debug3(NGX_LOG_DEBUG_STREAM, u->request->connection->log, 0,
++                   "stream lua tcp socket push res: pos:%p, last:%p, len:%d",
++                   u->buffer.pos, u->buffer.last, len);
++
++    if (actual_len != NULL) {
++        len = u->length - u->rest;
++        *buf = u->buffer.pos - len;
++
++        if ((*buf)[len - 1] == '\n') {
++            len--;
++        }
++        if ((*buf)[len - 1] == '\r') {
++            len--;
++        }
++        *actual_len = len;
++
++    } else {
++        *buf = u->buffer.pos - len;
++    }
++
++    return NGX_OK;
++}
++
++
++static void
++ngx_stream_lua_ffi_socket_prepare_error_retvals(ngx_stream_lua_request_t *r,
++    ngx_stream_lua_socket_tcp_upstream_t *u, ngx_uint_t ft_type,
++    u_char *errbuf, size_t *errbuf_size)
++{
++    u_char          *p;
++
++    if (ft_type & NGX_STREAM_LUA_SOCKET_FT_TIMEOUT) {
++        *errbuf_size = ngx_snprintf(errbuf, *errbuf_size, "timeout") - errbuf;
++
++    } else if (ft_type & NGX_STREAM_LUA_SOCKET_FT_CLOSED) {
++        *errbuf_size = ngx_snprintf(errbuf, *errbuf_size, "closed") - errbuf;
++
++    } else if (ft_type & NGX_STREAM_LUA_SOCKET_FT_TRUNCATED) {
++        *errbuf_size = ngx_snprintf(errbuf, *errbuf_size, "truncated") - errbuf;
++
++    } else if (ft_type & NGX_STREAM_LUA_SOCKET_FT_BUFTOOSMALL) {
++        *errbuf_size = ngx_snprintf(errbuf, *errbuf_size, "buffer too small")
++                       - errbuf;
++
++    } else if (ft_type & NGX_STREAM_LUA_SOCKET_FT_NOMEM) {
++        *errbuf_size = ngx_snprintf(errbuf, *errbuf_size, "no memory") - errbuf;
++
++    } else if (ft_type & NGX_STREAM_LUA_SOCKET_FT_CLIENTABORT) {
++        *errbuf_size = ngx_snprintf(errbuf, *errbuf_size, "client aborted")
++                       - errbuf;
++
++    } else {
++
++        if (u->socket_errno) {
++            p = ngx_strerror(u->socket_errno, errbuf, *errbuf_size);
++            /* for compatibility with LuaSocket */
++            ngx_strlow(errbuf, errbuf, p - errbuf);
++            *errbuf_size = p - errbuf;
++
++        } else {
++            *errbuf_size = ngx_snprintf(errbuf, *errbuf_size, "error")
++                           - errbuf;
++        }
++    }
++}
++
++
++static void
++ngx_stream_lua_ffi_socket_read_error_retval_handler(
++    ngx_stream_lua_request_t *r, ngx_stream_lua_socket_tcp_upstream_t *u,
++    u_char *errbuf, size_t *errbuf_size)
++{
++    ngx_uint_t          ft_type;
++
++    if (u->ft_type & NGX_STREAM_LUA_SOCKET_FT_TIMEOUT) {
++        u->no_close = 1;
++    }
++
++    if (u->read_co_ctx) {
++        u->read_co_ctx->cleanup = NULL;
++    }
++
++    ft_type = u->ft_type;
++    u->ft_type = 0;
++
++    if (u->no_close) {
++        u->no_close = 0;
++
++    } else {
++        ngx_stream_lua_socket_tcp_finalize_read_part(r, u);
++    }
++
++    ngx_stream_lua_ffi_socket_prepare_error_retvals(r, u, ft_type,
++                                                    errbuf, errbuf_size);
++}
++
++
++static ngx_int_t
++ngx_stream_lua_ffi_socket_read_retval_handler(ngx_stream_lua_request_t *r,
++    ngx_stream_lua_socket_tcp_upstream_t *u, u_char **buf, size_t len,
++    size_t *actual_len, u_char *errbuf, size_t *errbuf_size)
++{
++    ngx_stream_lua_ctx_t        *ctx;
++    ngx_event_t                 *ev;
++
++    ngx_stream_lua_loc_conf_t           *llcf;
++
++    ctx = ngx_stream_lua_get_module_ctx(r, ngx_stream_lua_module);
++
++    if (u->raw_downstream || u->body_downstream) {
++        llcf = ngx_stream_lua_get_module_loc_conf(r, ngx_stream_lua_module);
++
++        if (llcf->check_client_abort) {
++
++            r->read_event_handler = ngx_stream_lua_rd_check_broken_connection;
++
++            ev = r->connection->read;
++
++            dd("rev active: %d", ev->active);
++
++            if ((ngx_event_flags & NGX_USE_LEVEL_EVENT) && !ev->active) {
++                if (ngx_add_event(ev, NGX_READ_EVENT, 0) != NGX_OK) {
++                    *errbuf_size = ngx_snprintf(errbuf, *errbuf_size,
++                                                "failed to add event") - errbuf;
++                    return NGX_ERROR;
++                }
++            }
++
++        } else {
++            /* llcf->check_client_abort == 0 */
++            r->read_event_handler = ngx_stream_lua_block_reading;
++        }
++    }
++
++    if (u->ft_type) {
++        ngx_stream_lua_ffi_socket_read_error_retval_handler(r, u, errbuf,
++                                                            errbuf_size);
++        return NGX_ERROR;
++    }
++
++    if (buf != NULL) {
++        ngx_stream_lua_ffi_socket_push_res(r, ctx, u, buf, len, actual_len);
++    }
++
++    return NGX_OK;
++}
++
++
++int
++ngx_stream_lua_ffi_socket_tcp_read_buf(ngx_stream_lua_request_t *r,
++    ngx_stream_lua_socket_tcp_upstream_t *u, u_char **buf, size_t len,
++    size_t *actual_len, u_char *errbuf, size_t *errbuf_size)
++{
++    ngx_int_t                            rc;
++    ngx_stream_lua_loc_conf_t           *llcf;
++    ngx_stream_lua_ctx_t                *lctx;
++    ngx_stream_lua_co_ctx_t             *coctx;
++
++    if (u == NULL || u->peer.connection == NULL || u->read_closed) {
++
++        llcf = ngx_stream_lua_get_module_loc_conf(r, ngx_stream_lua_module);
++
++        if (llcf->log_socket_errors) {
++            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
++                          "stream attempt to receive data on a closed "
++                          "socket: u:%p, c:%p, ft:%d eof:%d",
++                          u, u ? u->peer.connection : NULL,
++                          u ? (int) u->ft_type : 0, u ? (int) u->eof : 0);
++        }
++
++        *errbuf_size = ngx_snprintf(errbuf, *errbuf_size, "closed") - errbuf;
++        return NGX_ERROR;
++    }
++
++    if (u->request != r) {
++        *errbuf_size = ngx_snprintf(errbuf, *errbuf_size, "bad request")
++                       - errbuf;
++        return NGX_DONE;
++    }
++
++    ngx_stream_lua_ffi_socket_check_busy_connecting(r, u, errbuf, errbuf_size);
++    ngx_stream_lua_ffi_socket_check_busy_reading(r, u, errbuf, errbuf_size);
++
++    ngx_log_debug1(NGX_LOG_DEBUG_STREAM, r->connection->log, 0,
++                   "stream lua tcp socket read timeout: %M", u->read_timeout);
++
++    if (actual_len != NULL) {
++        u->input_filter = ngx_stream_lua_socket_read_line_within_bytes;
++    } else {
++        u->input_filter = ngx_stream_lua_socket_read_chunk;
++    }
++
++    u->length = (size_t) len;
++    u->rest = u->length;
++    u->input_filter_ctx = u;
++
++    lctx = ngx_stream_lua_get_module_ctx(r, ngx_stream_lua_module);
++
++    if (buf != NULL) {
++        if (u->bufs_in == NULL) {
++            size_t buf_len = len > u->conf->buffer_size ? len : u->conf->buffer_size;
++
++            ngx_log_debug1(NGX_LOG_DEBUG_STREAM, r->connection->log, 0,
++                           "stream lua tcp socket allocate new new buf of size %uz",
++                           buf_len);
++
++            u->bufs_in =
++                ngx_stream_lua_chain_get_free_buf(r->connection->log,
++                                                  r->pool,
++                                                  &lctx->free_recv_bufs,
++                                                  buf_len);
++
++            if (u->bufs_in == NULL) {
++                *errbuf_size = ngx_snprintf(errbuf, *errbuf_size, "no memory") - errbuf;
++                return NGX_DONE;
++            }
++
++            u->buf_in = u->bufs_in;
++            u->buffer = *u->buf_in->buf;
++
++        } else {
++            size_t           remain_space = u->buffer.end - u->buffer.pos;
++            size_t           remain_data = u->buffer.last - u->buffer.pos;
++            size_t           buf_len;
++            u_char          *pos;
++            ngx_chain_t     *cl, *tmp_cl;
++
++            if (remain_space < len) {
++                buf_len = len > u->conf->buffer_size ? len : u->conf->buffer_size;
++
++                ngx_log_debug1(NGX_LOG_DEBUG_STREAM, r->connection->log, 0,
++                               "stream lua tcp socket allocate new new buf of size %uz",
++                               buf_len);
++
++                cl = ngx_stream_lua_chain_get_free_buf(r->connection->log,
++                                                       r->pool,
++                                                       &lctx->free_recv_bufs,
++                                                       buf_len);
++                if (cl == NULL) {
++                    *errbuf_size = ngx_snprintf(errbuf, *errbuf_size, "no memory") - errbuf;
++                    return NGX_DONE;
++                }
++
++                for (tmp_cl = u->bufs_in; tmp_cl->next; tmp_cl = tmp_cl->next) {}
++                tmp_cl->next = cl;
++                u->buf_in = cl;
++
++                u->buffer.last = u->buffer.pos;
++                pos = u->buffer.pos;
++                u->buffer = *cl->buf;
++
++                if (remain_data > 0) {
++                    u->buffer.last = ngx_copy(u->buffer.last, pos, remain_data);
++                }
++            }
++        }
++
++    } else if (u->bufs_in == NULL) {
++        ngx_log_debug1(NGX_LOG_DEBUG_STREAM, r->connection->log, 0,
++                       "stream lua tcp socket allocate new new buf of size %uz",
++                       u->conf->buffer_size);
++
++        u->bufs_in =
++            ngx_stream_lua_chain_get_free_buf(r->connection->log,
++                                              r->pool,
++                                              &lctx->free_recv_bufs,
++                                              u->conf->buffer_size);
++
++        if (u->bufs_in == NULL) {
++            *errbuf_size = ngx_snprintf(errbuf, *errbuf_size, "no memory") - errbuf;
++            return NGX_DONE;
++        }
++
++        u->buf_in = u->bufs_in;
++        u->buffer = *u->buf_in->buf;
++    }
++
++    dd("tcp receive: buf_in: %p, bufs_in: %p", u->buf_in, u->bufs_in);
++
++    ngx_log_debug1(NGX_LOG_DEBUG_STREAM, r->connection->log, 0,
++                   "stream lua tcp socket read timeout: %M", u->read_timeout);
++
++    if (u->raw_downstream || u->body_downstream) {
++        r->read_event_handler = ngx_stream_lua_req_socket_rev_handler;
++    }
++
++    u->read_waiting = 0;
++    u->read_co_ctx = NULL;
++
++    rc = ngx_stream_lua_socket_tcp_read(r, u);
++
++    ngx_log_debug1(NGX_LOG_DEBUG_STREAM, r->connection->log, 0,
++                   "stream lua socket tcp read, rc: %d", rc);
++
++    if (rc == NGX_ERROR) {
++        dd("read failed: %d", (int) u->ft_type);
++        rc = ngx_stream_lua_ffi_socket_read_retval_handler(r, u, buf, len,
++                                                           actual_len,
++                                                         errbuf, errbuf_size);
++        dd("tcp receive retval returned: %d", (int) rc);
++        return rc;
++    }
++
++    if (rc == NGX_OK) {
++
++        ngx_log_debug0(NGX_LOG_DEBUG_STREAM, r->connection->log, 0,
++                       "stream lua tcp socket receive done in a single run");
++
++        return ngx_stream_lua_ffi_socket_read_retval_handler(r, u, buf, len,
++                                                             actual_len,
++                                                         errbuf, errbuf_size);
++    }
++
++    if (rc == NGX_AGAIN) {
++        u->read_event_handler = ngx_stream_lua_socket_read_handler;
++
++        coctx = lctx->cur_co_ctx;
++
++        ngx_stream_lua_cleanup_pending_operation(coctx);
++        coctx->cleanup = ngx_stream_lua_coctx_cleanup;
++        coctx->data = u;
++
++        if (lctx->entered_content_phase) {
++            r->write_event_handler = ngx_stream_lua_content_wev_handler;
++
++        } else {
++            r->write_event_handler = ngx_stream_lua_core_run_phases;
++        }
++
++        u->read_co_ctx = coctx;
++        u->read_waiting = 1;
++        u->read_prepare_retvals = ngx_stream_lua_socket_tcp_dummy_retval_handler;
++
++        dd("setting data to %p, coctx:%p", u, coctx);
++
++        if (u->raw_downstream || u->body_downstream) {
++            lctx->downstream = u;
++        }
++
++        ngx_log_debug1(NGX_LOG_DEBUG_STREAM, r->connection->log, 0,
++                       "lua socket receive yield, u: %p", u);
++
++        return NGX_AGAIN;
++    }
++
++    return ngx_stream_lua_ffi_socket_read_retval_handler(r, u, buf, len,
++                                                         actual_len,
++                                                         errbuf, errbuf_size);
++}
++
++
++int
++ngx_stream_lua_ffi_socket_tcp_get_read_buf_result(ngx_stream_lua_request_t *r,
++    ngx_stream_lua_socket_tcp_upstream_t *u, u_char **buf, size_t len,
++    size_t *actual_len, u_char *errbuf, size_t *errbuf_size)
++{
++    ngx_log_debug0(NGX_LOG_DEBUG_STREAM, r->connection->log, 0,
++                   "lua tcp socket get receive result");
++
++    return ngx_stream_lua_ffi_socket_read_retval_handler(r, u, buf, len,
++                                                         actual_len,
++                                                         errbuf, errbuf_size);
++}
++
++
++int
++ngx_stream_lua_ffi_socket_tcp_has_pending_data(ngx_stream_lua_request_t *r,
++    ngx_stream_lua_socket_tcp_upstream_t *u,
++    u_char *errbuf, size_t *errbuf_size)
++{
++    /* skip many input checks as we require glance to be called
++     * after any read methods called successfully */
++
++    if (u == NULL || u->bufs_in == NULL) {
++        *errbuf_size = ngx_snprintf(errbuf, *errbuf_size, "closed") - errbuf;
++        return NGX_ERROR;
++    }
++
++    /* no remain data */
++    if ((u->buffer.last == u->buffer.pos && u->buffer.last != u->buffer.end)
++        || u->eof /* EOF reached */)
++    {
++        return NGX_OK;
++    }
++
++    return NGX_AGAIN;
++}
++
++
++static void
++ngx_stream_lua_ffi_socket_write_error_retval_handler(
++    ngx_stream_lua_request_t *r, ngx_stream_lua_socket_tcp_upstream_t *u,
++    u_char *errbuf, size_t *errbuf_size)
++{
++    ngx_uint_t          ft_type;
++
++    if (u->write_co_ctx) {
++        u->write_co_ctx->cleanup = NULL;
++    }
++
++    ngx_stream_lua_socket_tcp_finalize_write_part(r, u, 0);
++
++    ft_type = u->ft_type;
++    u->ft_type = 0;
++
++    ngx_stream_lua_ffi_socket_prepare_error_retvals(r, u, ft_type,
++                                                    errbuf, errbuf_size);
++}
++
++
++int
++ngx_stream_lua_ffi_socket_tcp_send_from_socket(ngx_stream_lua_request_t *r,
++    ngx_stream_lua_socket_tcp_upstream_t *u, ngx_stream_lua_socket_tcp_upstream_t *src,
++    u_char *errbuf, size_t *errbuf_size)
++{
++    size_t                               len = 0;
++    ngx_int_t                            rc;
++    ngx_chain_t                         *cl, *in_cl;
++    ngx_stream_lua_ctx_t                *ctx;
++    int                                  tcp_nodelay;
++    ngx_buf_t                           *b;
++    ngx_connection_t                    *c;
++    ngx_stream_lua_loc_conf_t           *llcf;
++    ngx_stream_core_srv_conf_t          *clcf;
++    ngx_stream_lua_co_ctx_t             *coctx;
++
++    if (u == NULL || u->peer.connection == NULL || u->write_closed) {
++        llcf = ngx_stream_lua_get_module_loc_conf(r, ngx_stream_lua_module);
++
++        if (llcf->log_socket_errors) {
++            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
++                          "attempt to send data on a closed socket: u:%p, "
++                          "c:%p, ft:%d eof:%d",
++                          u, u ? u->peer.connection : NULL,
++                          u ? (int) u->ft_type : 0, u ? (int) u->eof : 0);
++        }
++
++        *errbuf_size = ngx_snprintf(errbuf, *errbuf_size, "closed") - errbuf;
++        return NGX_ERROR;
++    }
++
++    if (u->request != r) {
++        *errbuf_size = ngx_snprintf(errbuf, *errbuf_size, "bad request")
++                       - errbuf;
++        return NGX_DONE;
++    }
++
++    ngx_stream_lua_ffi_socket_check_busy_connecting(r, u, errbuf, errbuf_size);
++    ngx_stream_lua_ffi_socket_check_busy_writing(r, u, errbuf, errbuf_size);
++
++    if (u->body_downstream) {
++        *errbuf_size = ngx_snprintf(errbuf, *errbuf_size,
++                                    "attempt to write to request sockets")
++                       - errbuf;
++        return NGX_DONE;
++    }
++
++    ngx_log_debug1(NGX_LOG_DEBUG_STREAM, r->connection->log, 0,
++                   "lua tcp socket send timeout: %M", u->send_timeout);
++
++    ctx = ngx_stream_lua_get_module_ctx(r, ngx_stream_lua_module);
++
++    for (in_cl = src->bufs_in; in_cl; in_cl = in_cl->next) {
++        b = in_cl->buf;
++
++        len += b->last - b->pos;
++
++        ngx_log_debug3(NGX_LOG_DEBUG_STREAM, r->connection->log, 0,
++                       "lua tcp socket move cl:%p buf %p, len: %d",
++                       in_cl, b, b->last - b->pos);
++
++    }
++
++    ngx_log_debug2(NGX_LOG_DEBUG_STREAM, r->connection->log, 0,
++                   "lua tcp socket move total buf %p, len: %d",
++                   src->bufs_in, len);
++
++    if (len == 0) {
++        return NGX_OK;
++    }
++
++    cl = ngx_stream_lua_chain_get_free_buf(r->connection->log, r->pool,
++                                           &ctx->free_bufs, len);
++
++    if (cl == NULL) {
++        *errbuf_size = ngx_snprintf(errbuf, *errbuf_size, "no memory") - errbuf;
++        return NGX_DONE;
++    }
++
++    if (!src->bufs_in->next) {
++        cl->buf->pos = src->bufs_in->buf->pos;
++        cl->buf->last = src->bufs_in->buf->last;
++
++    } else {
++        /* TODO: avoid copying (it requires to modify the way cosocket sends data) */
++        for (in_cl = src->bufs_in; in_cl; in_cl = in_cl->next) {
++            b = in_cl->buf;
++            cl->buf->last = ngx_copy(cl->buf->last, b->pos, b->last - b->pos);
++        }
++    }
++
++    ngx_stream_lua_ffi_socket_reset_buf(ctx, src);
++
++    u->request_bufs = cl;
++
++    u->request_len = len;
++
++    /* mimic ngx_stream_upstream_init_request here */
++
++    clcf = ngx_stream_lua_get_module_loc_conf(r, ngx_stream_core_module);
++    c = u->peer.connection;
++
++    if (clcf->tcp_nodelay && c->tcp_nodelay == NGX_TCP_NODELAY_UNSET) {
++        ngx_log_debug0(NGX_LOG_DEBUG_STREAM, c->log, 0,
++                       "lua socket tcp_nodelay");
++
++        tcp_nodelay = 1;
++
++        if (setsockopt(c->fd, IPPROTO_TCP, TCP_NODELAY,
++                       (const void *) &tcp_nodelay, sizeof(int))
++            == -1)
++        {
++            llcf = ngx_stream_lua_get_module_loc_conf(r, ngx_stream_lua_module);
++            if (llcf->log_socket_errors) {
++                ngx_connection_error(c, ngx_socket_errno,
++                                     "setsockopt(TCP_NODELAY) "
++                                     "failed");
++            }
++
++            *errbuf_size = ngx_snprintf(errbuf, *errbuf_size,
++                                        "setsocketopt tcp_nodelay failed")
++                           - errbuf;
++            return NGX_ERROR;
++        }
++
++        c->tcp_nodelay = NGX_TCP_NODELAY_SET;
++    }
++
++    u->write_waiting = 0;
++    u->write_co_ctx = NULL;
++
++    ngx_stream_lua_probe_socket_tcp_send_start(r, u, b->pos, len);
++
++    rc = ngx_stream_lua_socket_send(r, u);
++
++    dd("socket send returned %d", (int) rc);
++
++    if (rc == NGX_ERROR) {
++        ngx_stream_lua_ffi_socket_write_error_retval_handler(r, u, errbuf,
++                                                             errbuf_size);
++        return NGX_ERROR;
++    }
++
++    if (rc == NGX_OK) {
++        return rc;
++    }
++
++    /* rc == NGX_AGAIN */
++
++    coctx = ctx->cur_co_ctx;
++
++    ngx_stream_lua_cleanup_pending_operation(coctx);
++    coctx->cleanup = ngx_stream_lua_coctx_cleanup;
++    coctx->data = u;
++
++    if (u->raw_downstream) {
++        ctx->writing_raw_req_socket = 1;
++    }
++
++    if (ctx->entered_content_phase) {
++        r->write_event_handler = ngx_stream_lua_content_wev_handler;
++
++    } else {
++        r->write_event_handler = ngx_stream_lua_core_run_phases;
++    }
++
++    u->write_co_ctx = coctx;
++    u->write_waiting = 1;
++    u->write_prepare_retvals = ngx_stream_lua_socket_tcp_dummy_retval_handler;
++
++    dd("setting data to %p", u);
++
++    ngx_log_debug1(NGX_LOG_DEBUG_STREAM, c->log, 0,
++                   "lua socket send yield, u: %p", u);
++
++    return NGX_AGAIN;
++}
++
++
++int
++ngx_stream_lua_ffi_socket_tcp_get_send_result(ngx_stream_lua_request_t *r,
++    ngx_stream_lua_socket_tcp_upstream_t *u, u_char *errbuf,
++    size_t *errbuf_size)
++{
++    ngx_log_debug0(NGX_LOG_DEBUG_STREAM, r->connection->log, 0,
++                   "lua tcp socket get send result");
++
++    if (u->ft_type) {
++        ngx_stream_lua_ffi_socket_write_error_retval_handler(r, u, errbuf,
++                                                             errbuf_size);
++        return NGX_ERROR;
++    }
++
++    return NGX_OK;
++}
++
++
+ static ngx_int_t
+ ngx_stream_lua_socket_tcp_conn_op_resume(ngx_stream_lua_request_t *r)
+ {
+diff --git src/ngx_stream_lua_socket_tcp.h src/ngx_stream_lua_socket_tcp.h
+index 3473250..cad0406 100644
+--- src/ngx_stream_lua_socket_tcp.h
++++ src/ngx_stream_lua_socket_tcp.h
+@@ -28,6 +28,7 @@
+ #define NGX_STREAM_LUA_SOCKET_FT_PARTIALWRITE  0x0040
+ #define NGX_STREAM_LUA_SOCKET_FT_CLIENTABORT   0x0080
+ #define NGX_STREAM_LUA_SOCKET_FT_SSL           0x0100
++#define NGX_STREAM_LUA_SOCKET_FT_TRUNCATED     0x1000
+ 
+ 
+ typedef struct ngx_stream_lua_socket_tcp_upstream_s

--- a/patch/1.29.2.4/ngx_stream_lua-xrpc.patch
+++ b/patch/1.29.2.4/ngx_stream_lua-xrpc.patch
@@ -231,10 +231,10 @@ index 57f389d..6855e37 100644
 +        len = u->length - u->rest;
 +        *buf = u->buffer.pos - len;
 +
-+        if ((*buf)[len - 1] == '\n') {
++        if (len > 0 && (*buf)[len - 1] == '\n') {
 +            len--;
 +        }
-+        if ((*buf)[len - 1] == '\r') {
++        if (len > 0 && (*buf)[len - 1] == '\r') {
 +            len--;
 +        }
 +        *actual_len = len;
@@ -713,8 +713,8 @@ index 57f389d..6855e37 100644
 +    }
 +
 +    if (!src->bufs_in->next) {
-+        cl->buf->pos = src->bufs_in->buf->pos;
-+        cl->buf->last = src->bufs_in->buf->last;
++        b = src->bufs_in->buf;
++        cl->buf->last = ngx_copy(cl->buf->last, b->pos, b->last - b->pos);
 +
 +    } else {
 +        /* TODO: avoid copying (it requires to modify the way cosocket sends data) */

--- a/patch/1.29.2.4/ngx_stream_lua-xrpc.patch
+++ b/patch/1.29.2.4/ngx_stream_lua-xrpc.patch
@@ -56,7 +56,7 @@ index 159185c..83ff85f 100644
 +#if (NGX_DEBUG)
 +    ngx_log_debug2(NGX_LOG_DEBUG_STREAM, log, 0,
 +                   "stream lua read partial line data: %*s",
-+                   dst - begin, begin);
++                   src->pos - begin, begin);
 +#endif
 +
 +    buf_in->buf->last = dst;

--- a/patch/1.29.2.4/ngx_stream_lua-xrpc.patch
+++ b/patch/1.29.2.4/ngx_stream_lua-xrpc.patch
@@ -426,7 +426,7 @@ index 57f389d..6855e37 100644
 +            size_t buf_len = len > u->conf->buffer_size ? len : u->conf->buffer_size;
 +
 +            ngx_log_debug1(NGX_LOG_DEBUG_STREAM, r->connection->log, 0,
-+                           "stream lua tcp socket allocate new new buf of size %uz",
++                           "stream lua tcp socket allocate new buf of size %uz",
 +                           buf_len);
 +
 +            u->bufs_in =
@@ -454,7 +454,7 @@ index 57f389d..6855e37 100644
 +                buf_len = len > u->conf->buffer_size ? len : u->conf->buffer_size;
 +
 +                ngx_log_debug1(NGX_LOG_DEBUG_STREAM, r->connection->log, 0,
-+                               "stream lua tcp socket allocate new new buf of size %uz",
++                               "stream lua tcp socket allocate new buf of size %uz",
 +                               buf_len);
 +
 +                cl = ngx_stream_lua_chain_get_free_buf(r->connection->log,
@@ -482,7 +482,7 @@ index 57f389d..6855e37 100644
 +
 +    } else if (u->bufs_in == NULL) {
 +        ngx_log_debug1(NGX_LOG_DEBUG_STREAM, r->connection->log, 0,
-+                       "stream lua tcp socket allocate new new buf of size %uz",
++                       "stream lua tcp socket allocate new buf of size %uz",
 +                       u->conf->buffer_size);
 +
 +        u->bufs_in =

--- a/patch/1.29.2.4/ngx_stream_lua-xrpc.patch
+++ b/patch/1.29.2.4/ngx_stream_lua-xrpc.patch
@@ -76,7 +76,7 @@ index e65d572..25175a5 100644
      ssize_t bytes, ngx_log_t *log);
  
 +ngx_int_t ngx_stream_lua_read_line_within_bytes(ngx_buf_t *src, ngx_chain_t *buf_in,
-+     size_t *max, ssize_t bytes, ngx_log_t *log);
++     size_t *rest, ssize_t bytes, ngx_log_t *log);
  
  #endif /* _NGX_STREAM_LUA_INPUT_FILTERS_H_INCLUDED_ */
  
@@ -84,7 +84,7 @@ diff --git src/ngx_stream_lua_socket_tcp.c src/ngx_stream_lua_socket_tcp.c
 index 57f389d..6855e37 100644
 --- src/ngx_stream_lua_socket_tcp.c
 +++ src/ngx_stream_lua_socket_tcp.c
-@@ -237,6 +237,41 @@ enum {
+@@ -237,6 +237,43 @@ enum {
      }
  
  
@@ -114,6 +114,7 @@ index 57f389d..6855e37 100644
 +        *errbuf_size = ngx_snprintf((errbuf), *(errbuf_size),                \
 +                                    "socket busy writing")                   \
 +                       - (errbuf);                                           \
++        return NGX_ERROR;                                                    \
 +    }                                                                        \
 +    if ((u)->raw_downstream                                                  \
 +        && ((r)->connection->buffered))                                      \
@@ -121,6 +122,7 @@ index 57f389d..6855e37 100644
 +        *errbuf_size = ngx_snprintf((errbuf), *(errbuf_size),                \
 +                                    "socket busy writing")                   \
 +                       - (errbuf);                                           \
++        return NGX_ERROR;                                                    \
 +    }
 +
  

--- a/patch/patch.sh
+++ b/patch/patch.sh
@@ -78,6 +78,12 @@ elif [[ "$root" == *openresty-1.27.1.2 ]]; then
       apply_patch "$patch_dir" "$root" "lua-resty-core" "0.1.31"
       apply_patch "$patch_dir" "$root" "ngx_lua" "0.10.28"
       apply_patch "$patch_dir" "$root" "ngx_stream_lua" "0.0.16"
+elif [[ "$root" == *openresty-1.29.2.4 ]]; then
+      patch_dir="$PWD/1.29.2.4"
+      apply_patch "$patch_dir" "$root" "nginx" "1.29.2"
+      apply_patch "$patch_dir" "$root" "lua-resty-core" "0.1.34rc2"
+      apply_patch "$patch_dir" "$root" "ngx_lua" "0.10.31rc2"
+      apply_patch "$patch_dir" "$root" "ngx_stream_lua" "0.0.19rc3"
 else
     err "can't detect OpenResty version"
     exit 1


### PR DESCRIPTION
Add the patch set for OpenResty 1.29.2.4 and wire patch.sh to apply it against the bundled nginx 1.29.2, lua-resty-core 0.1.34rc2, ngx_lua 0.10.31rc2, and ngx_stream_lua 0.0.19rc3.\n\nVerified locally by applying the patch set to the official OpenResty 1.29.2.4 tarball and building nginx with apisix-nginx-module enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TLS session hostname accessor and optional "reject in handshake" verification
  * Per-pool connection keepalive with pool-aware peer selection
  * New TLS handshake support for TCP sockets and updated socket handshake APIs
  * HTTP variable exposing original destination address

* **Improvements**
  * Unified shared-dictionary behavior across subsystems
  * Multiple APISIX-aware integrations: delayed client_max_body_size checks, gzip controls, proxy buffering, mirror-on-demand, real-IP helper, upstream mTLS/SSL behavior
  * Privileged-agent listener controls and last-log-reopen time tracking
  * Updated 50x error pages with APISIX attribution

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/apisix-nginx-module/pull/113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->