### PR TITLE
fix(tlshandshake): restore sslhandshake FFI compatibility and stop mutating caller options

### DIFF
--- a/patch/1.21.4/lua-resty-core-tlshandshake.patch
+++ b/patch/1.21.4/lua-resty-core-tlshandshake.patch
@@ -32,7 +32,7 @@ new file mode 100644
 index 0000000..f66f51f
 --- /dev/null
 +++ lib/resty/core/socket/tcp.lua
-@@ -0,0 +1,305 @@
+@@ -0,0 +1,317 @@
 +-- Copyright (C) by OpenResty Inc.
 +
 +
@@ -193,8 +193,14 @@ index 0000000..f66f51f
 +                    "client_priv_key and client_priv_key_path", 2)
 +        end
 +
-+        if options.client_cert then
-+            if type(options.client_cert) ~= "string" then
++        -- keep the loaded file content in locals instead of writing it
++        -- back into the caller's options table: the table is usually a
++        -- shared, long-lived config and mutating it makes the *_path
++        -- variant fail on the next call with the "both set" validation
++        -- error above
++        local cert_pem = options.client_cert
++        if cert_pem then
++            if type(cert_pem) ~= "string" then
 +                error("bad client_cert option type", 2)
 +            end
 +        else
@@ -207,11 +213,12 @@ index 0000000..f66f51f
 +                return nil, err
 +            end
 +
-+            options.client_cert = txt
++            cert_pem = txt
 +        end
 +
-+        if options.client_priv_key then
-+            if type(options.client_priv_key) ~= "string" then
++        local pkey_pem = options.client_priv_key
++        if pkey_pem then
++            if type(pkey_pem) ~= "string" then
 +                error("bad client_priv_key option type", 2)
 +            end
 +        else
@@ -224,16 +231,16 @@ index 0000000..f66f51f
 +                return nil, err
 +            end
 +
-+            options.client_priv_key = txt
++            pkey_pem = txt
 +        end
 +
-+        local cert, err = ssl.parse_pem_cert(options.client_cert)
++        local cert, err = ssl.parse_pem_cert(cert_pem)
 +        if not cert then
 +            return nil, err
 +        end
 +        client_cert = cert
 +
-+        local pkey, err = ssl.parse_pem_priv_key(options.client_priv_key)
++        local pkey, err = ssl.parse_pem_priv_key(pkey_pem)
 +        if not pkey then
 +            return nil, err
 +        end
@@ -321,7 +328,7 @@ index 0000000..f66f51f
 +do
 +    local old_socket_tcp = ngx.socket.tcp
 +
-+    function ngx.socket.tcp()
++    local function socket_tcp()
 +        local ok, sock = pcall(old_socket_tcp)
 +        if not ok then
 +            error(sock, 2)
@@ -332,6 +339,11 @@ index 0000000..f66f51f
 +
 +        return sock
 +    end
++
++    -- ngx.socket.stream is an alias of ngx.socket.tcp sharing the same
++    -- cosocket metatable, so it must get the same wrapper
++    ngx.socket.tcp = socket_tcp
++    ngx.socket.stream = socket_tcp
 +end
 +
 +

--- a/patch/1.29.2.4/lua-resty-core-tlshandshake.patch
+++ b/patch/1.29.2.4/lua-resty-core-tlshandshake.patch
@@ -32,7 +32,7 @@ new file mode 100644
 index 0000000..b6e009c
 --- /dev/null
 +++ lib/resty/core/socket/tcp.lua
-@@ -0,0 +1,305 @@
+@@ -0,0 +1,316 @@
 +-- Copyright (C) by OpenResty Inc.
 +
 +
@@ -193,8 +193,13 @@ index 0000000..b6e009c
 +                    "client_priv_key and client_priv_key_path", 2)
 +        end
 +
-+        if options.client_cert then
-+            if type(options.client_cert) ~= "string" then
++        -- keep the loaded file content in locals instead of writing it
++        -- back into the caller's options table: the table is usually a
++        -- shared, long-lived config and mutating it makes the *_path
++        -- variant fail on the next call with "cannot both be set"
++        local cert_pem = options.client_cert
++        if cert_pem then
++            if type(cert_pem) ~= "string" then
 +                error("bad client_cert option type", 2)
 +            end
 +        else
@@ -207,11 +212,12 @@ index 0000000..b6e009c
 +                return nil, err
 +            end
 +
-+            options.client_cert = txt
++            cert_pem = txt
 +        end
 +
-+        if options.client_priv_key then
-+            if type(options.client_priv_key) ~= "string" then
++        local pkey_pem = options.client_priv_key
++        if pkey_pem then
++            if type(pkey_pem) ~= "string" then
 +                error("bad client_priv_key option type", 2)
 +            end
 +        else
