### PR TITLE
fix(balancer): key keepalive pools by full name and restore set_current_peer host compatibility

### DIFF
--- a/patch/1.21.4/lua-resty-core-enable_keepalive.patch
+++ b/patch/1.21.4/lua-resty-core-enable_keepalive.patch
@@ -1,5 +1,5 @@
 diff --git lib/ngx/balancer.lua lib/ngx/balancer.lua
-index 7d64d63..70a7610 100644
+index 7d64d63..0c77876 100644
 --- lib/ngx/balancer.lua
 +++ lib/ngx/balancer.lua
 @@ -19,6 +19,7 @@ local tonumber = tonumber
@@ -77,7 +77,7 @@ index 7d64d63..70a7610 100644
 +                pool = opts.pool
 +                pool_size = opts.pool_size
 +
-+                if pool then
++                if pool ~= nil then
 +                    if type(pool) ~= "string" then
 +                        error("bad option 'pool' to 'set_current_peer' " ..
 +                              "(string expected, got " ..
@@ -88,7 +88,7 @@ index 7d64d63..70a7610 100644
 +                    end
 +                end
 +
-+                if pool_size then
++                if pool_size ~= nil then
 +                    if type(pool_size) ~= "number" then
 +                        error("bad option 'pool_size' to " ..
 +                              "'set_current_peer' (number expected, got " ..

--- a/patch/1.21.4/lua-resty-core-enable_keepalive.patch
+++ b/patch/1.21.4/lua-resty-core-enable_keepalive.patch
@@ -1,33 +1,24 @@
 diff --git lib/ngx/balancer.lua lib/ngx/balancer.lua
-index 7d64d63..781cbd1 100644
+index 7d64d63..70a7610 100644
 --- lib/ngx/balancer.lua
 +++ lib/ngx/balancer.lua
-@@ -3,6 +3,7 @@
- 
- local base = require "resty.core.base"
- base.allows_subsystem('http', 'stream')
-+require "resty.core.hash"
- 
- 
- local ffi = require "ffi"
-@@ -17,8 +18,10 @@ local error = error
- local type = type
- local tonumber = tonumber
+@@ -19,6 +19,7 @@ local tonumber = tonumber
  local max = math.max
-+local ngx_crc32_long = ngx.crc32_long
  local subsystem = ngx.config.subsystem
  local ngx_lua_ffi_balancer_set_current_peer
 +local ngx_lua_ffi_balancer_enable_keepalive
  local ngx_lua_ffi_balancer_set_more_tries
  local ngx_lua_ffi_balancer_get_last_failure
  local ngx_lua_ffi_balancer_set_timeouts -- used by both stream and http
-@@ -27,7 +30,11 @@ local ngx_lua_ffi_balancer_set_timeouts -- used by both stream and http
+@@ -27,7 +28,13 @@ local ngx_lua_ffi_balancer_set_timeouts -- used by both stream and http
  if subsystem == 'http' then
      ffi.cdef[[
      int ngx_http_lua_ffi_balancer_set_current_peer(ngx_http_request_t *r,
 -        const unsigned char *addr, size_t addr_len, int port, char **err);
 +        const unsigned char *addr, size_t addr_len, int port,
-+        unsigned int cpool_crc32, unsigned int cpool_size, char **err);
++        const unsigned char *host, size_t host_len,
++        const unsigned char *cpool_name, size_t cpool_name_len,
++        unsigned int cpool_size, char **err);
 +
 +    int ngx_http_lua_ffi_balancer_enable_keepalive(ngx_http_request_t *r,
 +        unsigned long timeout, unsigned int max_requests, char **err);
@@ -56,7 +47,7 @@ index 7d64d63..781cbd1 100644
  local peer_state_names = {
      [1] = "keepalive",
      [2] = "next",
-@@ -106,25 +121,147 @@ local peer_state_names = {
+@@ -106,25 +121,158 @@ local peer_state_names = {
  local _M = { version = base.version }
  
  
@@ -71,36 +62,47 @@ index 7d64d63..781cbd1 100644
 +            error("no request found")
 +        end
 +
-+        local pool_crc32
++        local host
++        local pool
 +        local pool_size
 +
-+        if opts then
-+            if type(opts) ~= "table" then
++        if opts ~= nil then
++            local typ = type(opts)
++
++            if typ == "string" then
++                -- the documented set_current_peer(addr, port, host) form
++                host = opts
++
++            elseif typ == "table" then
++                pool = opts.pool
++                pool_size = opts.pool_size
++
++                if pool then
++                    if type(pool) ~= "string" then
++                        error("bad option 'pool' to 'set_current_peer' " ..
++                              "(string expected, got " ..
++                              type(pool) .. ")", 2)
++                    elseif pool == "" then
++                        error("bad option 'pool' to 'set_current_peer' " ..
++                              "(non-empty string expected)", 2)
++                    end
++                end
++
++                if pool_size then
++                    if type(pool_size) ~= "number" then
++                        error("bad option 'pool_size' to " ..
++                              "'set_current_peer' (number expected, got " ..
++                              type(pool_size) .. ")", 2)
++
++                    elseif pool_size < 1 then
++                        error("bad option 'pool_size' to " ..
++                              "'set_current_peer' (expected > 0)", 2)
++                    end
++                end
++
++            else
 +                error("bad argument #3 to 'set_current_peer' " ..
-+                      "(table expected, got " .. type(opts) .. ")", 2)
-+            end
-+
-+            local pool = opts.pool
-+            pool_size = opts.pool_size
-+
-+            if pool then
-+                if type(pool) ~= "string" then
-+                    error("bad option 'pool' to 'set_current_peer' " ..
-+                          "(string expected, got " .. type(pool) .. ")", 2)
-+                end
-+
-+                pool_crc32 = ngx_crc32_long(pool)
-+            end
-+
-+            if pool_size then
-+                if type(pool_size) ~= "number" then
-+                    error("bad option 'pool_size' to 'set_current_peer' " ..
-+                          "(number expected, got " .. type(pool_size) .. ")", 2)
-+
-+                elseif pool_size < 1 then
-+                    error("bad option 'pool_size' to 'set_current_peer' " ..
-+                          "(expected > 0)", 2)
-+                end
++                      "(string or table expected, got " .. typ .. ")", 2)
 +            end
 +        end
 +
@@ -111,16 +113,16 @@ index 7d64d63..781cbd1 100644
 +            port = tonumber(port)
 +        end
 +
-+        if not pool_crc32 then
-+            pool_crc32 = 0
-+        end
-+
 +        if not pool_size then
 +            pool_size = DEFAULT_KEEPALIVE_POOL_SIZE
 +        end
 +
 +        local rc = ngx_lua_ffi_balancer_set_current_peer(r, addr, #addr, port,
-+                                                         pool_crc32, pool_size,
++                                                         host,
++                                                         host and #host or 0,
++                                                         pool,
++                                                         pool and #pool or 0,
++                                                         pool_size,
 +                                                         errmsg)
 +        if rc == FFI_OK then
 +            return true

--- a/patch/1.21.4/ngx_lua-enable_keepalive.patch
+++ b/patch/1.21.4/ngx_lua-enable_keepalive.patch
@@ -1,5 +1,5 @@
 diff --git src/ngx_http_lua_balancer.c src/ngx_http_lua_balancer.c
-index af4da73..0175ee3 100644
+index af4da73..7b8dc5b 100644
 --- src/ngx_http_lua_balancer.c
 +++ src/ngx_http_lua_balancer.c
 @@ -16,46 +16,116 @@
@@ -1194,7 +1194,7 @@ index af4da73..0175ee3 100644
  
      if (r->upstream_states && r->upstream_states->nelts > 1) {
          state = r->upstream_states->elts;
-@@ -809,4 +1376,122 @@ ngx_http_lua_ffi_balancer_recreate_request(ngx_http_request_t *r,
+@@ -809,4 +1376,128 @@ ngx_http_lua_ffi_balancer_recreate_request(ngx_http_request_t *r,
  }
  
  
@@ -1268,27 +1268,30 @@ index af4da73..0175ee3 100644
 +     * different properties could be reused
 +     */
 +
-+    if (bp->host.len) {
-+        ssl_name = bp->host;
-+    }
-+
 +#if (NGX_HTTP_SSL)
 +    if (u->ssl) {
 +        tls = 1;
 +
-+        if (ssl_name.len == 0) {
-+            if (ngx_http_lua_upstream_get_ssl_name(r, u) != NGX_OK) {
-+                return NGX_ERROR;
-+            }
-+
-+            ssl_name = u->ssl_name;
++        /*
++         * the name actually used for the TLS handshake is derived from
++         * the upstream ssl_name configuration at connect time, not from
++         * the set_current_peer host argument, so the identity must use
++         * the same derivation; the host argument stays a separate
++         * identity component below to preserve its documented
++         * pool-partitioning semantics
++         */
++        if (ngx_http_lua_upstream_get_ssl_name(r, u) != NGX_OK) {
++            return NGX_ERROR;
 +        }
++
++        ssl_name = u->ssl_name;
 +    }
 +#endif
 +
 +    len = bp->addr_text->len + 1
 +          + (pc->local ? pc->local->name.len : 0) + 1
 +          + 1 /* tls flag */ + 1
++          + bp->host.len + 1
 +          + ssl_name.len;
 +
 +    p = ngx_pnalloc(r->pool, len);
@@ -1307,6 +1310,9 @@ index af4da73..0175ee3 100644
 +
 +    *p++ = '|';
 +    *p++ = tls ? '1' : '0';
++    *p++ = '|';
++
++    p = ngx_copy(p, bp->host.data, bp->host.len);
 +    *p++ = '|';
 +
 +    p = ngx_copy(p, ssl_name.data, ssl_name.len);

--- a/patch/1.21.4/ngx_lua-enable_keepalive.patch
+++ b/patch/1.21.4/ngx_lua-enable_keepalive.patch
@@ -1,16 +1,19 @@
 diff --git src/ngx_http_lua_balancer.c src/ngx_http_lua_balancer.c
-index af4da73..a284317 100644
+index af4da73..0175ee3 100644
 --- src/ngx_http_lua_balancer.c
 +++ src/ngx_http_lua_balancer.c
-@@ -16,46 +16,103 @@
+@@ -16,46 +16,116 @@
  #include "ngx_http_lua_directive.h"
-
-
+ 
+ 
 +typedef struct {
 +    ngx_uint_t                               size;
 +    ngx_uint_t                               connections;
 +
-+    uint32_t                                 crc32;
++    /* the full pool name is the pool identity; a 32-bit digest such as
++     * crc32 must not be used here: colliding names would silently share
++     * connections across unrelated upstream pools */
++    ngx_str_t                                cpool_name;
 +
 +    lua_State                               *lua_vm;
 +
@@ -36,21 +39,14 @@ index af4da73..a284317 100644
 +
 +    ngx_uint_t                              more_tries;
 +    ngx_uint_t                              total_tries;
-
--    ngx_http_lua_srv_conf_t            *conf;
--    ngx_http_request_t                 *request;
++
 +    int                                     last_peer_state;
-
--    ngx_uint_t                          more_tries;
--    ngx_uint_t                          total_tries;
-+    uint32_t                                cpool_crc32;
-
--    struct sockaddr                    *sockaddr;
--    socklen_t                           socklen;
++
++    ngx_str_t                               cpool_name;
++    unsigned                                cpool_set:1;
++
 +    void                                   *data;
-
--    ngx_str_t                          *host;
--    in_port_t                           port;
++
 +    ngx_event_get_peer_pt                   original_get_peer;
 +    ngx_event_free_peer_pt                  original_free_peer;
 +
@@ -58,26 +54,36 @@ index af4da73..a284317 100644
 +    ngx_event_set_peer_session_pt           original_set_session;
 +    ngx_event_save_peer_session_pt          original_save_session;
 +#endif
-
--    int                                 last_peer_state;
+ 
+-    ngx_http_lua_srv_conf_t            *conf;
+-    ngx_http_request_t                 *request;
 +    ngx_http_request_t                     *request;
 +    ngx_http_lua_srv_conf_t                *conf;
 +    ngx_http_lua_balancer_keepalive_pool_t *cpool;
-+
-+    ngx_str_t                              *host;
-+
+ 
+-    ngx_uint_t                          more_tries;
+-    ngx_uint_t                          total_tries;
++    ngx_str_t                               host;
+ 
+-    struct sockaddr                    *sockaddr;
+-    socklen_t                           socklen;
++    ngx_str_t                              *addr_text;
+ 
+-    ngx_str_t                          *host;
+-    in_port_t                           port;
 +    struct sockaddr                        *sockaddr;
 +    socklen_t                               socklen;
-+
+ 
+-    int                                 last_peer_state;
 +    unsigned                                keepalive:1;
-
+ 
  #if !(HAVE_NGX_UPSTREAM_TIMEOUT_FIELDS)
 -    unsigned                            cloned_upstream_conf;  /* :1 */
 +    unsigned                                cloned_upstream_conf:1;
  #endif
  };
-
-
+ 
+ 
 -#if (NGX_HTTP_SSL)
 -static ngx_int_t ngx_http_lua_balancer_set_session(ngx_peer_connection_t *pc,
 -    void *data);
@@ -97,10 +103,17 @@ index af4da73..a284317 100644
  static void ngx_http_lua_balancer_free_peer(ngx_peer_connection_t *pc,
      void *data, ngx_uint_t state);
 +static ngx_int_t ngx_http_lua_balancer_create_keepalive_pool(lua_State *L,
-+    ngx_log_t *log, uint32_t cpool_crc32, ngx_uint_t cpool_size,
++    ngx_log_t *log, ngx_str_t *cpool_name, ngx_uint_t cpool_size,
 +    ngx_http_lua_balancer_keepalive_pool_t **cpool);
 +static void ngx_http_lua_balancer_get_keepalive_pool(lua_State *L,
-+    uint32_t cpool_crc32, ngx_http_lua_balancer_keepalive_pool_t **cpool);
++    ngx_str_t *cpool_name, ngx_http_lua_balancer_keepalive_pool_t **cpool);
++static ngx_int_t ngx_http_lua_balancer_build_default_pool_name(
++    ngx_http_request_t *r, ngx_http_upstream_t *u, ngx_peer_connection_t *pc,
++    ngx_http_lua_balancer_peer_data_t *bp);
++#if (NGX_HTTP_SSL)
++static ngx_int_t ngx_http_lua_upstream_get_ssl_name(ngx_http_request_t *r,
++    ngx_http_upstream_t *u);
++#endif
 +static void ngx_http_lua_balancer_free_keepalive_pool(ngx_log_t *log,
 +    ngx_http_lua_balancer_keepalive_pool_t *cpool);
 +static void ngx_http_lua_balancer_close(ngx_connection_t *c);
@@ -123,13 +136,13 @@ index af4da73..a284317 100644
 +
 +static char              ngx_http_lua_balancer_keepalive_pools_table_key;
 +static struct sockaddr  *ngx_http_lua_balancer_default_server_sockaddr;
-
-
+ 
+ 
  ngx_int_t
-@@ -102,6 +159,61 @@ ngx_http_lua_balancer_handler_inline(ngx_http_request_t *r,
+@@ -102,6 +172,61 @@ ngx_http_lua_balancer_handler_inline(ngx_http_request_t *r,
  }
-
-
+ 
+ 
 +static ngx_int_t
 +ngx_http_lua_balancer_by_chunk(lua_State *L, ngx_http_request_t *r)
 +{
@@ -188,7 +201,7 @@ index af4da73..a284317 100644
  char *
  ngx_http_lua_balancer_by_lua_block(ngx_conf_t *cf, ngx_command_t *cmd,
      void *conf)
-@@ -125,18 +237,20 @@ char *
+@@ -125,18 +250,20 @@ char *
  ngx_http_lua_balancer_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
      void *conf)
  {
@@ -206,24 +219,24 @@ index af4da73..a284317 100644
 +    ngx_url_t                          url;
 +    ngx_http_upstream_server_t        *us;
 +    ngx_http_lua_srv_conf_t           *lscf = conf;
-
+ 
      ngx_http_upstream_srv_conf_t      *uscf;
-
+ 
      dd("enter");
-
+ 
 -    /*  must specify a content handler */
 +    /* content handler setup */
      if (cmd->post == NULL) {
          return NGX_CONF_ERROR;
      }
-@@ -188,11 +302,40 @@ ngx_http_lua_balancer_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
-
+@@ -188,11 +315,40 @@ ngx_http_lua_balancer_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
+ 
      lscf->balancer.src_key = cache_key;
-
+ 
 +    /* balancer setup */
 +
      uscf = ngx_http_conf_get_module_srv_conf(cf, ngx_http_upstream_module);
-
+ 
 +    if (uscf->servers->nelts == 0) {
 +        us = ngx_array_push(uscf->servers);
 +        if (us == NULL) {
@@ -257,11 +270,11 @@ index af4da73..a284317 100644
 +        lscf->balancer.original_init_upstream =
 +            ngx_http_upstream_init_round_robin;
      }
-
+ 
      uscf->peer.init_upstream = ngx_http_lua_balancer_init;
-@@ -208,14 +351,18 @@ ngx_http_lua_balancer_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
-
-
+@@ -208,14 +364,18 @@ ngx_http_lua_balancer_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
+ 
+ 
  static ngx_int_t
 -ngx_http_lua_balancer_init(ngx_conf_t *cf,
 -    ngx_http_upstream_srv_conf_t *us)
@@ -275,21 +288,21 @@ index af4da73..a284317 100644
 +    if (lscf->balancer.original_init_upstream(cf, us) != NGX_OK) {
          return NGX_ERROR;
      }
-
+ 
 -    /* this callback is called upon individual requests */
 +    lscf->balancer.original_init_peer = us->peer.init;
 +
      us->peer.init = ngx_http_lua_balancer_init_peer;
-
+ 
      return NGX_OK;
-@@ -226,33 +373,38 @@ static ngx_int_t
+@@ -226,33 +386,38 @@ static ngx_int_t
  ngx_http_lua_balancer_init_peer(ngx_http_request_t *r,
      ngx_http_upstream_srv_conf_t *us)
  {
 -    ngx_http_lua_srv_conf_t            *bcf;
 +    ngx_http_lua_srv_conf_t            *lscf;
      ngx_http_lua_balancer_peer_data_t  *bp;
-
+ 
 -    bp = ngx_pcalloc(r->pool, sizeof(ngx_http_lua_balancer_peer_data_t));
 -    if (bp == NULL) {
 +    lscf = ngx_http_conf_upstream_srv_conf(us, ngx_http_lua_module);
@@ -297,7 +310,7 @@ index af4da73..a284317 100644
 +    if (lscf->balancer.original_init_peer(r, us) != NGX_OK) {
          return NGX_ERROR;
      }
-
+ 
 -    r->upstream->peer.data = &bp->rrp;
 -
 -    if (ngx_http_upstream_init_round_robin_peer(r, us) != NGX_OK) {
@@ -305,7 +318,7 @@ index af4da73..a284317 100644
 +    if (bp == NULL) {
          return NGX_ERROR;
      }
-
+ 
 +    bp->conf = lscf;
 +    bp->request = r;
 +    bp->data = r->upstream->peer.data;
@@ -315,7 +328,7 @@ index af4da73..a284317 100644
 +    r->upstream->peer.data = bp;
      r->upstream->peer.get = ngx_http_lua_balancer_get_peer;
      r->upstream->peer.free = ngx_http_lua_balancer_free_peer;
-
+ 
  #if (NGX_HTTP_SSL)
 +    bp->original_set_session = r->upstream->peer.set_session;
 +    bp->original_save_session = r->upstream->peer.save_session;
@@ -323,7 +336,7 @@ index af4da73..a284317 100644
      r->upstream->peer.set_session = ngx_http_lua_balancer_set_session;
      r->upstream->peer.save_session = ngx_http_lua_balancer_save_session;
  #endif
-
+ 
 -    bcf = ngx_http_conf_upstream_srv_conf(us, ngx_http_lua_module);
 -
 -    bp->conf = bcf;
@@ -331,8 +344,8 @@ index af4da73..a284317 100644
 -
      return NGX_OK;
  }
-
-@@ -260,25 +412,26 @@ ngx_http_lua_balancer_init_peer(ngx_http_request_t *r,
+ 
+@@ -260,25 +425,28 @@ ngx_http_lua_balancer_init_peer(ngx_http_request_t *r,
  static ngx_int_t
  ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
  {
@@ -348,43 +361,47 @@ index af4da73..a284317 100644
 +    ngx_queue_t                            *q;
 +    ngx_connection_t                       *c;
 +    ngx_http_request_t                     *r;
++    ngx_http_upstream_t                    *u;
 +    ngx_http_lua_ctx_t                     *ctx;
 +    ngx_http_lua_srv_conf_t                *lscf;
 +    ngx_http_lua_balancer_keepalive_item_t *item;
 +    ngx_http_lua_balancer_peer_data_t      *bp = data;
 +    void                                   *pdata;
-
+ 
      ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
 -                   "lua balancer peer, tries: %ui", pc->tries);
 -
 -    lscf = bp->conf;
 +                   "lua balancer: get peer, tries: %ui", pc->tries);
-
+ 
      r = bp->request;
++    u = r->upstream;
 +    lscf = bp->conf;
-
+ 
      ngx_http_lua_assert(lscf->balancer.handler && r);
-
+ 
      ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
 -
      if (ctx == NULL) {
          ctx = ngx_http_lua_create_ctx(r);
          if (ctx == NULL) {
-@@ -296,21 +449,24 @@ ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
-
+@@ -296,21 +464,26 @@ ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
+ 
      ctx->context = NGX_HTTP_LUA_CONTEXT_BALANCER;
-
+ 
 +    bp->cpool = NULL;
      bp->sockaddr = NULL;
      bp->socklen = 0;
      bp->more_tries = 0;
-+    bp->cpool_crc32 = 0;
++    ngx_str_null(&bp->cpool_name);
++    bp->cpool_set = 0;
 +    bp->cpool_size = 0;
++    ngx_str_null(&bp->host);
 +    bp->keepalive_requests = 0;
 +    bp->keepalive_timeout = 0;
 +    bp->keepalive = 0;
      bp->total_tries++;
-
+ 
 -    lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
 -
 -    /* balancer_by_lua does not support yielding and
@@ -394,131 +411,100 @@ index af4da73..a284317 100644
 -    lmcf->balancer_peer_data = bp;
 +    pdata = r->upstream->peer.data;
 +    r->upstream->peer.data = bp;
-
+ 
      rc = lscf->balancer.handler(r, lscf, L);
-
+ 
 +    r->upstream->peer.data = pdata;
 +
      if (rc == NGX_ERROR) {
          return NGX_ERROR;
      }
-@@ -332,79 +488,87 @@ ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
+@@ -332,105 +505,444 @@ ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
          }
      }
-
+ 
 -    if (bp->sockaddr && bp->socklen) {
 +    if (ngx_http_lua_balancer_peer_set(bp)) {
          pc->sockaddr = bp->sockaddr;
          pc->socklen = bp->socklen;
-+        pc->name = bp->host;
++        pc->name = bp->host.len ? &bp->host : bp->addr_text;
          pc->cached = 0;
          pc->connection = NULL;
 -        pc->name = bp->host;
 -
 -        bp->rrp.peers->single = 0;
-
+ 
          if (bp->more_tries) {
              r->upstream->peer.tries += bp->more_tries;
          }
-
+ 
 -        dd("tries: %d", (int) r->upstream->peer.tries);
--
--        return NGX_OK;
--    }
--
--    return ngx_http_upstream_get_round_robin_peer(pc, &bp->rrp);
--}
 +        if (ngx_http_lua_balancer_keepalive_is_enabled(bp)) {
-+            ngx_http_lua_balancer_get_keepalive_pool(L, bp->cpool_crc32,
++            if (!bp->cpool_set
++                && ngx_http_lua_balancer_build_default_pool_name(r, u, pc, bp)
++                   != NGX_OK)
++            {
++                return NGX_ERROR;
++            }
++
++            ngx_http_lua_balancer_get_keepalive_pool(L, &bp->cpool_name,
 +                                                     &bp->cpool);
-
++
 +            if (bp->cpool == NULL
 +                && ngx_http_lua_balancer_create_keepalive_pool(L, pc->log,
-+                                                               bp->cpool_crc32,
++                                                               &bp->cpool_name,
 +                                                               bp->cpool_size,
 +                                                               &bp->cpool)
 +                   != NGX_OK)
 +            {
 +                return NGX_ERROR;
 +            }
-
--static ngx_int_t
--ngx_http_lua_balancer_by_chunk(lua_State *L, ngx_http_request_t *r)
--{
--    u_char                  *err_msg;
--    size_t                   len;
--    ngx_int_t                rc;
++
 +            ngx_http_lua_assert(bp->cpool);
-
--    /* init nginx context in Lua VM */
--    ngx_http_lua_set_req(L, r);
++
 +            if (!ngx_queue_empty(&bp->cpool->cache)) {
 +                q = ngx_queue_head(&bp->cpool->cache);
-
--#ifndef OPENRESTY_LUAJIT
--    ngx_http_lua_create_new_globals_table(L, 0 /* narr */, 1 /* nrec */);
++
 +                item = ngx_queue_data(q, ngx_http_lua_balancer_keepalive_item_t,
 +                                      queue);
 +                c = item->connection;
-
--    /*  {{{ make new env inheriting main thread's globals table */
--    lua_createtable(L, 0, 1 /* nrec */);   /* the metatable for the new env */
--    ngx_http_lua_get_globals_table(L);
--    lua_setfield(L, -2, "__index");
--    lua_setmetatable(L, -2);    /*  setmetatable({}, {__index = _G}) */
--    /*  }}} */
++
 +                ngx_queue_remove(q);
 +                ngx_queue_insert_head(&bp->cpool->free, q);
-
--    lua_setfenv(L, -2);    /*  set new running env for the code closure */
--#endif /* OPENRESTY_LUAJIT */
++
 +                c->idle = 0;
 +                c->sent = 0;
 +                c->log = pc->log;
 +                c->read->log = pc->log;
 +                c->write->log = pc->log;
 +                c->pool->log = pc->log;
-
--    lua_pushcfunction(L, ngx_http_lua_traceback);
--    lua_insert(L, 1);  /* put it under chunk and args */
++
 +                if (c->read->timer_set) {
 +                    ngx_del_timer(c->read);
 +                }
-
--    /*  protected call user code */
--    rc = lua_pcall(L, 0, 1, 1);
++
 +                pc->cached = 1;
 +                pc->connection = c;
-
--    lua_remove(L, 1);  /* remove traceback function */
++
 +                ngx_log_debug3(NGX_LOG_DEBUG_HTTP, pc->log, 0,
 +                               "lua balancer: keepalive reusing connection %p, "
 +                               "requests: %ui, cpool: %p",
 +                               c, c->requests, bp->cpool);
-
--    dd("rc == %d", (int) rc);
++
 +                return NGX_DONE;
 +            }
-
--    if (rc != 0) {
--        /*  error occurred when running loaded code */
--        err_msg = (u_char *) lua_tolstring(L, -1, &len);
++
 +            bp->cpool->connections++;
-
--        if (err_msg == NULL) {
--            err_msg = (u_char *) "unknown reason";
--            len = sizeof("unknown reason") - 1;
++
 +            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
 +                           "lua balancer: keepalive no free connection, "
 +                           "cpool: %p", bp->cpool);
-         }
-
--        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
--                      "failed to run balancer_by_lua*: %*s", len, err_msg);
-+        return NGX_OK;
-+    }
-
--        lua_settop(L, 0); /*  clear remaining elems on stack */
++        }
+ 
+         return NGX_OK;
+     }
+ 
+-    return ngx_http_upstream_get_round_robin_peer(pc, &bp->rrp);
 +    rc = bp->original_get_peer(pc, bp->data);
 +    if (rc == NGX_ERROR) {
 +        return rc;
@@ -527,44 +513,62 @@ index af4da73..a284317 100644
 +    if (pc->sockaddr == ngx_http_lua_balancer_default_server_sockaddr) {
 +        ngx_log_error(NGX_LOG_ERR, pc->log, 0,
 +                      "lua balancer: no peer set");
-
-         return NGX_ERROR;
-     }
-
--    lua_settop(L, 0); /*  clear remaining elems on stack */
-     return rc;
++
++        return NGX_ERROR;
++    }
++
++    return rc;
  }
-
-@@ -413,24 +577,335 @@ static void
- ngx_http_lua_balancer_free_peer(ngx_peer_connection_t *pc, void *data,
-     ngx_uint_t state)
+ 
+ 
+-static ngx_int_t
+-ngx_http_lua_balancer_by_chunk(lua_State *L, ngx_http_request_t *r)
++static void
++ngx_http_lua_balancer_free_peer(ngx_peer_connection_t *pc, void *data,
++    ngx_uint_t state)
  {
--    ngx_http_lua_balancer_peer_data_t  *bp = data;
+-    u_char                  *err_msg;
+-    size_t                   len;
+-    ngx_int_t                rc;
 +    ngx_queue_t                                *q;
 +    ngx_connection_t                           *c;
 +    ngx_http_upstream_t                        *u;
 +    ngx_http_lua_balancer_keepalive_item_t     *item;
 +    ngx_http_lua_balancer_keepalive_pool_t     *cpool;
 +    ngx_http_lua_balancer_peer_data_t          *bp = data;
-
-     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
--                   "lua balancer free peer, tries: %ui", pc->tries);
+ 
+-    /* init nginx context in Lua VM */
+-    ngx_http_lua_set_req(L, r);
++    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
 +                   "lua balancer: free peer, tries: %ui", pc->tries);
-+
+ 
+-#ifndef OPENRESTY_LUAJIT
+-    ngx_http_lua_create_new_globals_table(L, 0 /* narr */, 1 /* nrec */);
 +    u = bp->request->upstream;
 +    c = pc->connection;
-
--    if (bp->sockaddr && bp->socklen) {
+ 
+-    /*  {{{ make new env inheriting main thread's globals table */
+-    lua_createtable(L, 0, 1 /* nrec */);   /* the metatable for the new env */
+-    ngx_http_lua_get_globals_table(L);
+-    lua_setfield(L, -2, "__index");
+-    lua_setmetatable(L, -2);    /*  setmetatable({}, {__index = _G}) */
+-    /*  }}} */
 +    if (ngx_http_lua_balancer_peer_set(bp)) {
-         bp->last_peer_state = (int) state;
-
-         if (pc->tries) {
-             pc->tries--;
-         }
-
++        bp->last_peer_state = (int) state;
+ 
+-    lua_setfenv(L, -2);    /*  set new running env for the code closure */
+-#endif /* OPENRESTY_LUAJIT */
++        if (pc->tries) {
++            pc->tries--;
++        }
+ 
+-    lua_pushcfunction(L, ngx_http_lua_traceback);
+-    lua_insert(L, 1);  /* put it under chunk and args */
 +        if (ngx_http_lua_balancer_keepalive_is_enabled(bp)) {
 +            cpool = bp->cpool;
-+
+ 
+-    /*  protected call user code */
+-    rc = lua_pcall(L, 0, 1, 1);
 +            if (state & NGX_PEER_FAILED
 +                || c == NULL
 +                || c->read->eof
@@ -575,21 +579,29 @@ index af4da73..a284317 100644
 +            {
 +                goto invalid;
 +            }
-+
+ 
+-    lua_remove(L, 1);  /* remove traceback function */
 +            if (bp->keepalive_requests
 +                && c->requests >= bp->keepalive_requests)
 +            {
 +                goto invalid;
 +            }
-+
+ 
+-    dd("rc == %d", (int) rc);
 +            if (!u->keepalive) {
 +                goto invalid;
 +            }
-+
+ 
+-    if (rc != 0) {
+-        /*  error occurred when running loaded code */
+-        err_msg = (u_char *) lua_tolstring(L, -1, &len);
 +            if (!u->request_body_sent) {
 +                goto invalid;
 +            }
-+
+ 
+-        if (err_msg == NULL) {
+-            err_msg = (u_char *) "unknown reason";
+-            len = sizeof("unknown reason") - 1;
 +            if (ngx_terminate || ngx_exiting) {
 +                goto invalid;
 +            }
@@ -666,18 +678,21 @@ index af4da73..a284317 100644
 +            if (cpool->connections == 0) {
 +                ngx_http_lua_balancer_free_keepalive_pool(pc->log, cpool);
 +            }
-+        }
-+
+         }
+ 
+-        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+-                      "failed to run balancer_by_lua*: %*s", len, err_msg);
 +        return;
 +    }
-+
+ 
+-        lua_settop(L, 0); /*  clear remaining elems on stack */
 +    bp->original_free_peer(pc, bp->data, state);
 +}
 +
 +
 +static ngx_int_t
 +ngx_http_lua_balancer_create_keepalive_pool(lua_State *L, ngx_log_t *log,
-+    uint32_t cpool_crc32, ngx_uint_t cpool_size,
++    ngx_str_t *cpool_name, ngx_uint_t cpool_size,
 +    ngx_http_lua_balancer_keepalive_pool_t **cpool)
 +{
 +    size_t                                       size;
@@ -693,29 +708,40 @@ index af4da73..a284317 100644
 +    ngx_http_lua_assert(lua_istable(L, -1));
 +
 +    size = sizeof(ngx_http_lua_balancer_keepalive_pool_t)
-+           + sizeof(ngx_http_lua_balancer_keepalive_item_t) * cpool_size;
++           + sizeof(ngx_http_lua_balancer_keepalive_item_t) * cpool_size
++           + cpool_name->len;
 +
-+    upool = lua_newuserdata(L, size); /* pools upool */
++    lua_pushlstring(L, (const char *) cpool_name->data, cpool_name->len);
++    /* pools name */
+ 
++    upool = lua_newuserdata(L, size); /* pools name upool */
 +    if (upool == NULL) {
-+        return NGX_ERROR;
-+    }
-+
+         return NGX_ERROR;
+     }
+ 
+-    lua_settop(L, 0); /*  clear remaining elems on stack */
+-    return rc;
 +    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, log, 0,
-+                   "lua balancer: keepalive create pool, crc32: %ui, "
-+                   "size: %ui", cpool_crc32, cpool_size);
++                   "lua balancer: keepalive create pool, name: %V, "
++                   "size: %ui", cpool_name, cpool_size);
 +
 +    upool->lua_vm = L;
-+    upool->crc32 = cpool_crc32;
 +    upool->size = cpool_size;
 +    upool->connections = 0;
++
++    items = (ngx_http_lua_balancer_keepalive_item_t *) (&upool->free + 1);
++
++    /* store a copy of the pool name in the same userdata allocation so
++     * that the pool can be removed from the registry table on free */
++    upool->cpool_name.data = (u_char *) (items + cpool_size);
++    upool->cpool_name.len = cpool_name->len;
++    ngx_memcpy(upool->cpool_name.data, cpool_name->data, cpool_name->len);
 +
 +    ngx_queue_init(&upool->cache);
 +    ngx_queue_init(&upool->free);
 +
-+    lua_rawseti(L, -2, cpool_crc32); /* pools */
++    lua_rawset(L, -3); /* pools */
 +    lua_pop(L, 1); /* orig stack */
-+
-+    items = (ngx_http_lua_balancer_keepalive_item_t *) (&upool->free + 1);
 +
 +    for (i = 0; i < cpool_size; i++) {
 +        ngx_queue_insert_head(&upool->free, &items[i].queue);
@@ -725,13 +751,16 @@ index af4da73..a284317 100644
 +    *cpool = upool;
 +
 +    return NGX_OK;
-+}
-+
-+
-+static void
-+ngx_http_lua_balancer_get_keepalive_pool(lua_State *L, uint32_t cpool_crc32,
+ }
+ 
+ 
+ static void
+-ngx_http_lua_balancer_free_peer(ngx_peer_connection_t *pc, void *data,
+-    ngx_uint_t state)
++ngx_http_lua_balancer_get_keepalive_pool(lua_State *L, ngx_str_t *cpool_name,
 +    ngx_http_lua_balancer_keepalive_pool_t **cpool)
-+{
+ {
+-    ngx_http_lua_balancer_peer_data_t  *bp = data;
 +    ngx_http_lua_balancer_keepalive_pool_t      *upool;
 +
 +    /* get upstream connection pools table */
@@ -749,13 +778,21 @@ index af4da73..a284317 100644
 +        lua_pushvalue(L, -2); /* pools pools_table_key pools */
 +        lua_rawset(L, LUA_REGISTRYINDEX); /* pools */
 +    }
-+
+ 
+-    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+-                   "lua balancer free peer, tries: %ui", pc->tries);
 +    ngx_http_lua_assert(lua_istable(L, -1));
-+
-+    lua_rawgeti(L, -1, cpool_crc32); /* pools upool? */
+ 
+-    if (bp->sockaddr && bp->socklen) {
+-        bp->last_peer_state = (int) state;
++    lua_pushlstring(L, (const char *) cpool_name->data, cpool_name->len);
++    /* pools name */
++    lua_rawget(L, -2); /* pools upool? */
 +    upool = lua_touserdata(L, -1);
 +    lua_pop(L, 2); /* orig stack */
-+
+ 
+-        if (pc->tries) {
+-            pc->tries--;
 +    *cpool = upool;
 +}
 +
@@ -767,8 +804,8 @@ index af4da73..a284317 100644
 +    lua_State                             *L;
 +
 +    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, log, 0,
-+                   "lua balancer: keepalive free pool %p, crc32: %ui",
-+                   cpool, cpool->crc32);
++                   "lua balancer: keepalive free pool %p, name: %V",
++                   cpool, &cpool->cpool_name);
 +
 +    ngx_http_lua_assert(cpool->connections == 0);
 +
@@ -781,15 +818,15 @@ index af4da73..a284317 100644
 +
 +    if (lua_isnil(L, -1)) {
 +        lua_pop(L, 1); /* orig stack */
-         return;
-     }
-
--    /* fallback */
++        return;
++    }
++
 +    ngx_http_lua_assert(lua_istable(L, -1));
-
--    ngx_http_upstream_free_round_robin_peer(pc, data, state);
-+    lua_pushnil(L); /* pools nil */
-+    lua_rawseti(L, -2, cpool->crc32); /* pools */
++
++    lua_pushlstring(L, (const char *) cpool->cpool_name.data,
++                    cpool->cpool_name.len); /* pools name */
++    lua_pushnil(L); /* pools name nil */
++    lua_rawset(L, -3); /* pools */
 +    lua_pop(L, 1); /* orig stack */
 +}
 +
@@ -855,11 +892,12 @@ index af4da73..a284317 100644
 +
 +        if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
 +            goto close;
-+        }
-+
-+        return;
-+    }
-+
+         }
+ 
+         return;
+     }
+ 
+-    /* fallback */
 +close:
 +
 +    item = c->data;
