### PR TITLE
fix: address OpenResty 1.29 compatibility regressions

### DIFF
--- a/patch/1.29.2.4/lua-resty-core-tlshandshake.patch
+++ b/patch/1.29.2.4/lua-resty-core-tlshandshake.patch
@@ -338,3 +338,16 @@ index 0000000..b6e009c
 +return {
 +    version = base.version
 +}
+diff --git lib/resty/core/socket.lua lib/resty/core/socket.lua
+index ea973b7..a039ac5 100644
+--- lib/resty/core/socket.lua
++++ lib/resty/core/socket.lua
+@@ -73 +73,4 @@ ngx_http_lua_ffi_ssl_free_session(void *sess);
+-
++
++void
++ngx_http_lua_ffi_tls_free_session(void *sess);
++
+@@ -493 +496 @@ local function getsslsession(cosocket)
+-    return ffi_gc(session_ptr[0], C.ngx_http_lua_ffi_ssl_free_session)
++    return ffi_gc(session_ptr[0], C.ngx_http_lua_ffi_tls_free_session)

--- a/patch/1.29.2.4/nginx-listen-in-privileged-agent.patch
+++ b/patch/1.29.2.4/nginx-listen-in-privileged-agent.patch
@@ -55,19 +55,17 @@ index d0b4a55..9da09db 100644
              ngx_log_debug2(NGX_LOG_DEBUG_CORE, cycle->log, 0,
                             "closing unused fd:%d listening on %V",
 diff --git src/http/ngx_http.c src/http/ngx_http.c
-index d835f89..6e71644 100644
+index d835f89..8f019c2 100644
 --- src/http/ngx_http.c
 +++ src/http/ngx_http.c
-@@ -1262,6 +1262,15 @@ ngx_http_add_addresses(ngx_conf_t *cf, ngx_http_core_srv_conf_t *cscf,
+@@ -1262,6 +1262,13 @@ ngx_http_add_addresses(ngx_conf_t *cf, ngx_http_core_srv_conf_t *cscf,
              continue;
          }
  
 +        if (lsopt->privileged_agent != addr[i].opt.privileged_agent) {
 +            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
-+                               "%V is already occupied by %s",
-+                               &addr[i].opt.addr_text,
-+                               addr[i].opt.privileged_agent
-+                                   ? "privileged agent" : "worker process");
++                               "%V is already occupied by privileged agent",
++                               &addr[i].opt.addr_text);
 +            return NGX_ERROR;
 +        }
 +

--- a/patch/1.29.2.4/nginx-listen-in-privileged-agent.patch
+++ b/patch/1.29.2.4/nginx-listen-in-privileged-agent.patch
@@ -55,17 +55,19 @@ index d0b4a55..9da09db 100644
              ngx_log_debug2(NGX_LOG_DEBUG_CORE, cycle->log, 0,
                             "closing unused fd:%d listening on %V",
 diff --git src/http/ngx_http.c src/http/ngx_http.c
-index d835f89..8f019c2 100644
+index d835f89..6e71644 100644
 --- src/http/ngx_http.c
 +++ src/http/ngx_http.c
-@@ -1262,6 +1262,13 @@ ngx_http_add_addresses(ngx_conf_t *cf, ngx_http_core_srv_conf_t *cscf,
+@@ -1262,6 +1262,15 @@ ngx_http_add_addresses(ngx_conf_t *cf, ngx_http_core_srv_conf_t *cscf,
              continue;
          }
  
 +        if (lsopt->privileged_agent != addr[i].opt.privileged_agent) {
 +            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
-+                               "%V is already occupied by privileged agent",
-+                               &addr[i].opt.addr_text);
++                               "%V is already occupied by %s",
++                               &addr[i].opt.addr_text,
++                               addr[i].opt.privileged_agent
++                                   ? "privileged agent" : "worker process");
 +            return NGX_ERROR;
 +        }
 +