@@ -224,16 +230,16 @@ index 0000000..b6e009c
 +                return nil, err
 +            end
 +
-+            options.client_priv_key = txt
++            pkey_pem = txt
 +        end
 +
-+        local cert, err = ssl.parse_pem_cert(options.client_cert)
++        local cert, err = ssl.parse_pem_cert(cert_pem)
 +        if not cert then
 +            return nil, err
 +        end
 +        client_cert = cert
 +
-+        local pkey, err = ssl.parse_pem_priv_key(options.client_priv_key)
++        local pkey, err = ssl.parse_pem_priv_key(pkey_pem)
 +        if not pkey then
 +            return nil, err
 +        end
@@ -321,7 +327,7 @@ index 0000000..b6e009c
 +do
 +    local old_socket_tcp = ngx.socket.tcp
 +
-+    function ngx.socket.tcp()
++    local function socket_tcp()
 +        local ok, sock = pcall(old_socket_tcp)
 +        if not ok then
 +            error(sock, 2)
@@ -332,22 +338,14 @@ index 0000000..b6e009c
 +
 +        return sock
 +    end
++
++    -- ngx.socket.stream is an alias of ngx.socket.tcp sharing the same
++    -- cosocket metatable, so it must get the same wrapper
++    ngx.socket.tcp = socket_tcp
++    ngx.socket.stream = socket_tcp
 +end
 +
 +
 +return {
 +    version = base.version
 +}
-diff --git lib/resty/core/socket.lua lib/resty/core/socket.lua
-index ea973b7..a039ac5 100644
---- lib/resty/core/socket.lua
-+++ lib/resty/core/socket.lua
-@@ -73 +73,4 @@ ngx_http_lua_ffi_ssl_free_session(void *sess);
--
-+
-+void
-+ngx_http_lua_ffi_tls_free_session(void *sess);
-+
-@@ -493 +496 @@ local function getsslsession(cosocket)
--    return ffi_gc(session_ptr[0], C.ngx_http_lua_ffi_ssl_free_session)
-+    return ffi_gc(session_ptr[0], C.ngx_http_lua_ffi_tls_free_session)

--- a/patch/1.29.2.4/ngx_lua-tlshandshake.patch
+++ b/patch/1.29.2.4/ngx_lua-tlshandshake.patch
@@ -198,3 +198,50 @@ index 230679f..106bd76 100644
  {
      ngx_log_debug1(NGX_LOG_DEBUG_HTTP, ngx_cycle->log, 0,
                     "lua ssl free session: %p", sess);
+@@ -2207,6 +2207,46 @@ ngx_http_lua_ffi_tls_free_session(ngx_ssl_session_t *sess)
+ 
+     ngx_ssl_free_session(sess);
+ }
++
++
++/*
++ * The following functions keep the original FFI symbol names so that
++ * consumers built against the stock lua-resty-core (e.g. the shared
++ * cosocket metatable used by both ngx.socket.tcp() and
++ * ngx.socket.stream() objects) keep working.
++ */
++
++int
++ngx_http_lua_ffi_socket_tcp_sslhandshake(ngx_http_request_t *r,
++    ngx_http_lua_socket_tcp_upstream_t *u, ngx_ssl_session_t *sess,
++    int enable_session_reuse, ngx_str_t *server_name, int verify,
++    int ocsp_status_req, STACK_OF(X509) *chain, EVP_PKEY *pkey,
++    const char **errmsg)
++{
++    return ngx_http_lua_ffi_socket_tcp_tlshandshake(r, u, sess,
++                                                    enable_session_reuse,
++                                                    server_name, verify,
++                                                    ocsp_status_req, chain,
++                                                    pkey, errmsg);
++}
++
++
++int
++ngx_http_lua_ffi_socket_tcp_get_sslhandshake_result(ngx_http_request_t *r,
++    ngx_http_lua_socket_tcp_upstream_t *u, ngx_ssl_session_t **sess,
++    const char **errmsg, int *openssl_error_code)
++{
++    return ngx_http_lua_ffi_socket_tcp_get_tlshandshake_result(
++                                            r, u, sess, errmsg,
++                                            openssl_error_code);
++}
++
++
++void
++ngx_http_lua_ffi_ssl_free_session(ngx_ssl_session_t *sess)
++{
++    ngx_http_lua_ffi_tls_free_session(sess);
++}
+ 
+ 
+ int