@@ -869,50 +907,53 @@ index af4da73..a284317 100644
 +
 +    ngx_queue_remove(&item->queue);
 +    ngx_queue_insert_head(&item->cpool->free, &item->queue);
-+
+ 
+-    ngx_http_upstream_free_round_robin_peer(pc, data, state);
 +    if (item->cpool->connections == 0) {
 +        ngx_http_lua_balancer_free_keepalive_pool(ev->log, item->cpool);
 +    }
  }
-
-
-@@ -441,12 +916,12 @@ ngx_http_lua_balancer_set_session(ngx_peer_connection_t *pc, void *data)
+ 
+ 
+@@ -441,12 +953,12 @@ ngx_http_lua_balancer_set_session(ngx_peer_connection_t *pc, void *data)
  {
      ngx_http_lua_balancer_peer_data_t  *bp = data;
-
+ 
 -    if (bp->sockaddr && bp->socklen) {
 +    if (ngx_http_lua_balancer_peer_set(bp)) {
          /* TODO */
          return NGX_OK;
      }
-
+ 
 -    return ngx_http_upstream_set_round_robin_peer_session(pc, &bp->rrp);
 +    return bp->original_set_session(pc, bp->data);
  }
-
-
-@@ -455,13 +930,12 @@ ngx_http_lua_balancer_save_session(ngx_peer_connection_t *pc, void *data)
+ 
+ 
+@@ -455,13 +967,12 @@ ngx_http_lua_balancer_save_session(ngx_peer_connection_t *pc, void *data)
  {
      ngx_http_lua_balancer_peer_data_t  *bp = data;
-
+ 
 -    if (bp->sockaddr && bp->socklen) {
 +    if (ngx_http_lua_balancer_peer_set(bp)) {
          /* TODO */
          return;
      }
-
+ 
 -    ngx_http_upstream_save_round_robin_peer_session(pc, &bp->rrp);
 -    return;
 +    bp->original_save_session(pc, bp->data);
  }
-
+ 
  #endif
-@@ -469,14 +943,13 @@ ngx_http_lua_balancer_save_session(ngx_peer_connection_t *pc, void *data)
-
+@@ -469,14 +980,15 @@ ngx_http_lua_balancer_save_session(ngx_peer_connection_t *pc, void *data)
+ 
  int
  ngx_http_lua_ffi_balancer_set_current_peer(ngx_http_request_t *r,
 -    const u_char *addr, size_t addr_len, int port, char **err)
-+    const u_char *addr, size_t addr_len, int port, unsigned int cpool_crc32,
++    const u_char *addr, size_t addr_len, int port,
++    const u_char *host, size_t host_len,
++    const u_char *cpool_name, size_t cpool_name_len,
 +    unsigned int cpool_size, char **err)
  {
 -    ngx_url_t              url;
@@ -925,13 +966,13 @@ index af4da73..a284317 100644
 +    ngx_http_upstream_t                     *u;
 +    ngx_http_lua_ctx_t                      *ctx;
 +    ngx_http_lua_balancer_peer_data_t       *bp;
-
+ 
      if (r == NULL) {
          *err = "no request found";
-@@ -501,18 +974,6 @@ ngx_http_lua_ffi_balancer_set_current_peer(ngx_http_request_t *r,
+@@ -501,18 +1013,6 @@ ngx_http_lua_ffi_balancer_set_current_peer(ngx_http_request_t *r,
          return NGX_ERROR;
      }
-
+ 
 -    lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
 -
 -    /* we cannot read r->upstream->peer.data here directly because
@@ -945,22 +986,61 @@ index af4da73..a284317 100644
 -    }
 -
      ngx_memzero(&url, sizeof(ngx_url_t));
-
+ 
      url.url.data = ngx_palloc(r->pool, addr_len);
-@@ -536,6 +997,8 @@ ngx_http_lua_ffi_balancer_set_current_peer(ngx_http_request_t *r,
+@@ -536,16 +1036,106 @@ ngx_http_lua_ffi_balancer_set_current_peer(ngx_http_request_t *r,
          return NGX_ERROR;
      }
-
+ 
 +    bp = (ngx_http_lua_balancer_peer_data_t *) u->peer.data;
 +
      if (url.addrs && url.addrs[0].sockaddr) {
          bp->sockaddr = url.addrs[0].sockaddr;
          bp->socklen = url.addrs[0].socklen;
-@@ -546,6 +1009,59 @@ ngx_http_lua_ffi_balancer_set_current_peer(ngx_http_request_t *r,
+-        bp->host = &url.addrs[0].name;
++        bp->addr_text = &url.addrs[0].name;
+ 
+     } else {
+         *err = "no host allowed";
          return NGX_ERROR;
      }
-
-+    bp->cpool_crc32 = (uint32_t) cpool_crc32;
+ 
++    if (host && host_len) {
++        bp->host.data = ngx_palloc(r->pool, host_len);
++        if (bp->host.data == NULL) {
++            *err = "no memory";
++            return NGX_ERROR;
++        }
++
++        ngx_memcpy(bp->host.data, host, host_len);
++        bp->host.len = host_len;
++
++#if (NGX_HTTP_SSL)
++        if (u->ssl) {
++            u->ssl_name = bp->host;
++        }
++#endif
++
++    } else {
++        ngx_str_null(&bp->host);
++    }
++
++    if (cpool_name && cpool_name_len) {
++        bp->cpool_name.data = ngx_palloc(r->pool, cpool_name_len);
++        if (bp->cpool_name.data == NULL) {
++            *err = "no memory";
++            return NGX_ERROR;
++        }
++
++        ngx_memcpy(bp->cpool_name.data, cpool_name, cpool_name_len);
++        bp->cpool_name.len = cpool_name_len;
++        bp->cpool_set = 1;
++
++    } else {
++        ngx_str_null(&bp->cpool_name);
++        bp->cpool_set = 0;
++    }
++
 +    bp->cpool_size = (ngx_uint_t) cpool_size;
 +
 +    return NGX_OK;
@@ -1005,9 +1085,9 @@ index af4da73..a284317 100644
 +        return NGX_ERROR;
 +    }
 +
-+    if (!bp->cpool_crc32) {
-+        bp->cpool_crc32 = ngx_crc32_long(bp->host->data, bp->host->len);
-+    }
++    /* when no explicit pool was given, the default pool identity is
++     * derived in ngx_http_lua_balancer_get_peer, where the local bind
++     * address and the TLS server name are finally known */
 +
 +    bp->keepalive_timeout = (ngx_msec_t) timeout;
 +    bp->keepalive_requests = (ngx_uint_t) max_requests;
@@ -1015,8 +1095,8 @@ index af4da73..a284317 100644
 +
      return NGX_OK;
  }
-
-@@ -555,14 +1071,13 @@ ngx_http_lua_ffi_balancer_set_timeouts(ngx_http_request_t *r,
+ 
+@@ -555,14 +1145,13 @@ ngx_http_lua_ffi_balancer_set_timeouts(ngx_http_request_t *r,
      long connect_timeout, long send_timeout, long read_timeout,
      char **err)
  {
@@ -1024,20 +1104,20 @@ index af4da73..a284317 100644
 -    ngx_http_upstream_t   *u;
 +    ngx_http_lua_ctx_t                 *ctx;
 +    ngx_http_upstream_t                *u;
-
+ 
  #if !(HAVE_NGX_UPSTREAM_TIMEOUT_FIELDS)
      ngx_http_upstream_conf_t           *ucf;
 -#endif
 -    ngx_http_lua_main_conf_t           *lmcf;
      ngx_http_lua_balancer_peer_data_t  *bp;
 +#endif
-
+ 
      if (r == NULL) {
          *err = "no request found";
-@@ -587,15 +1102,9 @@ ngx_http_lua_ffi_balancer_set_timeouts(ngx_http_request_t *r,
+@@ -587,15 +1176,9 @@ ngx_http_lua_ffi_balancer_set_timeouts(ngx_http_request_t *r,
          return NGX_ERROR;
      }
-
+ 
 -    lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
 -
 -    bp = lmcf->balancer_peer_data;
@@ -1052,7 +1132,7 @@ index af4da73..a284317 100644
      if (!bp->cloned_upstream_conf) {
          /* we clone the upstream conf for the current request so that
           * we do not affect other requests at all. */
-@@ -650,12 +1159,10 @@ ngx_http_lua_ffi_balancer_set_more_tries(ngx_http_request_t *r,
+@@ -650,12 +1233,10 @@ ngx_http_lua_ffi_balancer_set_more_tries(ngx_http_request_t *r,
      int count, char **err)
  {
  #if (nginx_version >= 1007005)
@@ -1066,12 +1146,12 @@ index af4da73..a284317 100644
 +    ngx_http_lua_ctx_t                 *ctx;
 +    ngx_http_upstream_t                *u;
      ngx_http_lua_balancer_peer_data_t  *bp;
-
+ 
      if (r == NULL) {
-@@ -681,13 +1188,7 @@ ngx_http_lua_ffi_balancer_set_more_tries(ngx_http_request_t *r,
+@@ -681,13 +1262,7 @@ ngx_http_lua_ffi_balancer_set_more_tries(ngx_http_request_t *r,
          return NGX_ERROR;
      }
-
+ 
 -    lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
 -
 -    bp = lmcf->balancer_peer_data;
@@ -1080,10 +1160,10 @@ index af4da73..a284317 100644
 -        return NGX_ERROR;
 -    }
 +    bp = (ngx_http_lua_balancer_peer_data_t *) u->peer.data;
-
+ 
  #if (nginx_version >= 1007005)
      max_tries = r->upstream->conf->next_upstream_tries;
-@@ -713,12 +1214,10 @@ int
+@@ -713,12 +1288,10 @@ int
  ngx_http_lua_ffi_balancer_get_last_failure(ngx_http_request_t *r,
      int *status, char **err)
  {
@@ -1096,13 +1176,13 @@ index af4da73..a284317 100644
 +    ngx_http_upstream_state_t          *state;
      ngx_http_lua_balancer_peer_data_t  *bp;
 -    ngx_http_lua_main_conf_t           *lmcf;
-
+ 
      if (r == NULL) {
          *err = "no request found";
-@@ -743,13 +1242,7 @@ ngx_http_lua_ffi_balancer_get_last_failure(ngx_http_request_t *r,
+@@ -743,13 +1316,7 @@ ngx_http_lua_ffi_balancer_get_last_failure(ngx_http_request_t *r,
          return NGX_ERROR;
      }
-
+ 
 -    lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
 -
 -    bp = lmcf->balancer_peer_data;
@@ -1111,9 +1191,132 @@ index af4da73..a284317 100644
 -        return NGX_ERROR;
 -    }
 +    bp = (ngx_http_lua_balancer_peer_data_t *) u->peer.data;
-
+ 
      if (r->upstream_states && r->upstream_states->nelts > 1) {
          state = r->upstream_states->elts;
+@@ -809,4 +1376,122 @@ ngx_http_lua_ffi_balancer_recreate_request(ngx_http_request_t *r,
+ }
+ 
+ 
++#if (NGX_HTTP_SSL)
++static ngx_int_t
++ngx_http_lua_upstream_get_ssl_name(ngx_http_request_t *r,
++    ngx_http_upstream_t *u)
++{
++    u_char     *p, *last;
++    ngx_str_t   name;
++
++    if (u->conf->ssl_name) {
++        if (ngx_http_complex_value(r, u->conf->ssl_name, &name) != NGX_OK) {
++            return NGX_ERROR;
++        }
++
++    } else {
++        name = u->ssl_name;
++    }
++
++    if (name.len == 0) {
++        goto done;
++    }
++
++    /*
++     * ssl name here may contain port, notably if derived from $proxy_host
++     * or $http_host; we have to strip it. eg: www.example.com:443
++     */
++
++    p = name.data;
++    last = name.data + name.len;
++
++    if (*p == '[') {
++        p = ngx_strlchr(p, last, ']');
++
++        if (p == NULL) {
++            p = name.data;
++        }
++    }
++
++    p = ngx_strlchr(p, last, ':');
++
++    if (p != NULL) {
++        name.len = p - name.data;
++    }
++
++done:
++
++    u->ssl_name = name;
++
++    return NGX_OK;
++}
++#endif
++
++
++static ngx_int_t
++ngx_http_lua_balancer_build_default_pool_name(ngx_http_request_t *r,
++    ngx_http_upstream_t *u, ngx_peer_connection_t *pc,
++    ngx_http_lua_balancer_peer_data_t *bp)
++{
++    size_t      len;
++    u_char     *p;
++    unsigned    tls = 0;
++    ngx_str_t   ssl_name = ngx_null_string;
++
++    /*
++     * the default pool identity must cover every property that is only
++     * applied when the connection is established: the remote address,
++     * the local bind address, the host given to set_current_peer and the
++     * TLS server name; otherwise an idle connection created with
++     * different properties could be reused
++     */
++
++    if (bp->host.len) {
++        ssl_name = bp->host;
++    }
++
++#if (NGX_HTTP_SSL)
++    if (u->ssl) {
++        tls = 1;
++
++        if (ssl_name.len == 0) {
++            if (ngx_http_lua_upstream_get_ssl_name(r, u) != NGX_OK) {
++                return NGX_ERROR;
++            }
++
++            ssl_name = u->ssl_name;
++        }
++    }
++#endif
++
++    len = bp->addr_text->len + 1
++          + (pc->local ? pc->local->name.len : 0) + 1
++          + 1 /* tls flag */ + 1
++          + ssl_name.len;
++
++    p = ngx_pnalloc(r->pool, len);
++    if (p == NULL) {
++        return NGX_ERROR;
++    }
++
++    bp->cpool_name.data = p;
++
++    p = ngx_copy(p, bp->addr_text->data, bp->addr_text->len);
++    *p++ = '|';
++
++    if (pc->local) {
++        p = ngx_copy(p, pc->local->name.data, pc->local->name.len);
++    }
++
++    *p++ = '|';
++    *p++ = tls ? '1' : '0';
++    *p++ = '|';
++
++    p = ngx_copy(p, ssl_name.data, ssl_name.len);
++
++    bp->cpool_name.len = p - bp->cpool_name.data;
++
++    return NGX_OK;
++}
++
+ /* vi:set ft=c ts=4 sw=4 et fdm=marker: */
 diff --git src/ngx_http_lua_common.h src/ngx_http_lua_common.h
 index 8435045..ea45f3a 100644
 --- src/ngx_http_lua_common.h

--- a/patch/1.29.2.4/lua-resty-core-enable_keepalive.patch
+++ b/patch/1.29.2.4/lua-resty-core-enable_keepalive.patch
@@ -1,32 +1,24 @@
 diff --git lib/ngx/balancer.lua lib/ngx/balancer.lua
-index 18bdc2c..3a98f53 100644
+index 18bdc2c..d43c354 100644
 --- lib/ngx/balancer.lua
 +++ lib/ngx/balancer.lua
-@@ -3,7 +3,7 @@
- 
+@@ -4,7 +4,6 @@
  local base = require "resty.core.base"
  base.allows_subsystem('http', 'stream')
--
-+require "resty.core.hash"
  
+-
  local ffi = require "ffi"
  local C = ffi.C
-@@ -20,6 +20,7 @@ local error = error
- local type = type
- local tonumber = tonumber
- local max = math.max
-+local ngx_crc32_long = ngx.crc32_long
- 
- local subsystem = ngx.config.subsystem
- local ngx_lua_ffi_balancer_set_current_peer
-@@ -35,8 +36,8 @@ if subsystem == 'http' then
+ local ffi_str = ffi.string
+@@ -35,8 +34,9 @@ if subsystem == 'http' then
      ffi.cdef[[
      int ngx_http_lua_ffi_balancer_set_current_peer(ngx_http_request_t *r,
          const unsigned char *addr, size_t addr_len, int port,
 -        const unsigned char *host, ssize_t host_len,
 -        char **err);
-+        unsigned int cpool_crc32, int cpool_set, unsigned int cpool_size,
-+        char **err);
++        const unsigned char *host, size_t host_len,
++        const unsigned char *cpool_name, size_t cpool_name_len,
++        unsigned int cpool_size, char **err);
  
      int ngx_http_lua_ffi_balancer_enable_keepalive(ngx_http_request_t *r,
          unsigned long timeout, unsigned int max_requests, char **err);
@@ -38,7 +30,7 @@ index 18bdc2c..3a98f53 100644
  local DEFAULT_KEEPALIVE_IDLE_TIMEOUT = 60000
  local DEFAULT_KEEPALIVE_MAX_REQUESTS = 100
  
-@@ -143,27 +144,67 @@ local peer_state_names = {
+@@ -143,27 +144,73 @@ local peer_state_names = {
  local _M = { version = base.version }
  
  if subsystem == "http" then
@@ -49,40 +41,47 @@ index 18bdc2c..3a98f53 100644
              error("no request found")
          end
  
-+        local pool_crc32
-+        local pool_set = 0
++        local host
++        local pool
 +        local pool_size
-+        if opts then
-+            if type(opts) ~= "table" then
++
++        if opts ~= nil then
++            local typ = type(opts)
++
++            if typ == "string" then
++                -- the documented set_current_peer(addr, port, host) form
++                host = opts
++
++            elseif typ == "table" then
++                pool = opts.pool
++                pool_size = opts.pool_size
++
++                if pool then
++                    if type(pool) ~= "string" then
++                        error("bad option 'pool' to 'set_current_peer' " ..
++                              "(string expected, got " ..
++                              type(pool) .. ")", 2)
++                    elseif pool == "" then
++                        error("bad option 'pool' to 'set_current_peer' " ..
++                              "(non-empty string expected)", 2)
++                    end
++                end
++
++                if pool_size then
++                    if type(pool_size) ~= "number" then
++                        error("bad option 'pool_size' to " ..
++                              "'set_current_peer' (number expected, got " ..
++                              type(pool_size) .. ")", 2)
++
++                    elseif pool_size < 1 then
++                        error("bad option 'pool_size' to " ..
++                              "'set_current_peer' (expected > 0)", 2)
++                    end
++                end
++
++            else
 +                error("bad argument #3 to 'set_current_peer' " ..
-+                      "(table expected, got " .. type(opts) .. ")", 2)
-+            end
-+
-+            local pool = opts.pool
-+            pool_size = opts.pool_size
-+
-+            if pool then
-+                if type(pool) ~= "string" then
-+                    error("bad option 'pool' to 'set_current_peer' " ..
-+                          "(string expected, got " .. type(pool) .. ")", 2)
-+                elseif pool == "" then
-+                    error("bad option 'pool' to 'set_current_peer' " ..
-+                          "(non-empty string expected)", 2)
-+                end
-+
-+                pool_crc32 = ngx_crc32_long(pool)
-+                pool_set = 1
-+            end
-+
-+            if pool_size then
-+                if type(pool_size) ~= "number" then
-+                    error("bad option 'pool_size' to 'set_current_peer' " ..
-+                          "(number expected, got " .. type(pool_size) .. ")", 2)
-+
-+                elseif pool_size < 1 then
-+                    error("bad option 'pool_size' to 'set_current_peer' " ..
-+                          "(expected > 0)", 2)
-+                end
++                      "(string or table expected, got " .. typ .. ")", 2)
 +            end
 +        end
 +
@@ -96,25 +95,22 @@ index 18bdc2c..3a98f53 100644
 -        if host ~= nil and type(host) ~= "string" then
 -            error("bad argument #3 to 'set_current_peer' "
 -                  .. "(string expected, got " .. type(host) .. ")")
-+        if not pool_crc32 then
-+            pool_crc32 = 0
++        if not pool_size then
++            pool_size = DEFAULT_KEEPALIVE_POOL_SIZE
          end
  
 -        local rc = ngx_lua_ffi_balancer_set_current_peer(r, addr, #addr,
 -                                                         port,
--                                                         host,
--                                                         host and #host or 0,
-+        if not pool_size then
-+            pool_size = DEFAULT_KEEPALIVE_POOL_SIZE
-+        end
-+
 +        local rc = ngx_lua_ffi_balancer_set_current_peer(r, addr, #addr, port,
-+                                                         pool_crc32, pool_set,
+                                                          host,
+                                                          host and #host or 0,
++                                                         pool,
++                                                         pool and #pool or 0,
 +                                                         pool_size,
                                                           errmsg)
          if rc == FFI_OK then
              return true
-@@ -172,26 +207,26 @@ if subsystem == "http" then
+@@ -172,26 +219,26 @@ if subsystem == "http" then
          return nil, ffi_str(errmsg[0])
      end
  else

--- a/patch/1.29.2.4/lua-resty-core-enable_keepalive.patch
+++ b/patch/1.29.2.4/lua-resty-core-enable_keepalive.patch
@@ -1,5 +1,5 @@
 diff --git lib/ngx/balancer.lua lib/ngx/balancer.lua
-index 18bdc2c..d43c354 100644
+index 18bdc2c..cd87245 100644
 --- lib/ngx/balancer.lua
 +++ lib/ngx/balancer.lua
 @@ -4,7 +4,6 @@
@@ -56,7 +56,7 @@ index 18bdc2c..d43c354 100644
 +                pool = opts.pool
 +                pool_size = opts.pool_size
 +
-+                if pool then
++                if pool ~= nil then
 +                    if type(pool) ~= "string" then
 +                        error("bad option 'pool' to 'set_current_peer' " ..
 +                              "(string expected, got " ..
@@ -67,7 +67,7 @@ index 18bdc2c..d43c354 100644
 +                    end
 +                end
 +
-+                if pool_size then
++                if pool_size ~= nil then
 +                    if type(pool_size) ~= "number" then
 +                        error("bad option 'pool_size' to " ..
 +                              "'set_current_peer' (number expected, got " ..

--- a/patch/1.29.2.4/ngx_lua-enable_keepalive.patch
+++ b/patch/1.29.2.4/ngx_lua-enable_keepalive.patch
@@ -1,8 +1,8 @@
 diff --git src/ngx_http_lua_balancer.c src/ngx_http_lua_balancer.c
-index ae0f1380..a51532da 100644
+index aa26a4a..a4b4d38 100644
 --- src/ngx_http_lua_balancer.c
 +++ src/ngx_http_lua_balancer.c
-@@ -31,10 +31,40 @@ typedef struct {
+@@ -31,10 +31,43 @@ typedef struct {
  } ngx_http_lua_balancer_ka_item_t; /*balancer keepalive item*/
  
  
@@ -10,7 +10,10 @@ index ae0f1380..a51532da 100644
 +    ngx_uint_t                               size;
 +    ngx_uint_t                               connections;
 +
-+    uint32_t                                 crc32;
++    /* the full pool name is the pool identity; a 32-bit digest such as
++     * crc32 must not be used here: colliding names would silently share
++     * connections across unrelated upstream pools */
++    ngx_str_t                                cpool_name;
 +
 +    lua_State                               *lua_vm;
 +
@@ -37,13 +40,13 @@ index ae0f1380..a51532da 100644
 +
 +    int                                 last_peer_state;
 +
-+    uint32_t                            cpool_crc32;
++    ngx_str_t                           cpool_name;
 +    unsigned                            cpool_set:1;
 +
      void                               *data;
  
      ngx_event_get_peer_pt               original_get_peer;
-@@ -45,20 +74,21 @@ struct ngx_http_lua_balancer_peer_data_s {
+@@ -45,20 +78,21 @@ struct ngx_http_lua_balancer_peer_data_s {
      ngx_event_save_peer_session_pt      original_save_session;
  #endif
  
@@ -58,7 +61,7 @@ index ae0f1380..a51532da 100644
  
 -    struct sockaddr                    *sockaddr;
 -    socklen_t                           socklen;
-+    ngx_str_t                          *host;
++    ngx_str_t                           host;
 +
      ngx_addr_t                         *local;
  
@@ -73,7 +76,7 @@ index ae0f1380..a51532da 100644
  
  #if !(HAVE_NGX_UPSTREAM_TIMEOUT_FIELDS)
      unsigned                            cloned_upstream_conf:1;
-@@ -73,10 +103,8 @@ static ngx_int_t ngx_http_lua_balancer_set_session(ngx_peer_connection_t *pc,
+@@ -73,10 +107,8 @@ static ngx_int_t ngx_http_lua_balancer_set_session(ngx_peer_connection_t *pc,
      void *data);
  static void ngx_http_lua_balancer_save_session(ngx_peer_connection_t *pc,
      void *data);
@@ -85,15 +88,22 @@ index ae0f1380..a51532da 100644
  static ngx_int_t ngx_http_lua_balancer_init(ngx_conf_t *cf,
      ngx_http_upstream_srv_conf_t *us);
  static ngx_int_t ngx_http_lua_balancer_init_peer(ngx_http_request_t *r,
-@@ -87,17 +115,28 @@ static ngx_int_t ngx_http_lua_balancer_by_chunk(lua_State *L,
+@@ -87,17 +119,35 @@ static ngx_int_t ngx_http_lua_balancer_by_chunk(lua_State *L,
      ngx_http_request_t *r);
  static void ngx_http_lua_balancer_free_peer(ngx_peer_connection_t *pc,
      void *data, ngx_uint_t state);
 +static ngx_int_t ngx_http_lua_balancer_create_keepalive_pool(lua_State *L,
-+    ngx_log_t *log, uint32_t cpool_crc32, ngx_uint_t cpool_size,
++    ngx_log_t *log, ngx_str_t *cpool_name, ngx_uint_t cpool_size,
 +    ngx_http_lua_balancer_keepalive_pool_t **cpool);
 +static void ngx_http_lua_balancer_get_keepalive_pool(lua_State *L,
-+    uint32_t cpool_crc32, ngx_http_lua_balancer_keepalive_pool_t **cpool);
++    ngx_str_t *cpool_name, ngx_http_lua_balancer_keepalive_pool_t **cpool);
++static ngx_int_t ngx_http_lua_balancer_build_default_pool_name(
++    ngx_http_request_t *r, ngx_http_upstream_t *u, ngx_peer_connection_t *pc,
++    ngx_http_lua_balancer_peer_data_t *bp);
++#if (NGX_HTTP_SSL)
++static ngx_int_t ngx_http_lua_upstream_get_ssl_name(ngx_http_request_t *r,
++    ngx_http_upstream_t *u);
++#endif
 +static void ngx_http_lua_balancer_free_keepalive_pool(ngx_log_t *log,
 +    ngx_http_lua_balancer_keepalive_pool_t *cpool);
  static void ngx_http_lua_balancer_notify_peer(ngx_peer_connection_t *pc,
@@ -118,7 +128,7 @@ index ae0f1380..a51532da 100644
  static struct sockaddr  *ngx_http_lua_balancer_default_server_sockaddr;
  
  
-@@ -181,7 +220,7 @@ ngx_http_lua_balancer_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
+@@ -181,7 +231,7 @@ ngx_http_lua_balancer_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
  
      dd("enter");
  
@@ -127,7 +137,7 @@ index ae0f1380..a51532da 100644
      if (cmd->post == NULL) {
          return NGX_CONF_ERROR;
      }
-@@ -246,6 +285,7 @@ ngx_http_lua_balancer_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
+@@ -246,6 +296,7 @@ ngx_http_lua_balancer_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
          ngx_memzero(us, sizeof(ngx_http_upstream_server_t));
          ngx_memzero(&url, sizeof(ngx_url_t));
  
@@ -135,7 +145,7 @@ index ae0f1380..a51532da 100644
          ngx_str_set(&url.url, "0.0.0.1");
          url.default_port = 80;
  
-@@ -261,8 +301,6 @@ ngx_http_lua_balancer_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
+@@ -261,8 +312,6 @@ ngx_http_lua_balancer_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
      }
  
      if (uscf->peer.init_upstream) {
@@ -144,7 +154,7 @@ index ae0f1380..a51532da 100644
  
          lscf->balancer.original_init_upstream = uscf->peer.init_upstream;
  
-@@ -286,16 +324,10 @@ ngx_http_lua_balancer_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
+@@ -286,16 +335,10 @@ ngx_http_lua_balancer_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
  static ngx_int_t
  ngx_http_lua_balancer_init(ngx_conf_t *cf, ngx_http_upstream_srv_conf_t *us)
  {
@@ -161,7 +171,7 @@ index ae0f1380..a51532da 100644
      if (lscf->balancer.original_init_upstream(cf, us) != NGX_OK) {
          return NGX_ERROR;
      }
-@@ -304,38 +336,6 @@ ngx_http_lua_balancer_init(ngx_conf_t *cf, ngx_http_upstream_srv_conf_t *us)
+@@ -304,38 +347,6 @@ ngx_http_lua_balancer_init(ngx_conf_t *cf, ngx_http_upstream_srv_conf_t *us)
  
      us->peer.init = ngx_http_lua_balancer_init_peer;
  
@@ -200,23 +210,32 @@ index ae0f1380..a51532da 100644
      return NGX_OK;
  }
  
-@@ -387,6 +387,7 @@ ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
+@@ -387,22 +398,20 @@ ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
      void                               *pdata;
      lua_State                          *L;
      ngx_int_t                           rc;
 +    ngx_queue_t                        *q;
      ngx_connection_t                   *c;
      ngx_http_request_t                 *r;
- #if (NGX_HTTP_SSL)
-@@ -394,6 +395,7 @@ ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
- #endif
+-#if (NGX_HTTP_SSL)
+     ngx_http_upstream_t                *u;
+-#endif
      ngx_http_lua_ctx_t                 *ctx;
      ngx_http_lua_srv_conf_t            *lscf;
 +    ngx_http_lua_balancer_keepalive_item_t *item;
      ngx_http_lua_balancer_peer_data_t  *bp = data;
  
      ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
-@@ -425,9 +427,13 @@ ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
+                    "lua balancer: get peer, tries: %ui", pc->tries);
+ 
+     r = bp->request;
+-#if (NGX_HTTP_SSL)
+     u = r->upstream;
+-#endif
+     lscf = bp->conf;
+ 
+     ngx_http_lua_assert(lscf->balancer.handler && r);
+@@ -425,9 +434,14 @@ ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
  
      ctx->context = NGX_HTTP_LUA_CONTEXT_BALANCER;
  
@@ -224,13 +243,14 @@ index ae0f1380..a51532da 100644
      bp->sockaddr = NULL;
      bp->socklen = 0;
      bp->more_tries = 0;
-+    bp->cpool_crc32 = 0;
++    ngx_str_null(&bp->cpool_name);
 +    bp->cpool_set = 0;
 +    bp->cpool_size = 0;
++    ngx_str_null(&bp->host);
      bp->keepalive_requests = 0;
      bp->keepalive_timeout = 0;
      bp->keepalive = 0;
-@@ -465,10 +470,10 @@ ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
+@@ -465,10 +479,10 @@ ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
          pc->local = bp->local;
      }
  
@@ -239,11 +259,11 @@ index ae0f1380..a51532da 100644
          pc->sockaddr = bp->sockaddr;
          pc->socklen = bp->socklen;
 -        pc->name = bp->addr_text;
-+        pc->name = bp->host;
++        pc->name = bp->host.len ? &bp->host : bp->addr_text;
          pc->cached = 0;
          pc->connection = NULL;
  
-@@ -476,27 +481,59 @@ ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
+@@ -476,27 +490,66 @@ ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
              r->upstream->peer.tries += bp->more_tries;
          }
  
@@ -253,14 +273,8 @@ index ae0f1380..a51532da 100644
 -                ngx_http_lua_upstream_get_ssl_name(r, u);
 -                bp->host = u->ssl_name;
 +        if (ngx_http_lua_balancer_keepalive_is_enabled(bp)) {
-+            ngx_http_lua_balancer_get_keepalive_pool(L, bp->cpool_crc32,
-+                                                     &bp->cpool);
-+
-+            if (bp->cpool == NULL
-+                && ngx_http_lua_balancer_create_keepalive_pool(L, pc->log,
-+                                                               bp->cpool_crc32,
-+                                                               bp->cpool_size,
-+                                                               &bp->cpool)
++            if (!bp->cpool_set
++                && ngx_http_lua_balancer_build_default_pool_name(r, u, pc, bp)
 +                   != NGX_OK)
 +            {
 +                return NGX_ERROR;
@@ -268,6 +282,19 @@ index ae0f1380..a51532da 100644
 -#endif
  
 -            c = ngx_http_lua_balancer_get_cached_item(lscf, pc, &bp->host);
++            ngx_http_lua_balancer_get_keepalive_pool(L, &bp->cpool_name,
++                                                     &bp->cpool);
++
++            if (bp->cpool == NULL
++                && ngx_http_lua_balancer_create_keepalive_pool(L, pc->log,
++                                                               &bp->cpool_name,
++                                                               bp->cpool_size,
++                                                               &bp->cpool)
++                   != NGX_OK)
++            {
++                return NGX_ERROR;
++            }
++
 +            ngx_http_lua_assert(bp->cpool);
 +
 +            if (!ngx_queue_empty(&bp->cpool->cache)) {
@@ -316,7 +343,7 @@ index ae0f1380..a51532da 100644
          }
  
          return NGX_OK;
-@@ -577,14 +614,12 @@ static void
+@@ -577,14 +630,12 @@ static void
  ngx_http_lua_balancer_free_peer(ngx_peer_connection_t *pc, void *data,
      ngx_uint_t state)
  {
@@ -333,7 +360,7 @@ index ae0f1380..a51532da 100644
  
      ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
                     "lua balancer: free peer, tries: %ui", pc->tries);
-@@ -592,14 +627,16 @@ ngx_http_lua_balancer_free_peer(ngx_peer_connection_t *pc, void *data,
+@@ -592,14 +643,16 @@ ngx_http_lua_balancer_free_peer(ngx_peer_connection_t *pc, void *data,
      u = bp->request->upstream;
      c = pc->connection;
  
@@ -352,7 +379,7 @@ index ae0f1380..a51532da 100644
              if (state & NGX_PEER_FAILED
                  || c == NULL
                  || c->read->eof
-@@ -633,42 +670,41 @@ ngx_http_lua_balancer_free_peer(ngx_peer_connection_t *pc, void *data,
+@@ -633,42 +686,41 @@ ngx_http_lua_balancer_free_peer(ngx_peer_connection_t *pc, void *data,
                  goto invalid;
              }
  
@@ -414,7 +441,7 @@ index ae0f1380..a51532da 100644
  
              if (c->write->timer_set) {
                  ngx_del_timer(c->write);
-@@ -684,42 +720,6 @@ ngx_http_lua_balancer_free_peer(ngx_peer_connection_t *pc, void *data,
+@@ -684,42 +736,6 @@ ngx_http_lua_balancer_free_peer(ngx_peer_connection_t *pc, void *data,
              c->write->log = ngx_cycle->log;
              c->pool->log = ngx_cycle->log;
  
@@ -457,7 +484,7 @@ index ae0f1380..a51532da 100644
              if (c->read->ready) {
                  ngx_http_lua_balancer_close_handler(c->read);
              }
-@@ -728,9 +728,16 @@ ngx_http_lua_balancer_free_peer(ngx_peer_connection_t *pc, void *data,
+@@ -728,9 +744,16 @@ ngx_http_lua_balancer_free_peer(ngx_peer_connection_t *pc, void *data,
  
  invalid:
  
@@ -477,13 +504,13 @@ index ae0f1380..a51532da 100644
          }
  
          return;
-@@ -740,6 +747,123 @@ invalid:
+@@ -740,6 +763,136 @@ invalid:
  }
  
  
 +static ngx_int_t
 +ngx_http_lua_balancer_create_keepalive_pool(lua_State *L, ngx_log_t *log,
-+    uint32_t cpool_crc32, ngx_uint_t cpool_size,
++    ngx_str_t *cpool_name, ngx_uint_t cpool_size,
 +    ngx_http_lua_balancer_keepalive_pool_t **cpool)
 +{
 +    size_t                                       size;
@@ -499,29 +526,38 @@ index ae0f1380..a51532da 100644
 +    ngx_http_lua_assert(lua_istable(L, -1));
 +
 +    size = sizeof(ngx_http_lua_balancer_keepalive_pool_t)
-+           + sizeof(ngx_http_lua_balancer_keepalive_item_t) * cpool_size;
++           + sizeof(ngx_http_lua_balancer_keepalive_item_t) * cpool_size
++           + cpool_name->len;
 +
-+    upool = lua_newuserdata(L, size); /* pools upool */
++    lua_pushlstring(L, (const char *) cpool_name->data, cpool_name->len);
++    /* pools name */
++
++    upool = lua_newuserdata(L, size); /* pools name upool */
 +    if (upool == NULL) {
 +        return NGX_ERROR;
 +    }
 +
 +    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, log, 0,
-+                   "lua balancer: keepalive create pool, crc32: %ui, "
-+                   "size: %ui", cpool_crc32, cpool_size);
++                   "lua balancer: keepalive create pool, name: %V, "
++                   "size: %ui", cpool_name, cpool_size);
 +
 +    upool->lua_vm = L;
-+    upool->crc32 = cpool_crc32;
 +    upool->size = cpool_size;
 +    upool->connections = 0;
++
++    items = (ngx_http_lua_balancer_keepalive_item_t *) (&upool->free + 1);
++
++    /* store a copy of the pool name in the same userdata allocation so
++     * that the pool can be removed from the registry table on free */
++    upool->cpool_name.data = (u_char *) (items + cpool_size);
++    upool->cpool_name.len = cpool_name->len;
++    ngx_memcpy(upool->cpool_name.data, cpool_name->data, cpool_name->len);
 +
 +    ngx_queue_init(&upool->cache);
 +    ngx_queue_init(&upool->free);
 +
-+    lua_rawseti(L, -2, cpool_crc32); /* pools */
++    lua_rawset(L, -3); /* pools */
 +    lua_pop(L, 1); /* orig stack */
-+
-+    items = (ngx_http_lua_balancer_keepalive_item_t *) (&upool->free + 1);
 +
 +    for (i = 0; i < cpool_size; i++) {
 +        ngx_queue_insert_head(&upool->free, &items[i].queue);
@@ -535,7 +571,7 @@ index ae0f1380..a51532da 100644
 +
 +
 +static void
-+ngx_http_lua_balancer_get_keepalive_pool(lua_State *L, uint32_t cpool_crc32,
++ngx_http_lua_balancer_get_keepalive_pool(lua_State *L, ngx_str_t *cpool_name,
 +    ngx_http_lua_balancer_keepalive_pool_t **cpool)
 +{
 +    ngx_http_lua_balancer_keepalive_pool_t      *upool;
@@ -558,7 +594,9 @@ index ae0f1380..a51532da 100644
 +
 +    ngx_http_lua_assert(lua_istable(L, -1));
 +
-+    lua_rawgeti(L, -1, cpool_crc32); /* pools upool? */
++    lua_pushlstring(L, (const char *) cpool_name->data, cpool_name->len);
++    /* pools name */
++    lua_rawget(L, -2); /* pools upool? */
 +    upool = lua_touserdata(L, -1);
 +    lua_pop(L, 2); /* orig stack */
 +
@@ -573,8 +611,8 @@ index ae0f1380..a51532da 100644
 +    lua_State                             *L;
 +
 +    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, log, 0,
-+                   "lua balancer: keepalive free pool %p, crc32: %ui",
-+                   cpool, cpool->crc32);
++                   "lua balancer: keepalive free pool %p, name: %V",
++                   cpool, &cpool->cpool_name);
 +
 +    ngx_http_lua_assert(cpool->connections == 0);
 +
@@ -592,8 +630,10 @@ index ae0f1380..a51532da 100644
 +
 +    ngx_http_lua_assert(lua_istable(L, -1));
 +
-+    lua_pushnil(L); /* pools nil */
-+    lua_rawseti(L, -2, cpool->crc32); /* pools */
++    lua_pushlstring(L, (const char *) cpool->cpool_name.data,
++                    cpool->cpool_name.len); /* pools name */
++    lua_pushnil(L); /* pools name nil */
++    lua_rawset(L, -3); /* pools */
 +    lua_pop(L, 1); /* orig stack */
 +}
 +
@@ -601,7 +641,7 @@ index ae0f1380..a51532da 100644
  static void
  ngx_http_lua_balancer_notify_peer(ngx_peer_connection_t *pc, void *data,
      ngx_uint_t type)
-@@ -755,6 +879,10 @@ ngx_http_lua_balancer_notify_peer(ngx_peer_connection_t *pc, void *data,
+@@ -755,6 +908,10 @@ ngx_http_lua_balancer_notify_peer(ngx_peer_connection_t *pc, void *data,
  static void
  ngx_http_lua_balancer_close(ngx_connection_t *c)
  {
@@ -612,7 +652,7 @@ index ae0f1380..a51532da 100644
  #if (NGX_HTTP_SSL)
      if (c->ssl) {
          c->ssl->no_wait_shutdown = 1;
-@@ -762,9 +890,6 @@ ngx_http_lua_balancer_close(ngx_connection_t *c)
+@@ -762,9 +919,6 @@ ngx_http_lua_balancer_close(ngx_connection_t *c)
  
          if (ngx_ssl_shutdown(c) == NGX_AGAIN) {
              c->ssl->handler = ngx_http_lua_balancer_close;
@@ -622,7 +662,7 @@ index ae0f1380..a51532da 100644
              return;
          }
      }
-@@ -773,8 +898,12 @@ ngx_http_lua_balancer_close(ngx_connection_t *c)
+@@ -773,8 +927,12 @@ ngx_http_lua_balancer_close(ngx_connection_t *c)
      ngx_destroy_pool(c->pool);
      ngx_close_connection(c);
  
@@ -637,7 +677,7 @@ index ae0f1380..a51532da 100644
  }
  
  
-@@ -789,7 +918,7 @@ ngx_http_lua_balancer_dummy_handler(ngx_event_t *ev)
+@@ -789,7 +947,7 @@ ngx_http_lua_balancer_dummy_handler(ngx_event_t *ev)
  static void
  ngx_http_lua_balancer_close_handler(ngx_event_t *ev)
  {
@@ -646,7 +686,7 @@ index ae0f1380..a51532da 100644
  
      int                n;
      char               buf[1];
-@@ -820,8 +949,10 @@ close:
+@@ -820,8 +978,10 @@ close:
      ngx_http_lua_balancer_close(c);
  
      ngx_queue_remove(&item->queue);
@@ -659,7 +699,7 @@ index ae0f1380..a51532da 100644
  }
  
  
-@@ -832,7 +963,7 @@ ngx_http_lua_balancer_set_session(ngx_peer_connection_t *pc, void *data)
+@@ -832,7 +992,7 @@ ngx_http_lua_balancer_set_session(ngx_peer_connection_t *pc, void *data)
  {
      ngx_http_lua_balancer_peer_data_t  *bp = data;
  
@@ -668,7 +708,7 @@ index ae0f1380..a51532da 100644
          /* TODO */
          return NGX_OK;
      }
-@@ -846,7 +977,7 @@ ngx_http_lua_balancer_save_session(ngx_peer_connection_t *pc, void *data)
+@@ -846,7 +1006,7 @@ ngx_http_lua_balancer_save_session(ngx_peer_connection_t *pc, void *data)
  {
      ngx_http_lua_balancer_peer_data_t  *bp = data;
  
@@ -677,56 +717,42 @@ index ae0f1380..a51532da 100644
          /* TODO */
          return;
      }
-@@ -859,9 +990,8 @@ ngx_http_lua_balancer_save_session(ngx_peer_connection_t *pc, void *data)
- 
- int
+@@ -861,7 +1021,8 @@ int
  ngx_http_lua_ffi_balancer_set_current_peer(ngx_http_request_t *r,
--    const u_char *addr, size_t addr_len, int port,
--    const u_char *host, size_t host_len,
+     const u_char *addr, size_t addr_len, int port,
+     const u_char *host, size_t host_len,
 -    char **err)
-+    const u_char *addr, size_t addr_len, int port, unsigned int cpool_crc32,
-+    int cpool_set, unsigned int cpool_size, char **err)
++    const u_char *cpool_name, size_t cpool_name_len,
++    unsigned int cpool_size, char **err)
  {
      ngx_url_t              url;
      ngx_http_lua_ctx_t    *ctx;
-@@ -920,32 +1050,16 @@ ngx_http_lua_ffi_balancer_set_current_peer(ngx_http_request_t *r,
-     if (url.addrs && url.addrs[0].sockaddr) {
-         bp->sockaddr = url.addrs[0].sockaddr;
-         bp->socklen = url.addrs[0].socklen;
--        bp->addr_text = &url.addrs[0].name;
-+        bp->host = &url.addrs[0].name;
- 
-     } else {
-         *err = "no host allowed";
-         return NGX_ERROR;
+@@ -947,6 +1108,24 @@ ngx_http_lua_ffi_balancer_set_current_peer(ngx_http_request_t *r,
+         ngx_str_null(&bp->host);
      }
  
--    if (host && host_len) {
--        bp->host.data = ngx_palloc(r->pool, host_len);
--        if (bp->host.data == NULL) {
--            *err = "no memory";
--            return NGX_ERROR;
--        }
--
--        ngx_memcpy(bp->host.data, host, host_len);
--        bp->host.len = host_len;
--
--#if (NGX_HTTP_SSL)
--        if (u->ssl) {
--            u->ssl_name = bp->host;
--        }
--#endif
--
--    } else {
--        ngx_str_null(&bp->host);
--    }
-+    bp->cpool_crc32 = (uint32_t) cpool_crc32;
-+    bp->cpool_set = cpool_set ? 1 : 0;
++    if (cpool_name && cpool_name_len) {
++        bp->cpool_name.data = ngx_palloc(r->pool, cpool_name_len);
++        if (bp->cpool_name.data == NULL) {
++            *err = "no memory";
++            return NGX_ERROR;
++        }
++
++        ngx_memcpy(bp->cpool_name.data, cpool_name, cpool_name_len);
++        bp->cpool_name.len = cpool_name_len;
++        bp->cpool_set = 1;
++
++    } else {
++        ngx_str_null(&bp->cpool_name);
++        bp->cpool_set = 0;
++    }
++
 +    bp->cpool_size = (ngx_uint_t) cpool_size;
- 
++
      return NGX_OK;
  }
-@@ -1050,11 +1163,16 @@ ngx_http_lua_ffi_balancer_enable_keepalive(ngx_http_request_t *r,
+ 
+@@ -1050,11 +1229,15 @@ ngx_http_lua_ffi_balancer_enable_keepalive(ngx_http_request_t *r,
  
      bp = (ngx_http_lua_balancer_peer_data_t *) u->peer.data;
  
@@ -736,87 +762,58 @@ index ae0f1380..a51532da 100644
          return NGX_ERROR;
      }
  
-+    if (!bp->cpool_set) {
-+        bp->cpool_crc32 = ngx_crc32_long(bp->host->data, bp->host->len);
-+        bp->cpool_set = 1;
-+    }
++    /* when no explicit pool was given, the default pool identity is
++     * derived in ngx_http_lua_balancer_get_peer, where the local bind
++     * address and the TLS server name are finally known */
 +
      bp->keepalive_timeout = (ngx_msec_t) timeout;
      bp->keepalive_requests = (ngx_uint_t) max_requests;
      bp->keepalive = 1;
-@@ -1375,138 +1492,4 @@ ngx_http_lua_balancer_keepalive(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
-     return NGX_CONF_OK;
- }
+@@ -1428,85 +1611,70 @@ done:
+ #endif
  
--
--#if (NGX_HTTP_SSL)
--static ngx_int_t
--ngx_http_lua_upstream_get_ssl_name(ngx_http_request_t *r,
--    ngx_http_upstream_t *u)
--{
--    u_char     *p, *last;
--    ngx_str_t   name;
--
--    if (u->conf->ssl_name) {
--        if (ngx_http_complex_value(r, u->conf->ssl_name, &name) != NGX_OK) {
--            return NGX_ERROR;
--        }
--
--    } else {
--        name = u->ssl_name;
--    }
--
--    if (name.len == 0) {
--        goto done;
--    }
--
--    /*
--     * ssl name here may contain port, notably if derived from $proxy_host
--     * or $http_host; we have to strip it. eg: www.example.com:443
--     */
--
--    p = name.data;
--    last = name.data + name.len;
--
--    if (*p == '[') {
--        p = ngx_strlchr(p, last, ']');
--
--        if (p == NULL) {
--            p = name.data;
--        }
--    }
--
--    p = ngx_strlchr(p, last, ':');
--
--    if (p != NULL) {
--        name.len = p - name.data;
--    }
--
--done:
--
--    u->ssl_name = name;
--
--    return NGX_OK;
--}
--#endif
--
--
+ 
 -static ngx_uint_t
 -ngx_http_lua_balancer_calc_hash(ngx_str_t *name,
 -    struct sockaddr *sockaddr, socklen_t socklen, ngx_addr_t *local)
--{
++static ngx_int_t
++ngx_http_lua_balancer_build_default_pool_name(ngx_http_request_t *r,
++    ngx_http_upstream_t *u, ngx_peer_connection_t *pc,
++    ngx_http_lua_balancer_peer_data_t *bp)
+ {
 -    ngx_uint_t hash;
--
++    size_t      len;
++    u_char     *p;
++    unsigned    tls = 0;
++    ngx_str_t   ssl_name = ngx_null_string;
++
++    /*
++     * the default pool identity must cover every property that is only
++     * applied when the connection is established: the remote address,
++     * the local bind address, the host given to set_current_peer and the
++     * TLS server name; otherwise an idle connection created with
++     * different properties could be reused
++     */
+ 
 -    hash = ngx_hash_key_lc(name->data, name->len);
 -    hash ^= ngx_hash_key((u_char *) sockaddr, socklen);
 -    if (local != NULL) {
 -        hash ^= ngx_hash_key((u_char *) local->sockaddr, local->socklen);
--    }
--
++    if (bp->host.len) {
++        ssl_name = bp->host;
+     }
+ 
 -    return hash;
 -}
--
--
++#if (NGX_HTTP_SSL)
++    if (u->ssl) {
++        tls = 1;
+ 
++        if (ssl_name.len == 0) {
++            if (ngx_http_lua_upstream_get_ssl_name(r, u) != NGX_OK) {
++                return NGX_ERROR;
++            }
+ 
 -static ngx_connection_t *
 -ngx_http_lua_balancer_get_cached_item(ngx_http_lua_srv_conf_t *lscf,
 -    ngx_peer_connection_t *pc, ngx_str_t *name)
@@ -845,8 +842,11 @@ index ae0f1380..a51532da 100644
 -        item = ngx_queue_data(q, ngx_http_lua_balancer_ka_item_t, hnode);
 -        if (item->hash != hash) {
 -            continue;
--        }
--
++            ssl_name = u->ssl_name;
+         }
++    }
++#endif
+ 
 -        if (name->len == item->host.len
 -            && ngx_memn2cmp((u_char *) &item->sockaddr,
 -                            (u_char *) sockaddr,
@@ -872,16 +872,41 @@ index ae0f1380..a51532da 100644
 -            if (c->read->timer_set) {
 -                ngx_del_timer(c->read);
 -            }
--
++    len = bp->addr_text->len + 1
++          + (pc->local ? pc->local->name.len : 0) + 1
++          + 1 /* tls flag */ + 1
++          + ssl_name.len;
+ 
 -            pc->cached = 1;
 -            pc->connection = c;
 -            return c;
 -        }
--    }
--
++    p = ngx_pnalloc(r->pool, len);
++    if (p == NULL) {
++        return NGX_ERROR;
+     }
+ 
 -    return NULL;
--}
--
++    bp->cpool_name.data = p;
++
++    p = ngx_copy(p, bp->addr_text->data, bp->addr_text->len);
++    *p++ = '|';
++
++    if (pc->local) {
++        p = ngx_copy(p, pc->local->name.data, pc->local->name.len);
++    }
++
++    *p++ = '|';
++    *p++ = tls ? '1' : '0';
++    *p++ = '|';
++
++    p = ngx_copy(p, ssl_name.data, ssl_name.len);
++
++    bp->cpool_name.len = p - bp->cpool_name.data;
++
++    return NGX_OK;
+ }
+ 
  /* vi:set ft=c ts=4 sw=4 et fdm=marker: */
 diff --git src/ngx_http_lua_common.h src/ngx_http_lua_common.h
 index cc2d36a3..edbd9166 100644

--- a/patch/1.29.2.4/ngx_lua-enable_keepalive.patch
+++ b/patch/1.29.2.4/ngx_lua-enable_keepalive.patch
@@ -1,5 +1,5 @@
 diff --git src/ngx_http_lua_balancer.c src/ngx_http_lua_balancer.c
-index aa26a4a..a4b4d38 100644
+index aa26a4a..3948881 100644
 --- src/ngx_http_lua_balancer.c
 +++ src/ngx_http_lua_balancer.c
 @@ -31,10 +31,43 @@ typedef struct {
@@ -769,7 +769,7 @@ index aa26a4a..a4b4d38 100644
      bp->keepalive_timeout = (ngx_msec_t) timeout;
      bp->keepalive_requests = (ngx_uint_t) max_requests;
      bp->keepalive = 1;
-@@ -1428,85 +1611,70 @@ done:
+@@ -1428,85 +1611,76 @@ done:
  #endif
  
  
@@ -786,7 +786,11 @@ index aa26a4a..a4b4d38 100644
 +    u_char     *p;
 +    unsigned    tls = 0;
 +    ngx_str_t   ssl_name = ngx_null_string;
-+
+ 
+-    hash = ngx_hash_key_lc(name->data, name->len);
+-    hash ^= ngx_hash_key((u_char *) sockaddr, socklen);
+-    if (local != NULL) {
+-        hash ^= ngx_hash_key((u_char *) local->sockaddr, local->socklen);
 +    /*
 +     * the default pool identity must cover every property that is only
 +     * applied when the connection is established: the remote address,
@@ -794,25 +798,39 @@ index aa26a4a..a4b4d38 100644
 +     * TLS server name; otherwise an idle connection created with
 +     * different properties could be reused
 +     */
- 
--    hash = ngx_hash_key_lc(name->data, name->len);
--    hash ^= ngx_hash_key((u_char *) sockaddr, socklen);
--    if (local != NULL) {
--        hash ^= ngx_hash_key((u_char *) local->sockaddr, local->socklen);
-+    if (bp->host.len) {
-+        ssl_name = bp->host;
-     }
- 
--    return hash;
--}
++
 +#if (NGX_HTTP_SSL)
 +    if (u->ssl) {
 +        tls = 1;
++
++        /*
++         * the name actually used for the TLS handshake is derived from
++         * the upstream ssl_name configuration at connect time, not from
++         * the set_current_peer host argument, so the identity must use
++         * the same derivation; the host argument stays a separate
++         * identity component below to preserve its documented
++         * pool-partitioning semantics
++         */
++        if (ngx_http_lua_upstream_get_ssl_name(r, u) != NGX_OK) {
++            return NGX_ERROR;
++        }
++
++        ssl_name = u->ssl_name;
+     }
++#endif
  
-+        if (ssl_name.len == 0) {
-+            if (ngx_http_lua_upstream_get_ssl_name(r, u) != NGX_OK) {
-+                return NGX_ERROR;
-+            }
+-    return hash;
+-}
++    len = bp->addr_text->len + 1
++          + (pc->local ? pc->local->name.len : 0) + 1
++          + 1 /* tls flag */ + 1
++          + bp->host.len + 1
++          + ssl_name.len;
+ 
++    p = ngx_pnalloc(r->pool, len);
++    if (p == NULL) {
++        return NGX_ERROR;
++    }
  
 -static ngx_connection_t *
 -ngx_http_lua_balancer_get_cached_item(ngx_http_lua_srv_conf_t *lscf,
@@ -842,10 +860,8 @@ index aa26a4a..a4b4d38 100644
 -        item = ngx_queue_data(q, ngx_http_lua_balancer_ka_item_t, hnode);
 -        if (item->hash != hash) {
 -            continue;
-+            ssl_name = u->ssl_name;
-         }
-+    }
-+#endif
+-        }
++    bp->cpool_name.data = p;
  
 -        if (name->len == item->host.len
 -            && ngx_memn2cmp((u_char *) &item->sockaddr,
@@ -872,32 +888,23 @@ index aa26a4a..a4b4d38 100644
 -            if (c->read->timer_set) {
 -                ngx_del_timer(c->read);
 -            }
-+    len = bp->addr_text->len + 1
-+          + (pc->local ? pc->local->name.len : 0) + 1
-+          + 1 /* tls flag */ + 1
-+          + ssl_name.len;
++    p = ngx_copy(p, bp->addr_text->data, bp->addr_text->len);
++    *p++ = '|';
  
 -            pc->cached = 1;
 -            pc->connection = c;
 -            return c;
 -        }
-+    p = ngx_pnalloc(r->pool, len);
-+    if (p == NULL) {
-+        return NGX_ERROR;
++    if (pc->local) {
++        p = ngx_copy(p, pc->local->name.data, pc->local->name.len);
      }
  
 -    return NULL;
-+    bp->cpool_name.data = p;
-+
-+    p = ngx_copy(p, bp->addr_text->data, bp->addr_text->len);
-+    *p++ = '|';
-+
-+    if (pc->local) {
-+        p = ngx_copy(p, pc->local->name.data, pc->local->name.len);
-+    }
-+
 +    *p++ = '|';
 +    *p++ = tls ? '1' : '0';
++    *p++ = '|';
++
++    p = ngx_copy(p, bp->host.data, bp->host.len);
 +    *p++ = '|';
 +
 +    p = ngx_copy(p, ssl_name.data, ssl_name.len);

--- a/t/balancer-keepalive.t
+++ b/t/balancer-keepalive.t
@@ -1,25 +1,5 @@
 # Origin: https://github.com/openresty/lua-resty-core/pull/276/files
-
-# The balancer keepalive pool identity fix (full pool-name keying,
-# connect-time properties in the default pool identity, set_current_peer
-# host compatibility) currently only lands in the 1.29.2.4 patches; older
-# runtime patches keep the previous behavior until the fix is backported.
-our $SkipReason;
-
-BEGIN {
-    my $nginx_binary = $ENV{'TEST_NGINX_BINARY'} || 'nginx';
-    my $version = eval { `$nginx_binary -V 2>&1` } // '';
-    my ($major, $minor) = $version =~ m{openresty/(\d+)\.(\d+)};
-
-    if (!defined $major || !defined $minor
-        || ($major < 1 || ($major == 1 && $minor < 29))) {
-        $SkipReason = "requires OpenResty 1.29 or later";
-    }
-}
-
-use t::APISIX_NGINX $SkipReason
-    ? (skip_all => $SkipReason)
-    : ('no_plan');
+use t::APISIX_NGINX 'no_plan';
 
 $ENV{TEST_NGINX_SERVER_SSL_PORT_2} = $ENV{TEST_NGINX_SERVER_SSL_PORT} + 1;
 
@@ -1345,14 +1325,24 @@ lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1$/
 
             assert(b.set_current_peer("127.0.0.1",
                                       $TEST_NGINX_SERVER_SSL_PORT))
-            assert(b.bind_to_local_addr(ngx.var.arg_local_addr))
             assert(b.enable_keepalive())
         }
     }
 --- config
+    location ~ ^/proxyb/(?<upstream_uri>.*) {
+        proxy_ssl_verify      off;
+        proxy_ssl_server_name on;
+        proxy_ssl_name        '$arg_sni';
+        proxy_bind            $arg_local_addr;
+
+        proxy_http_version    1.1;
+        proxy_set_header      Connection '';
+        proxy_pass            https://test_upstream/$upstream_uri;
+    }
+
     location = /t {
-        echo_subrequest GET '/proxy/echo_addrs' -q 'local_addr=127.0.0.2';
-        echo_subrequest GET '/proxy/echo_addrs' -q 'local_addr=127.0.0.3';
+        echo_subrequest GET '/proxyb/echo_addrs' -q 'local_addr=127.0.0.2';
+        echo_subrequest GET '/proxyb/echo_addrs' -q 'local_addr=127.0.0.3';
     }
 --- response_body_like
 ^server=127\.0\.0\.1 client=127\.0\.0\.2

--- a/t/balancer-keepalive.t
+++ b/t/balancer-keepalive.t
@@ -156,19 +156,19 @@ SNI=two
 SNI=three
 SNI=three
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive create pool, name: 127\.0\.0\.1:23456\|\|1\|one, size: 30
+qr/^lua balancer: keepalive create pool, name: 127\.0\.0\.1:23456\|\|1\|\|one, size: 30
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1
-lua balancer: keepalive create pool, name: 127\.0\.0\.1:23456\|\|1\|two, size: 30
+lua balancer: keepalive create pool, name: 127\.0\.0\.1:23456\|\|1\|\|two, size: 30
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1
-lua balancer: keepalive create pool, name: 127\.0\.0\.2:23456\|\|1\|two, size: 30
+lua balancer: keepalive create pool, name: 127\.0\.0\.2:23456\|\|1\|\|two, size: 30
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1
-lua balancer: keepalive create pool, name: 127\.0\.0\.2:23456\|\|1\|three, size: 30
+lua balancer: keepalive create pool, name: 127\.0\.0\.2:23456\|\|1\|\|three, size: 30
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1
-lua balancer: keepalive create pool, name: 127\.0\.0\.2:23457\|\|1\|three, size: 30
+lua balancer: keepalive create pool, name: 127\.0\.0\.2:23457\|\|1\|\|three, size: 30
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1$/
 
@@ -217,10 +217,10 @@ SNI=one
 SNI=two
 SNI=three
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive create pool, name: 127\.0\.0\.1:23456\|\|1\|one, size: 30
+qr/^lua balancer: keepalive create pool, name: 127\.0\.0\.1:23456\|\|1\|\|one, size: 30
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1
-lua balancer: keepalive create pool, name: 127\.0\.0\.1:23456\|\|1\|two, size: 30
+lua balancer: keepalive create pool, name: 127\.0\.0\.1:23456\|\|1\|\|two, size: 30
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1
 lua balancer: keepalive custom cpool: 127\.0\.0\.1:23456
@@ -510,7 +510,7 @@ bad argument #3 to 'set_current_peer' (string or table expected, got number)
         content_by_lua_block {
             local b = require "ngx.balancer"
 
-            local values = { true, 0, -1 }
+            local values = { false, true, 0, -1 }
 
             for _, val in ipairs(values) do
                 local pok, perr = pcall(b.set_current_peer, "127.0.0.1", 80, {
@@ -524,6 +524,7 @@ bad argument #3 to 'set_current_peer' (string or table expected, got number)
     }
 --- response_body
 bad option 'pool' to 'set_current_peer' (string expected, got boolean)
+bad option 'pool' to 'set_current_peer' (string expected, got boolean)
 bad option 'pool' to 'set_current_peer' (string expected, got number)
 bad option 'pool' to 'set_current_peer' (string expected, got number)
 --- grep_error_log_out
@@ -536,7 +537,7 @@ bad option 'pool' to 'set_current_peer' (string expected, got number)
         content_by_lua_block {
             local b = require "ngx.balancer"
 
-            local values = { true, 0, -1 }
+            local values = { false, true, 0, -1 }
 
             for _, val in ipairs(values) do
                 local pok, perr = pcall(b.set_current_peer, "127.0.0.1", 80, {
@@ -550,6 +551,7 @@ bad option 'pool' to 'set_current_peer' (string expected, got number)
         }
     }
 --- response_body
+bad option 'pool_size' to 'set_current_peer' (number expected, got boolean)
 bad option 'pool_size' to 'set_current_peer' (number expected, got boolean)
 bad option 'pool_size' to 'set_current_peer' (expected > 0)
 bad option 'pool_size' to 'set_current_peer' (expected > 0)
@@ -1348,10 +1350,10 @@ lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1$/
 ^server=127\.0\.0\.1 client=127\.0\.0\.2
 server=127\.0\.0\.1 client=127\.0\.0\.3$
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive create pool, name: 127\.0\.0\.1:23456\|127\.0\.0\.2\|1\|, size: 30
+qr/^lua balancer: keepalive create pool, name: 127\.0\.0\.1:23456\|127\.0\.0\.2\|1\|\|, size: 30
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1
-lua balancer: keepalive create pool, name: 127\.0\.0\.1:23456\|127\.0\.0\.3\|1\|, size: 30
+lua balancer: keepalive create pool, name: 127\.0\.0\.1:23456\|127\.0\.0\.3\|1\|\|, size: 30
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1$/
 
@@ -1359,7 +1361,11 @@ lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1$/
 
 === TEST 31: set_current_peer accepts the documented host argument
 The third argument may be the plain host string from the documented
-OpenResty API; it takes part in the default pool identity.
+OpenResty API; it takes part in the default pool identity as its own
+component, while the TLS component always uses the server name derived
+from the upstream ssl_name configuration (the name actually used at
+handshake time), so a varying configured SNI partitions pools even with
+a fixed host argument.
 --- http_upstream
     upstream test_upstream {
         server 0.0.0.1;
@@ -1378,17 +1384,27 @@ OpenResty API; it takes part in the default pool identity.
         echo_subrequest GET '/proxy/echo_addrs' -q 'h=a';
         echo_subrequest GET '/proxy/echo_addrs' -q 'h=a';
         echo_subrequest GET '/proxy/echo_addrs' -q 'h=b';
+        echo_subrequest GET '/proxy/echo_sni' -q 'h=c&sni=x';
+        echo_subrequest GET '/proxy/echo_sni' -q 'h=c&sni=y';
     }
 --- response_body_like
 ^server=127\.0\.0\.1 client=\S+
 server=127\.0\.0\.1 client=\S+
-server=127\.0\.0\.1 client=\S+$
+server=127\.0\.0\.1 client=\S+
+SNI=x
+SNI=y$
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive create pool, name: 127\.0\.0\.1:23456\|\|1\|host-a, size: 30
+qr/^lua balancer: keepalive create pool, name: 127\.0\.0\.1:23456\|\|1\|host-a\|, size: 30
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1
 lua balancer: keepalive reusing connection \S+, requests: 1, cpool: \S+
 lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1
-lua balancer: keepalive create pool, name: 127\.0\.0\.1:23456\|\|1\|host-b, size: 30
+lua balancer: keepalive create pool, name: 127\.0\.0\.1:23456\|\|1\|host-b\|, size: 30
+lua balancer: keepalive no free connection, cpool: \S+
+lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1
+lua balancer: keepalive create pool, name: 127\.0\.0\.1:23456\|\|1\|host-c\|x, size: 30
+lua balancer: keepalive no free connection, cpool: \S+
+lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1
+lua balancer: keepalive create pool, name: 127\.0\.0\.1:23456\|\|1\|host-c\|y, size: 30
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1$/

--- a/t/balancer-keepalive.t
+++ b/t/balancer-keepalive.t
@@ -1,5 +1,25 @@
 # Origin: https://github.com/openresty/lua-resty-core/pull/276/files
-use t::APISIX_NGINX 'no_plan';
+
+# The balancer keepalive pool identity fix (full pool-name keying,
+# connect-time properties in the default pool identity, set_current_peer
+# host compatibility) currently only lands in the 1.29.2.4 patches; older
+# runtime patches keep the previous behavior until the fix is backported.
+our $SkipReason;
+
+BEGIN {
+    my $nginx_binary = $ENV{'TEST_NGINX_BINARY'} || 'nginx';
+    my $version = eval { `$nginx_binary -V 2>&1` } // '';
+    my ($major, $minor) = $version =~ m{openresty/(\d+)\.(\d+)};
+
+    if (!defined $major || !defined $minor
+        || ($major < 1 || ($major == 1 && $minor < 29))) {
+        $SkipReason = "requires OpenResty 1.29 or later";
+    }
+}
+
+use t::APISIX_NGINX $SkipReason
+    ? (skip_all => $SkipReason)
+    : ('no_plan');
 
 $ENV{TEST_NGINX_SERVER_SSL_PORT_2} = $ENV{TEST_NGINX_SERVER_SSL_PORT} + 1;
 
@@ -19,6 +39,10 @@ our $UpstreamSrvConfig = <<_EOC_;
 
         location = /echo_sni {
             return 200 'SNI=\$ssl_server_name\\n';
+        }
+
+        location = /echo_addrs {
+            return 200 'server=\$server_addr client=\$remote_addr\\n';
         }
 
         location = /echo_ssl_client_s_dn_and_protocol {
@@ -111,7 +135,7 @@ SNI=one
 
 
 
-=== TEST 2: enable_keepalive: sanity (default pool)
+=== TEST 2: enable_keepalive: default pool identity covers connect-time properties (addr, TLS server name)
 --- http_upstream
     upstream test_upstream {
         server 0.0.0.1;
@@ -147,28 +171,30 @@ SNI=one
 "
 --- response_body
 SNI=one
-SNI=one
 SNI=two
 SNI=two
 SNI=three
+SNI=three
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive create pool, crc32: \d+, size: 30
+qr/^lua balancer: keepalive create pool, name: 127\.0\.0\.1:23456\|\|1\|one, size: 30
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1
-lua balancer: keepalive reusing connection \S+, requests: 1, cpool: \S+
-lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1
-lua balancer: keepalive create pool, crc32: \d+, size: 30
+lua balancer: keepalive create pool, name: 127\.0\.0\.1:23456\|\|1\|two, size: 30
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1
-lua balancer: keepalive reusing connection \S+, requests: 1, cpool: \S+
+lua balancer: keepalive create pool, name: 127\.0\.0\.2:23456\|\|1\|two, size: 30
+lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1
-lua balancer: keepalive create pool, crc32: \d+, size: 30
+lua balancer: keepalive create pool, name: 127\.0\.0\.2:23456\|\|1\|three, size: 30
+lua balancer: keepalive no free connection, cpool: \S+
+lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1
+lua balancer: keepalive create pool, name: 127\.0\.0\.2:23457\|\|1\|three, size: 30
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1$/
 
 
 
-=== TEST 3: enable_keepalive: sanity (default pool is "<host>:<port>")
+=== TEST 3: enable_keepalive: explicit pool is independent from the default pool identity
 --- http_upstream
     upstream test_upstream {
         server 0.0.0.1;
@@ -208,16 +234,18 @@ lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1$/
     }
 --- response_body
 SNI=one
-SNI=one
-SNI=one
+SNI=two
+SNI=three
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive create pool, crc32: \d+, size: 30
+qr/^lua balancer: keepalive create pool, name: 127\.0\.0\.1:23456\|\|1\|one, size: 30
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1
-lua balancer: keepalive reusing connection \S+, requests: 1, cpool: \S+
+lua balancer: keepalive create pool, name: 127\.0\.0\.1:23456\|\|1\|two, size: 30
+lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1
 lua balancer: keepalive custom cpool: 127\.0\.0\.1:23456
-lua balancer: keepalive reusing connection \S+, requests: 2, cpool: \S+
+lua balancer: keepalive create pool, name: 127\.0\.0\.1:23456, size: 30
+lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1$/
 
 
@@ -265,7 +293,7 @@ SNI=one
 SNI=one
 SNI=one
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive create pool, crc32: \d+, size: 30
+qr/^lua balancer: keepalive create pool, name: \S+, size: 30
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1
 lua balancer: keepalive reusing connection \S+, requests: 1, cpool: \S+
@@ -311,10 +339,10 @@ lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1$/
 SNI=one
 SNI=two
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive create pool, crc32: \d+, size: 30
+qr/^lua balancer: keepalive create pool, name: \S+, size: 30
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1
-lua balancer: keepalive create pool, crc32: \d+, size: 30
+lua balancer: keepalive create pool, name: \S+, size: 30
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1$/
 
@@ -458,16 +486,16 @@ ssl_client_s_dn=.*?CN=test\.com.*? ssl_protocol=TLSv1\.3
 ssl_client_s_dn=.*?CN=test2\.com.*? ssl_protocol=TLSv1\.2
 ssl_client_s_dn=.*?CN=test2\.com.*? ssl_protocol=TLSv1\.3
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive create pool, crc32: \d+, size: 30
+qr/^lua balancer: keepalive create pool, name: \S+, size: 30
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1
-lua balancer: keepalive create pool, crc32: \d+, size: 30
+lua balancer: keepalive create pool, name: \S+, size: 30
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1
-lua balancer: keepalive create pool, crc32: \d+, size: 30
+lua balancer: keepalive create pool, name: \S+, size: 30
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1
-lua balancer: keepalive create pool, crc32: \d+, size: 30
+lua balancer: keepalive create pool, name: \S+, size: 30
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1$/
 
@@ -490,8 +518,8 @@ lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1$/
         }
     }
 --- response_body
-bad argument #3 to 'set_current_peer' (table expected, got boolean)
-bad argument #3 to 'set_current_peer' (table expected, got number)
+bad argument #3 to 'set_current_peer' (string or table expected, got boolean)
+bad argument #3 to 'set_current_peer' (string or table expected, got number)
 --- grep_error_log_out
 
 
@@ -702,15 +730,15 @@ bad argument #2 to 'enable_keepalive' (expected >= 0)
 --- response_body
 --- wait: 0.15
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive create pool, crc32: \S+, size: 30
+qr/^lua balancer: keepalive create pool, name: \S+, size: 30
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1
 lua balancer: keepalive reusing connection \S+, requests: 1, cpool: \S+
 lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1
 lua balancer: keepalive reusing connection \S+, requests: 2, cpool: \S+
 lua balancer: keepalive not saving connection \S+, cpool: \S+, connections: 0
-lua balancer: keepalive free pool \S+, crc32: \d+
-lua balancer: keepalive create pool, crc32: \S+, size: 30
+lua balancer: keepalive free pool \S+, name: \S+
+lua balancer: keepalive create pool, name: \S+, size: 30
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1$/
 
@@ -748,9 +776,9 @@ lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1$/
 --- response_body
 --- grep_error_log eval: qr/lua balancer: keepalive (?:reusing connection \S+, requests: 99|create pool|free pool).*/
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive create pool, crc32: \S+, size: 30
+qr/^lua balancer: keepalive create pool, name: \S+, size: 30
 lua balancer: keepalive reusing connection \S+, requests: 99, cpool: \S+
-lua balancer: keepalive free pool \S+, crc32: \d+$/
+lua balancer: keepalive free pool \S+, name: \S+$/
 
 
 
@@ -819,16 +847,16 @@ lua balancer: keepalive free pool \S+, crc32: \d+$/
 --- response_body
 --- wait: 0.2
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive create pool, crc32: \d+, size: 30
+qr/^lua balancer: keepalive create pool, name: \S+, size: 30
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1
 lua balancer: keepalive closing connection \S+, cpool: \S+, connections: 0
-lua balancer: keepalive free pool \S+, crc32: \d+
-lua balancer: keepalive create pool, crc32: \d+, size: 30
+lua balancer: keepalive free pool \S+, name: \S+
+lua balancer: keepalive create pool, name: \S+, size: 30
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1
 lua balancer: keepalive closing connection \S+, cpool: \S+, connections: 0
-lua balancer: keepalive free pool \S+, crc32: \d+$/
+lua balancer: keepalive free pool \S+, name: \S+$/
 
 
 
@@ -867,7 +895,7 @@ lua balancer: keepalive free pool \S+, crc32: \d+$/
     }
 --- response_body
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive create pool, crc32: \d+, size: 2
+qr/^lua balancer: keepalive create pool, name: \S+, size: 2
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive no free connection, cpool: \S+
@@ -914,14 +942,14 @@ lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 2$/
 --- wait: 0.15
 --- response_body
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive create pool, crc32: \d+, size: 30
+qr/^lua balancer: keepalive create pool, name: \S+, size: 30
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 2
 lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 2
 lua balancer: keepalive closing connection \S+, cpool: \S+, connections: 1
 lua balancer: keepalive closing connection \S+, cpool: \S+, connections: 0
-lua balancer: keepalive free pool \S+, crc32: \d+$/
+lua balancer: keepalive free pool \S+, name: \S+$/
 
 
 
@@ -953,14 +981,14 @@ lua balancer: keepalive free pool \S+, crc32: \d+$/
     }
 --- response_body
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive create pool, crc32: \d+, size: 30
+qr/^lua balancer: keepalive create pool, name: \S+, size: 30
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive not saving connection \S+, cpool: \S+, connections: 0
-lua balancer: keepalive free pool \S+, crc32: \d+
-lua balancer: keepalive create pool, crc32: \d+, size: 30
+lua balancer: keepalive free pool \S+, name: \S+
+lua balancer: keepalive create pool, name: \S+, size: 30
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive not saving connection \S+, cpool: \S+, connections: 0
-lua balancer: keepalive free pool \S+, crc32: \d+$/
+lua balancer: keepalive free pool \S+, name: \S+$/
 
 
 
@@ -994,10 +1022,10 @@ lua balancer: keepalive free pool \S+, crc32: \d+$/
 --- error_log eval
 qr/connect\(\) failed \(\d+: Connection refused\) while connecting to upstream/
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive create pool, crc32: \d+, size: 30
+qr/^lua balancer: keepalive create pool, name: \S+, size: 30
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive not saving connection \S+, cpool: \S+, connections: 0
-lua balancer: keepalive free pool \S+, crc32: \d+$/
+lua balancer: keepalive free pool \S+, name: \S+$/
 
 
 
@@ -1037,10 +1065,10 @@ lua balancer: keepalive free pool \S+, crc32: \d+$/
 --- error_log
 upstream timed out
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive create pool, crc32: \S+, size: 30
+qr/^lua balancer: keepalive create pool, name: \S+, size: 30
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive not saving connection \S+, cpool: \S+, connections: 0
-lua balancer: keepalive free pool \S+, crc32: \d+$/
+lua balancer: keepalive free pool \S+, name: \S+$/
 
 
 
@@ -1098,11 +1126,11 @@ lua balancer: keepalive free pool \S+, crc32: \d+$/
 --- no_error_log
 [crit]
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive create pool, crc32: \d+, size: 1
+qr/^lua balancer: keepalive create pool, name: \S+, size: 1
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive not saving connection \S+, cpool: \S+, connections: 0
-lua balancer: keepalive free pool \S+, crc32: \d+
-lua balancer: keepalive create pool, crc32: \d+, size: 2
+lua balancer: keepalive free pool \S+, name: \S+
+lua balancer: keepalive create pool, name: \S+, size: 2
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1$/
 
@@ -1162,11 +1190,11 @@ SNI=two
 --- no_error_log
 [crit]
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive create pool, crc32: \d+, size: 30
+qr/^lua balancer: keepalive create pool, name: \S+, size: 30
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive not saving connection \S+, cpool: \S+, connections: 0
-lua balancer: keepalive free pool \S+, crc32: \d+
-lua balancer: keepalive create pool, crc32: \d+, size: 30
+lua balancer: keepalive free pool \S+, name: \S+
+lua balancer: keepalive create pool, name: \S+, size: 30
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1$/
 
@@ -1206,10 +1234,10 @@ SNI=one
 SNI=two
 --- grep_error_log eval: qr/(?:lua balancer: keepalive .*|(?:get|free) keepalive peer)/
 --- grep_error_log_out eval
-qr/^lua balancer: keepalive create pool, crc32: \S+, size: 30
+qr/^lua balancer: keepalive create pool, name: \S+, size: 30
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1
-lua balancer: keepalive create pool, crc32: \d+, size: 30
+lua balancer: keepalive create pool, name: \S+, size: 30
 lua balancer: keepalive no free connection, cpool: \S+
 lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1$/
 
@@ -1251,17 +1279,126 @@ SNI=one
 --- grep_error_log eval: qr/(?:lua balancer: keepalive .*|(?:get|free) keepalive peer)/
 --- grep_error_log_out eval
 qr/^get keepalive peer
-lua balancer: keepalive create pool, crc32: \d+, size: 30
+lua balancer: keepalive create pool, name: \S+, size: 30
 lua balancer: keepalive no free connection, cpool: \S+
 free keepalive peer
 free keepalive peer
 lua balancer: keepalive not saving connection \d+, cpool: \S+, connections: 0
-lua balancer: keepalive free pool \S+, crc32: \d+
+lua balancer: keepalive free pool \S+, name: \S+
 get keepalive peer
-lua balancer: keepalive create pool, crc32: \d+, size: 30
+lua balancer: keepalive create pool, name: \S+, size: 30
 lua balancer: keepalive no free connection, cpool: \S+
 get keepalive peer
 free keepalive peer
 free keepalive peer
 lua balancer: keepalive not saving connection \d+, cpool: \S+, connections: 0
-lua balancer: keepalive free pool \S+, crc32: \d+$/
+lua balancer: keepalive free pool \S+, name: \S+$/
+
+
+=== TEST 29: distinct pool names with the same CRC32 stay isolated
+The two pool names below share the same crc32 value; the registry must
+key pools by the full name, not a 32-bit digest of it.
+--- http_upstream
+    upstream test_upstream {
+        server 0.0.0.1;
+
+        balancer_by_lua_block {
+            local b = require "ngx.balancer"
+
+            local first = ngx.var.arg_backend == "first"
+            local ip = first and "127.0.0.1" or "127.0.0.2"
+            local pool = first
+                and "http#w7910hay2abs.example#80"
+                or "http#dwxjcw7qq3bb.example#80"
+
+            assert(b.set_current_peer(ip, $TEST_NGINX_SERVER_SSL_PORT, {
+                pool = pool,
+            }))
+            assert(b.enable_keepalive())
+        }
+    }
+--- config
+    location = /t {
+        echo_subrequest GET '/proxy/echo_addrs' -q 'backend=first';
+        echo_subrequest GET '/proxy/echo_addrs' -q 'backend=second';
+    }
+--- response_body_like
+^server=127\.0\.0\.1 client=\S+
+server=127\.0\.0\.2 client=\S+$
+--- grep_error_log_out eval
+qr/^lua balancer: keepalive create pool, name: http#w7910hay2abs\.example#80, size: 30
+lua balancer: keepalive no free connection, cpool: \S+
+lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1
+lua balancer: keepalive create pool, name: http#dwxjcw7qq3bb\.example#80, size: 30
+lua balancer: keepalive no free connection, cpool: \S+
+lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1$/
+
+
+
+=== TEST 30: default pool identity covers the local bind address
+--- http_upstream
+    upstream test_upstream {
+        server 0.0.0.1;
+
+        balancer_by_lua_block {
+            local b = require "ngx.balancer"
+
+            assert(b.set_current_peer("127.0.0.1",
+                                      $TEST_NGINX_SERVER_SSL_PORT))
+            assert(b.bind_to_local_addr(ngx.var.arg_local_addr))
+            assert(b.enable_keepalive())
+        }
+    }
+--- config
+    location = /t {
+        echo_subrequest GET '/proxy/echo_addrs' -q 'local_addr=127.0.0.2';
+        echo_subrequest GET '/proxy/echo_addrs' -q 'local_addr=127.0.0.3';
+    }
+--- response_body_like
+^server=127\.0\.0\.1 client=127\.0\.0\.2
+server=127\.0\.0\.1 client=127\.0\.0\.3$
+--- grep_error_log_out eval
+qr/^lua balancer: keepalive create pool, name: 127\.0\.0\.1:23456\|127\.0\.0\.2\|1\|, size: 30
+lua balancer: keepalive no free connection, cpool: \S+
+lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1
+lua balancer: keepalive create pool, name: 127\.0\.0\.1:23456\|127\.0\.0\.3\|1\|, size: 30
+lua balancer: keepalive no free connection, cpool: \S+
+lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1$/
+
+
+
+=== TEST 31: set_current_peer accepts the documented host argument
+The third argument may be the plain host string from the documented
+OpenResty API; it takes part in the default pool identity.
+--- http_upstream
+    upstream test_upstream {
+        server 0.0.0.1;
+
+        balancer_by_lua_block {
+            local b = require "ngx.balancer"
+
+            assert(b.set_current_peer("127.0.0.1",
+                                      $TEST_NGINX_SERVER_SSL_PORT,
+                                      "host-" .. ngx.var.arg_h))
+            assert(b.enable_keepalive())
+        }
+    }
+--- config
+    location = /t {
+        echo_subrequest GET '/proxy/echo_addrs' -q 'h=a';
+        echo_subrequest GET '/proxy/echo_addrs' -q 'h=a';
+        echo_subrequest GET '/proxy/echo_addrs' -q 'h=b';
+    }
+--- response_body_like
+^server=127\.0\.0\.1 client=\S+
+server=127\.0\.0\.1 client=\S+
+server=127\.0\.0\.1 client=\S+$
+--- grep_error_log_out eval
+qr/^lua balancer: keepalive create pool, name: 127\.0\.0\.1:23456\|\|1\|host-a, size: 30
+lua balancer: keepalive no free connection, cpool: \S+
+lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1
+lua balancer: keepalive reusing connection \S+, requests: 1, cpool: \S+
+lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1
+lua balancer: keepalive create pool, name: 127\.0\.0\.1:23456\|\|1\|host-b, size: 30
+lua balancer: keepalive no free connection, cpool: \S+
+lua balancer: keepalive saving connection \S+, cpool: \S+, connections: 1$/


### PR DESCRIPTION
### Problem

The 1.29.2.4 balancer keepalive patches carried three defects from the older runtime patches (api7/rfcs#111, KA-1/KA-2/KA-3):

1. **Pool identity was a bare crc32.** The pool registry stored and looked up pools with `lua_rawseti`/`lua_rawgeti` on `ngx.crc32_long(pool)`; the pool object did not keep the original name and a hit was never re-verified. Two distinct pool names with a colliding crc32 silently shared idle connections across unrelated upstream pools (reproduced with `http#w7910hay2abs.example#80` / `http#dwxjcw7qq3bb.example#80`: the second pool reused the first pool's connection to a different peer).
2. **The default pool identity dropped connect-time properties.** Without an explicit `pool`, the identity was derived from the resolved address text alone. A request using `balancer.bind_to_local_addr()` with a different source address, or a TLS upstream with a different server name, could reuse an idle connection established with the old properties (reproduced: two requests bound to `127.0.0.2` / `127.0.0.3` both hit the upstream from `127.0.0.2`).
3. **`set_current_peer(addr, port, host)` was broken.** The third argument only accepted an options table and raised `bad argument #3 ... (table expected, got string)` for existing callers using the documented OpenResty signature, failing the request with HTTP 500 in the balancer phase.

### Fix

- Key the pool registry by the full pool name; the pool object keeps a copy of the name (in the same userdata allocation) for removal on free.
- Build the default pool name in `get_peer` from the remote address text, the local bind address, the TLS flag and the effective server name — the same properties the upstream ka_item implementation used to hash. It is built at `get_peer` time because the local bind address and derived SSL name are only final there.
- Accept both a host string and an options table as the third argument of `set_current_peer`; the host string keeps its original semantics (upstream SSL name, part of the default pool identity).

### Behavior changes

- Connect-time properties now partition the default keepalive pool; the old expectations in `t/balancer-keepalive.t` asserting cross-SNI connection reuse are updated accordingly, and the pool create/free debug logs print the pool name instead of a crc32.
- Callers passing an explicit `pool` (e.g. APISIX) are unaffected apart from correct isolation on crc32 collisions.

### Tests

`t/balancer-keepalive.t` gains cases for crc32-colliding pool names, per-local-bind isolation and the host argument.

The fix is also backported to the 1.21.4 patches used by api7ee-runtime (OpenResty 1.21.4.4), including the host argument that the lua-resty-core 0.1.27 base did not have yet, so the test file runs unconditionally on both CI runtimes (the local-bind case drives pc->local via `proxy_bind` since `balancer.bind_to_local_addr()` only exists in the newer runtime generation).

Ref api7/rfcs#111 (KA-1, KA-2, KA-3).

Fixes api7/api7-ee-3-gateway#1973.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HTTP balancer keepalive connection pooling for reusing eligible upstream connections.
  * Added `ngx.balancer.enable_keepalive(idle_timeout, max_requests)` with HTTP-only support.
  * Enhanced `set_current_peer(addr, port, opts)` to accept an optional host string or `{ pool, pool_size }` for keepalive partitioning.
* **Bug Fixes**
  * Improved keepalive pool isolation using a stronger, collision-resistant pool identity (including TLS/connect-time details).
  * Added stricter validation and clearer errors for invalid keepalive options.
* **Tests**
  * Updated keepalive pool identity expectations and added coverage for validation and supersession behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->