--- a/patch/1.29.2.4/nginx-listen-in-privileged-agent.patch
+++ b/patch/1.29.2.4/nginx-listen-in-privileged-agent.patch
@@ -26,21 +26,23 @@ index 84dd804..d3d6930 100644
  #if (NGX_HAVE_INET6)
      unsigned            ipv6only:1;
 diff --git src/event/ngx_event.c src/event/ngx_event.c
-index d0b4a55..54bdaae 100644
+index d0b4a55..9da09db 100644
 --- src/event/ngx_event.c
 +++ src/event/ngx_event.c
-@@ -845,6 +845,22 @@ ngx_event_process_init(ngx_cycle_t *cycle)
+@@ -845,6 +845,24 @@ ngx_event_process_init(ngx_cycle_t *cycle)
      for (i = 0; i < cycle->listening.nelts; i++) {
  
 +        if (ngx_is_privileged_agent != ls[i].privileged_agent) {
-+            ngx_log_debug2(NGX_LOG_DEBUG_CORE, cycle->log, 0,
-+                           "closing unused fd:%d listening on %V",
-+                           ls[i].fd, &ls[i].addr_text);
++            if (ls[i].fd != (ngx_socket_t) -1) {
++                ngx_log_debug2(NGX_LOG_DEBUG_CORE, cycle->log, 0,
++                               "closing unused fd:%d listening on %V",
++                               ls[i].fd, &ls[i].addr_text);
 +
-+            if (ngx_close_socket(ls[i].fd) == -1) {
-+                ngx_log_error(NGX_LOG_EMERG, cycle->log, ngx_socket_errno,
-+                              ngx_close_socket_n " %V failed",
-+                              &ls[i].addr_text);
++                if (ngx_close_socket(ls[i].fd) == -1) {
++                    ngx_log_error(NGX_LOG_EMERG, cycle->log, ngx_socket_errno,
++                                  ngx_close_socket_n " %V failed",
++                                  &ls[i].addr_text);
++                }
 +            }
 +
 +            ls[i].fd = (ngx_socket_t) -1;

--- a/t/privileged_agent.t
+++ b/t/privileged_agent.t
@@ -65,7 +65,7 @@ Bad file descriptor
 
 
 
-=== TEST 2: address conflict detection
+=== TEST 2: worker listener address conflict detection
 --- http_config
 init_by_lua_block {
     local process = require("ngx.process")
@@ -95,11 +95,45 @@ server {
     }
 --- must_die
 --- error_log
+127.0.0.1:9091 is already occupied by worker process
+
+
+
+=== TEST 3: privileged agent listener address conflict detection
+--- http_config
+init_by_lua_block {
+    local process = require("ngx.process")
+    assert(process.enable_privileged_agent())
+}
+server {
+    listen 127.0.0.1:9091 enable_process=privileged_agent;
+    location / {
+        content_by_lua_block {
+            local process = require("ngx.process")
+            ngx.say(process.type())
+        }
+    }
+}
+server {
+    listen 127.0.0.1:9091;
+    location / {
+        content_by_lua_block {
+            local process = require("ngx.process")
+            ngx.say(process.type())
+        }
+    }
+}
+--- config
+    location /t {
+        return 200;
+    }
+--- must_die
+--- error_log
 127.0.0.1:9091 is already occupied by privileged agent
 
 
 
-=== TEST 3: same port, different IP
+=== TEST 4: same port, different IP
 --- http_config
 init_by_lua_block {
     local process = require("ngx.process")

--- a/t/privileged_agent.t
+++ b/t/privileged_agent.t
@@ -65,7 +65,7 @@ Bad file descriptor
 
 
 
-=== TEST 2: worker listener address conflict detection
+=== TEST 2: address conflict detection
 --- http_config
 init_by_lua_block {
     local process = require("ngx.process")
@@ -82,40 +82,6 @@ server {
 }
 server {
     listen 127.0.0.1:9091 enable_process=privileged_agent;
-    location / {
-        content_by_lua_block {
-            local process = require("ngx.process")
-            ngx.say(process.type())
-        }
-    }
-}
---- config
-    location /t {
-        return 200;
-    }
---- must_die
---- error_log
-127.0.0.1:9091 is already occupied by worker process
-
-
-
-=== TEST 3: privileged agent listener address conflict detection
---- http_config
-init_by_lua_block {
-    local process = require("ngx.process")
-    assert(process.enable_privileged_agent())
-}
-server {
-    listen 127.0.0.1:9091 enable_process=privileged_agent;
-    location / {
-        content_by_lua_block {
-            local process = require("ngx.process")
-            ngx.say(process.type())
-        }
-    }
-}
-server {
-    listen 127.0.0.1:9091;
     location / {
         content_by_lua_block {
             local process = require("ngx.process")
@@ -133,7 +99,7 @@ server {
 
 
 
-=== TEST 4: same port, different IP
+=== TEST 3: same port, different IP
 --- http_config
 init_by_lua_block {
     local process = require("ngx.process")

--- a/t/privileged_agent.t
+++ b/t/privileged_agent.t
@@ -59,6 +59,9 @@ server {
             end
         }
     }
+--- no_error_log
+[emerg]
+Bad file descriptor
 
 
 

--- a/t/ssl-get-session.t
+++ b/t/ssl-get-session.t
@@ -1,0 +1,60 @@
+our $SkipReason;
+
+BEGIN {
+    my $nginx_binary = $ENV{'TEST_NGINX_BINARY'} || 'nginx';
+    my $version = eval { `$nginx_binary -V 2>&1` } // '';
+    my ($major, $minor) = $version =~ m{openresty/(\d+)\.(\d+)};
+
+    if (!defined $major || !defined $minor
+        || ($major < 1 || ($major == 1 && $minor < 29))) {
+        $SkipReason = "requires OpenResty 1.29 or later";
+    }
+}
+
+use t::APISIX_NGINX $SkipReason
+    ? (skip_all => $SkipReason)
+    : ('no_plan');
+
+no_root_location();
+run_tests;
+
+__DATA__
+
+=== TEST 1: getsslsession remains usable after tlshandshake
+--- config
+    listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+    ssl_certificate ../../certs/test.crt;
+    ssl_certificate_key ../../certs/test.key;
+    ssl_protocols TLSv1.2;
+
+    location = /up {
+        return 200 'ok';
+    }
+
+    location = /t {
+        lua_ssl_protocols TLSv1.2;
+        content_by_lua_block {
+            local sock = ngx.socket.tcp()
+            assert(sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock"))
+            assert(sock:tlshandshake())
+            assert(sock:send("GET /up HTTP/1.1\r\n" ..
+                             "Host: localhost\r\n" ..
+                             "Connection: keep-alive\r\n\r\n"))
+
+            assert(sock:receive("*l"))
+            while true do
+                local line = assert(sock:receive("*l"))
+                if line == "" then
+                    break
+                end
+            end
+            assert(sock:receive(2))
+
+            local ok, session = pcall(sock.getsslsession, sock)
+            ngx.say("pcall: ", ok)
+            ngx.say("session: ", type(session))
+        }
+    }
+--- response_body
+pcall: true
+session: cdata


### PR DESCRIPTION
OpenResty 1.29 introduced `getsslsession()` in `resty.core.socket`, but the 1.29 patch renamed the session-free FFI symbol without updating that method. Calling it after a successful TLS handshake therefore failed with an undefined-symbol error.

The same patch set also made normal workers call `close(-1)` for privileged-agent listeners, producing an `[emerg] Bad file descriptor` log on otherwise valid configurations.

This change updates `getsslsession()` to use the renamed FFI symbol and only closes process-specific listeners when their fd is valid. Regression tests cover TLS session retrieval and invalid-fd logging. The TLS test is limited to OpenResty 1.29+, where `getsslsession()` is available.
