### PR TITLE
fix: restore missing max_body_size guard for chunked body in 1.29.2.4 patch (client_max_body_size 0 wrongly 413s chunked)

### DIFF
--- a/patch/1.29.2.4/nginx-client_max_body_size.patch
+++ b/patch/1.29.2.4/nginx-client_max_body_size.patch
@@ -76,7 +76,7 @@ index afb0423..6faa09e 100644
      if (rb->rest == -1) {
  
          ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
-@@ -1139,8 +1165,14 @@ ngx_http_request_body_chunked_filter(ngx_http_request_t *r, ngx_chain_t *in)
+@@ -1139,8 +1165,15 @@ ngx_http_request_body_chunked_filter(ngx_http_request_t *r, ngx_chain_t *in)
  
                  clcf = ngx_http_get_module_loc_conf(r, ngx_http_core_module);
  
@@ -84,6 +84,7 @@ index afb0423..6faa09e 100644
 +                (void) clcf; /* unused */
 +
 +                if (max_body_size
++                    && max_body_size
 +#else
                  if (clcf->client_max_body_size
                      && clcf->client_max_body_size

--- a/t/client_max_body_size.t
+++ b/t/client_max_body_size.t
@@ -301,7 +301,7 @@ Hello\r
 Transfer-Encoding: chunked
 --- request eval
 qq{POST /t
-11\r
+b\r
 Hello World\r
 0\r
 \r

--- a/t/client_max_body_size.t
+++ b/t/client_max_body_size.t
@@ -254,3 +254,56 @@ client intended to send too large body
 --- request
 POST /t
 1234
+
+
+
+=== TEST 12: set client_max_body_size to 0 means no limitation, chunked
+--- config
+    location /t {
+        client_max_body_size 1;
+        access_by_lua_block {
+            local client = require("resty.apisix.client")
+            assert(client.set_client_max_body_size(0))
+        }
+        content_by_lua_block {
+            ngx.req.read_body()
+            ngx.exit(200)
+        }
+    }
+--- raw_request eval
+qq{POST /t HTTP/1.1\r
+Host: localhost\r
+Transfer-Encoding: chunked\r
+Connection: close\r
+\r
+5\r
+Hello\r
+0\r
+\r
+}
+
+
+
+=== TEST 13: set client_max_body_size to 0 means no limitation, http2 chunked
+--- config
+    location /t {
+        client_max_body_size 1;
+        access_by_lua_block {
+            local client = require("resty.apisix.client")
+            assert(client.set_client_max_body_size(0))
+        }
+        content_by_lua_block {
+            ngx.req.read_body()
+            ngx.exit(200)
+        }
+    }
+--- more_headers
+Transfer-Encoding: chunked
+--- request eval
+qq{POST /t
+11\r
+Hello World\r
+0\r
+\r
+}
+--- use_http2


### PR DESCRIPTION
## What this fixes

`patch/1.29.2.4/nginx-client_max_body_size.patch` dropped the `&& max_body_size` guard in the
chunked-body check that `patch/1.27.1.1/nginx-client_max_body_size.patch` has.

After C preprocessing, the `NGX_HTTP_APISIX` branch of `ngx_http_request_body_chunked_filter()`
becomes:

```c
if (max_body_size - r->headers_in.content_length_n < rb->chunked->size)
```

So with `client_max_body_size 0` (unlimited) and a chunked request (`content_length_n == 0`),
`0 - 0 < chunk_size` is true for any non-empty chunk → spurious **413**
`client intended to send too large chunked body`.

The content-length check and the `rb->received` check in the same patch kept their
`&& max_body_size` guard, so **only chunked requests** are affected.

## Impact

APISIX renders `client_max_body_size 0` by default. Once APISIX bundles this runtime
(APISIX 3.17.0 → apisix-runtime 1.3.6 → OpenResty 1.29.2.4 + apisix-nginx-module 1.19.5),
**any chunked upload through APISIX returns 413**: `docker push` blob upload (chunked PATCH),
large file/attachment uploads, etc.

Confirmed in production on APISIX 3.17.0 (docker push to a registry behind APISIX failed with
413), reproduced with a standalone OpenResty 1.29.2.4 build; OpenResty 1.27.1.2 (this module's
`1.27.1.1` patch) is unaffected.

## Fix

Restore the missing `&& max_body_size` line so `max_body_size == 0` short-circuits the chunked
check, matching `patch/1.27.1.1/...` and stock nginx semantics.

```diff
 #if (NGX_HTTP_APISIX)
                 (void) clcf; /* unused */

                 if (max_body_size
+                    && max_body_size
 #else
                 if (clcf->client_max_body_size
                     && clcf->client_max_body_size
 #endif
                        - r->headers_in.content_length_n < rb->chunked->size)
```

## Tests

Added regression cases to `t/client_max_body_size.t`:
- **TEST 12**: `set_client_max_body_size(0)` + `Transfer-Encoding: chunked` (HTTP/1.1),
  non-empty body → must pass, not 413.
- **TEST 13**: same over HTTP/2.

(TEST 11 already covered max-body-size 0 for `Content-Length`; chunked was the gap.)

## Related

This was originally reported (mistakenly) against OpenResty core in openresty/openresty#1139;
the actual root cause is this module's `1.29.2.4` patch, not nginx/OpenResty core.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved enforcement of request body size limits to behave consistently across standard, chunked, and HTTP/2 requests.
  * When body size checks are deferred/overridden, large or unlimited bodies are handled correctly and no longer result in unexpected `413` responses.
* **Tests**
  * Added new test coverage for “unlimited” body size behavior using chunked requests over both HTTP/1.1 and HTTP/2, ensuring requests complete without `413`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->