--- a/t/tlshandshake_compat.t
+++ b/t/tlshandshake_compat.t
@@ -1,19 +1,4 @@
-our $SkipReason;
-
-BEGIN {
-    my $nginx_binary = $ENV{'TEST_NGINX_BINARY'} || 'nginx';
-    my $version = eval { `$nginx_binary -V 2>&1` } // '';
-    my ($major, $minor) = $version =~ m{openresty/(\d+)\.(\d+)};
-
-    if (!defined $major || !defined $minor
-        || ($major < 1 || ($major == 1 && $minor < 29))) {
-        $SkipReason = "requires OpenResty 1.29 or later";
-    }
-}
-
-use t::APISIX_NGINX $SkipReason
-    ? (skip_all => $SkipReason)
-    : ('no_plan');
+use t::APISIX_NGINX 'no_plan';
 
 no_root_location();
 run_tests();

--- a/t/tlshandshake_compat.t
+++ b/t/tlshandshake_compat.t
@@ -1,0 +1,170 @@
+our $SkipReason;
+
+BEGIN {
+    my $nginx_binary = $ENV{'TEST_NGINX_BINARY'} || 'nginx';
+    my $version = eval { `$nginx_binary -V 2>&1` } // '';
+    my ($major, $minor) = $version =~ m{openresty/(\d+)\.(\d+)};
+
+    if (!defined $major || !defined $minor
+        || ($major < 1 || ($major == 1 && $minor < 29))) {
+        $SkipReason = "requires OpenResty 1.29 or later";
+    }
+}
+
+use t::APISIX_NGINX $SkipReason
+    ? (skip_all => $SkipReason)
+    : ('no_plan');
+
+no_root_location();
+run_tests();
+
+__DATA__
+
+=== TEST 1: sslhandshake works on both ngx.socket.tcp() and ngx.socket.stream() objects (http)
+--- config
+    listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+    ssl_certificate ../../certs/test.crt;
+    ssl_certificate_key ../../certs/test.key;
+
+    location = /up {
+        return 200 'ok';
+    }
+
+    location = /t {
+        content_by_lua_block {
+            for _, ctor in ipairs({"tcp", "stream"}) do
+                local sock = ngx.socket[ctor]()
+                sock:settimeout(2000)
+                assert(sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock"))
+
+                local pok, sess, err = pcall(sock.sslhandshake, sock,
+                                             nil, nil, false)
+                ngx.say(ctor, " pcall: ", pok, ", session: ",
+                        sess ~= nil, ", err: ", err)
+                sock:close()
+            end
+        }
+    }
+--- response_body
+tcp pcall: true, session: true, err: nil
+stream pcall: true, session: true, err: nil
+
+
+
+=== TEST 2: tlshandshake works on both ngx.socket.tcp() and ngx.socket.stream() objects (http)
+--- config
+    listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+    ssl_certificate ../../certs/test.crt;
+    ssl_certificate_key ../../certs/test.key;
+
+    location = /up {
+        return 200 'ok';
+    }
+
+    location = /t {
+        content_by_lua_block {
+            for _, ctor in ipairs({"tcp", "stream"}) do
+                local sock = ngx.socket[ctor]()
+                sock:settimeout(2000)
+                assert(sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock"))
+
+                local pok, sess, err = pcall(sock.tlshandshake, sock)
+                ngx.say(ctor, " pcall: ", pok, ", session: ",
+                        sess ~= nil, ", err: ", err)
+                sock:close()
+            end
+        }
+    }
+--- response_body
+tcp pcall: true, session: true, err: nil
+stream pcall: true, session: true, err: nil
+
+
+
+=== TEST 3: sslhandshake/tlshandshake work on both constructors (stream subsystem)
+--- stream_config
+    server {
+        listen unix:$TEST_NGINX_HTML_DIR/stream_tls.sock ssl;
+        ssl_certificate ../../certs/test.crt;
+        ssl_certificate_key ../../certs/test.key;
+        content_by_lua_block {
+            local sk = assert(ngx.req.socket(true))
+            sk:send("hello")
+        }
+    }
+--- stream_server_config
+    content_by_lua_block {
+        for _, ctor in ipairs({"tcp", "stream"}) do
+            local sock = ngx.socket[ctor]()
+            sock:settimeout(2000)
+            assert(sock:connect("unix:$TEST_NGINX_HTML_DIR/stream_tls.sock"))
+
+            local pok, sess, err = pcall(sock.sslhandshake, sock,
+                                         nil, nil, false)
+            ngx.say(ctor, " ssl pcall: ", pok, ", session: ",
+                    sess ~= nil, ", err: ", err)
+            sock:close()
+
+            sock = ngx.socket[ctor]()
+            sock:settimeout(2000)
+            assert(sock:connect("unix:$TEST_NGINX_HTML_DIR/stream_tls.sock"))
+
+            pok, sess, err = pcall(sock.tlshandshake, sock)
+            ngx.say(ctor, " tls pcall: ", pok, ", session: ",
+                    sess ~= nil, ", err: ", err)
+            sock:close()
+        end
+    }
+--- stream_request
+--- stream_response
+tcp ssl pcall: true, session: true, err: nil
+tcp tls pcall: true, session: true, err: nil
+stream ssl pcall: true, session: true, err: nil
+stream tls pcall: true, session: true, err: nil
+
+
+
+=== TEST 4: file-based TLS options can be reused across connections
+--- config
+    listen unix:$TEST_NGINX_HTML_DIR/nginx.sock ssl;
+    ssl_certificate ../../certs/mtls_server.crt;
+    ssl_certificate_key ../../certs/mtls_server.key;
+    ssl_client_certificate ../../certs/mtls_ca.crt;
+    ssl_verify_client on;
+
+    location = /up {
+        return 200 "ok\n";
+    }
+
+    location = /t {
+        content_by_lua_block {
+            local options = {
+                client_cert_path = "t/certs/mtls_client.crt",
+                client_priv_key_path = "t/certs/mtls_client.key",
+            }
+
+            for i = 1, 2 do
+                local sock = ngx.socket.tcp()
+                sock:settimeout(2000)
+                assert(sock:connect("unix:$TEST_NGINX_HTML_DIR/nginx.sock"))
+
+                local pok, sess, err = pcall(sock.tlshandshake, sock, options)
+                ngx.say(i, " pcall: ", pok, ", session: ",
+                        sess ~= nil, ", err: ", err)
+
+                if pok and sess then
+                    assert(sock:send("GET /up HTTP/1.0\r\nHost: localhost\r\n\r\n"))
+                    assert(sock:receive("*a"))
+                end
+                sock:close()
+            end
+
+            ngx.say("options untouched: ",
+                    options.client_cert == nil and
+                    options.client_priv_key == nil)
+        }
+    }
+--- response_body
+1 pcall: true, session: true, err: nil
+2 pcall: true, session: true, err: nil
+options untouched: true


### PR DESCRIPTION
### Problem

The tlshandshake patches renamed the sslhandshake FFI symbols in place (`ngx_http_lua_ffi_socket_tcp_sslhandshake`, `..._get_sslhandshake_result`, `..._ssl_free_session`) and only wrapped the `ngx.socket.tcp()` constructor in lua-resty-core. Both the http and stream subsystems also expose `ngx.socket.stream()` as an alias registered to the same constructor and sharing the same cosocket metatable, so (api7/rfcs#111, TLS-1):

- http: `ngx.socket.stream():sslhandshake()` resolved to the stock lua-resty-core implementation on the shared metatable and failed at call time with `undefined symbol: ngx_http_lua_ffi_socket_tcp_sslhandshake`;
- stream: `ngx.socket.stream():sslhandshake()` hit a nil method, because the C metatable implementation was removed by the patch and the wrapper never covered this constructor.

Separately (TLS-2), `tlshandshake()` wrote the contents of `client_cert_path`/`client_priv_key_path` back into the caller's options table. The table is typically a shared, long-lived config object, so the second handshake using the same table failed with `client_cert_path and client_cert cannot both be set`.

### Fix

- Keep the original FFI symbol names as thin wrappers around the renamed implementations, so every consumer built against stock lua-resty-core keeps working (this also covers `getsslsession`, making the socket.lua repoint from #116 unnecessary — that hunk is dropped and stock lua-resty-core is untouched again).
- Install the lua-resty-core wrapper on both `ngx.socket.tcp` and `ngx.socket.stream`.
- Keep the loaded certificate/key file contents in locals instead of mutating the caller's options table.

### Tests

New `t/tlshandshake_compat.t` covers `sslhandshake`/`tlshandshake` on both constructors in both subsystems and reusing the same file-based mTLS options across two connections (all four blocks fail without the fix).

The fix is also backported to the 1.21.4 patches used by api7ee-runtime. That generation never renamed the http FFI symbols (its tcp.lua binds the stock ssl-named functions directly), so only the two Lua-side defects exist there: the wrapper missing `ngx.socket.stream()` (nil `tlshandshake` on http stream objects; neither method on stream-subsystem stream objects, whose C `sslhandshake` the stream patch removes) and the caller-options mutation. With both supported runtimes fixed, the test file runs unconditionally on both CI matrices.

Ref api7/rfcs#111 (TLS-1, TLS-2).

Fixes api7/api7-ee-3-gateway#1973.