### PR TITLE
fix(xrpc): protect pending reads from move/reset and recycle the whole chain on reset

### DIFF
--- a/lib/resty/apisix/stream/xrpc/socket.lua
+++ b/lib/resty/apisix/stream/xrpc/socket.lua
@@ -40,15 +40,31 @@ ngx_stream_lua_ffi_socket_tcp_get_send_result(ngx_stream_lua_request_t *r,
     ngx_stream_lua_socket_tcp_upstream_t *u, u_char *errbuf,
     size_t *errbuf_size);
 
-void
-ngx_stream_lua_ffi_socket_tcp_reset_read_buf(ngx_stream_lua_request_t *r,
-    ngx_stream_lua_socket_tcp_upstream_t *u);
-
 int
 ngx_stream_lua_ffi_socket_tcp_has_pending_data(ngx_stream_lua_request_t *r,
     ngx_stream_lua_socket_tcp_upstream_t *u,
     u_char *errbuf, size_t *errbuf_size);
 ]]
+
+-- the 1.29.2.4 patches turned reset_read_buf into a fallible operation
+-- (it rejects a socket with a pending read); older runtime patches keep
+-- the void signature until the fix is backported
+local reset_read_buf_can_fail = ngx.config.nginx_version >= 1029000
+
+if reset_read_buf_can_fail then
+    ffi.cdef[[
+    int
+    ngx_stream_lua_ffi_socket_tcp_reset_read_buf(ngx_stream_lua_request_t *r,
+        ngx_stream_lua_socket_tcp_upstream_t *u,
+        u_char *errbuf, size_t *errbuf_size);
+    ]]
+else
+    ffi.cdef[[
+    void
+    ngx_stream_lua_ffi_socket_tcp_reset_read_buf(ngx_stream_lua_request_t *r,
+        ngx_stream_lua_socket_tcp_upstream_t *u);
+    ]]
+end
 local socket_tcp_read = C.ngx_stream_lua_ffi_socket_tcp_read_buf
 local socket_tcp_get_read_result = C.ngx_stream_lua_ffi_socket_tcp_get_read_buf_result
 local socket_tcp_move = C.ngx_stream_lua_ffi_socket_tcp_send_from_socket
@@ -268,7 +284,22 @@ local function reset_read_buf(cosocket)
     end
 
     local u = get_tcp_socket(cosocket)
-    socket_tcp_reset_read_buf(r, u)
+
+    if not reset_read_buf_can_fail then
+        socket_tcp_reset_read_buf(r, u)
+        return true
+    end
+
+    local errbuf = get_string_buf(ERR_BUF_SIZE)
+    local errbuf_size = get_size_ptr()
+    errbuf_size[0] = ERR_BUF_SIZE
+
+    local rc = socket_tcp_reset_read_buf(r, u, errbuf, errbuf_size)
+    if rc == FFI_ERROR then
+        return nil, ffi_str(errbuf, errbuf_size[0])
+    end
+
+    return true
 end
 
 

--- a/lib/resty/apisix/stream/xrpc/socket.lua
+++ b/lib/resty/apisix/stream/xrpc/socket.lua
@@ -46,10 +46,14 @@ ngx_stream_lua_ffi_socket_tcp_has_pending_data(ngx_stream_lua_request_t *r,
     u_char *errbuf, size_t *errbuf_size);
 ]]
 
--- the 1.29.2.4 patches turned reset_read_buf into a fallible operation
--- (it rejects a socket with a pending read); older runtime patches keep
--- the void signature until the fix is backported
-local reset_read_buf_can_fail = ngx.config.nginx_version >= 1029000
+-- the 1.29.2.4 and 1.21.4.x patches turned reset_read_buf into a
+-- fallible operation (it rejects a socket with a pending read); the
+-- other historical runtime patches keep the void signature until the
+-- fix is backported (nginx 1021004 identifies the OpenResty 1.21.4.x
+-- generation, whose patch directories are both fixed)
+local nginx_version = ngx.config.nginx_version
+local reset_read_buf_can_fail = nginx_version >= 1029000
+                                or nginx_version == 1021004
 
 if reset_read_buf_can_fail then
     ffi.cdef[[

--- a/patch/1.21.4.1/ngx_stream_lua-xrpc.patch
+++ b/patch/1.21.4.1/ngx_stream_lua-xrpc.patch
@@ -158,7 +158,7 @@ index 7fcfb45..9981b4b 100644
  static ngx_int_t
  ngx_stream_lua_socket_tcp_read(ngx_stream_lua_request_t *r,
      ngx_stream_lua_socket_tcp_upstream_t *u)
-@@ -6005,6 +6065,672 @@ static ngx_int_t ngx_stream_lua_socket_insert_buffer(
+@@ -6005,6 +6065,691 @@ static ngx_int_t ngx_stream_lua_socket_insert_buffer(
  }
  
  
@@ -166,19 +166,27 @@ index 7fcfb45..9981b4b 100644
 +ngx_stream_lua_ffi_socket_reset_buf(ngx_stream_lua_ctx_t *ctx,
 +    ngx_stream_lua_socket_tcp_upstream_t *u)
 +{
-+    ngx_chain_t             *cl = u->bufs_in;
-+    ngx_chain_t            **ll = NULL;
++    ngx_chain_t             *cl;
 +
-+    if (cl == NULL) {
++    if (u->bufs_in == NULL) {
 +        return;
 +    }
 +
-+    if (cl->next) {
-+        ll = &cl->next;
-+    }
++    if (u->bufs_in != u->buf_in) {
 +
-+    if (ll) {
-+        *ll = ctx->free_recv_bufs;
++        /*
++         * recycle every node before the current buf_in: link the whole
++         * [bufs_in, predecessor of buf_in] segment onto free_recv_bufs
++         * instead of only the head node, otherwise the nodes in between
++         * become unreachable and a new chain link is allocated from the
++         * request pool on every following read
++         */
++
++        for (cl = u->bufs_in; cl->next != u->buf_in; cl = cl->next) {
++            /* void */
++        }
++
++        cl->next = ctx->free_recv_bufs;
 +        ctx->free_recv_bufs = u->bufs_in;
 +        u->bufs_in = u->buf_in;
 +    }
@@ -195,14 +203,21 @@ index 7fcfb45..9981b4b 100644
 +}
 +
 +
-+void
++int
 +ngx_stream_lua_ffi_socket_tcp_reset_read_buf(ngx_stream_lua_request_t *r,
-+    ngx_stream_lua_socket_tcp_upstream_t *u)
++    ngx_stream_lua_socket_tcp_upstream_t *u,
++    u_char *errbuf, size_t *errbuf_size)
 +{
 +    ngx_stream_lua_ctx_t    *ctx;
 +
++    /* resetting the buffers under a pending read would corrupt the data
++     * being read into them */
++    ngx_stream_lua_ffi_socket_check_busy_reading(r, u, errbuf, errbuf_size);
++
 +    ctx = ngx_stream_lua_get_module_ctx(r, ngx_stream_lua_module);
 +    ngx_stream_lua_ffi_socket_reset_buf(ctx, u);
++
++    return NGX_OK;
 +}
 +
 +
@@ -670,6 +685,10 @@ index 7fcfb45..9981b4b 100644
 +
 +    ngx_stream_lua_ffi_socket_check_busy_connecting(r, u, errbuf, errbuf_size);
 +    ngx_stream_lua_ffi_socket_check_busy_writing(r, u, errbuf, errbuf_size);
++
++    /* the source buffers are consumed and reset below; a pending read on
++     * the source socket would have its data corrupted */
++    ngx_stream_lua_ffi_socket_check_busy_reading(r, src, errbuf, errbuf_size);
 +
 +    if (u->body_downstream) {
 +        *errbuf_size = ngx_snprintf(errbuf, *errbuf_size,

--- a/patch/1.21.4/ngx_stream_lua-xrpc.patch
+++ b/patch/1.21.4/ngx_stream_lua-xrpc.patch
@@ -158,7 +158,7 @@ index 7fcfb45..9981b4b 100644
  static ngx_int_t
  ngx_stream_lua_socket_tcp_read(ngx_stream_lua_request_t *r,
      ngx_stream_lua_socket_tcp_upstream_t *u)
-@@ -6005,6 +6065,672 @@ static ngx_int_t ngx_stream_lua_socket_insert_buffer(
+@@ -6005,6 +6065,691 @@ static ngx_int_t ngx_stream_lua_socket_insert_buffer(
  }
  
  
@@ -166,19 +166,27 @@ index 7fcfb45..9981b4b 100644
 +ngx_stream_lua_ffi_socket_reset_buf(ngx_stream_lua_ctx_t *ctx,
 +    ngx_stream_lua_socket_tcp_upstream_t *u)
 +{
-+    ngx_chain_t             *cl = u->bufs_in;
-+    ngx_chain_t            **ll = NULL;
++    ngx_chain_t             *cl;
 +
-+    if (cl == NULL) {
++    if (u->bufs_in == NULL) {
 +        return;
 +    }
 +
-+    if (cl->next) {
-+        ll = &cl->next;
-+    }
++    if (u->bufs_in != u->buf_in) {
 +
-+    if (ll) {
-+        *ll = ctx->free_recv_bufs;
++        /*
++         * recycle every node before the current buf_in: link the whole
++         * [bufs_in, predecessor of buf_in] segment onto free_recv_bufs
++         * instead of only the head node, otherwise the nodes in between
++         * become unreachable and a new chain link is allocated from the
++         * request pool on every following read
++         */
++
++        for (cl = u->bufs_in; cl->next != u->buf_in; cl = cl->next) {
++            /* void */
++        }
++
++        cl->next = ctx->free_recv_bufs;
 +        ctx->free_recv_bufs = u->bufs_in;
 +        u->bufs_in = u->buf_in;
 +    }
@@ -195,14 +203,21 @@ index 7fcfb45..9981b4b 100644
 +}
 +
 +
-+void
++int
 +ngx_stream_lua_ffi_socket_tcp_reset_read_buf(ngx_stream_lua_request_t *r,
-+    ngx_stream_lua_socket_tcp_upstream_t *u)
++    ngx_stream_lua_socket_tcp_upstream_t *u,
++    u_char *errbuf, size_t *errbuf_size)
 +{
 +    ngx_stream_lua_ctx_t    *ctx;
 +
++    /* resetting the buffers under a pending read would corrupt the data
++     * being read into them */
++    ngx_stream_lua_ffi_socket_check_busy_reading(r, u, errbuf, errbuf_size);
++
 +    ctx = ngx_stream_lua_get_module_ctx(r, ngx_stream_lua_module);
 +    ngx_stream_lua_ffi_socket_reset_buf(ctx, u);
++
++    return NGX_OK;
 +}
 +
 +
@@ -670,6 +685,10 @@ index 7fcfb45..9981b4b 100644
 +
 +    ngx_stream_lua_ffi_socket_check_busy_connecting(r, u, errbuf, errbuf_size);
 +    ngx_stream_lua_ffi_socket_check_busy_writing(r, u, errbuf, errbuf_size);
++
++    /* the source buffers are consumed and reset below; a pending read on
++     * the source socket would have its data corrupted */
++    ngx_stream_lua_ffi_socket_check_busy_reading(r, src, errbuf, errbuf_size);
 +
 +    if (u->body_downstream) {
 +        *errbuf_size = ngx_snprintf(errbuf, *errbuf_size,

--- a/patch/1.29.2.4/ngx_stream_lua-xrpc.patch
+++ b/patch/1.29.2.4/ngx_stream_lua-xrpc.patch
@@ -160,7 +160,7 @@ index 57f389d..6855e37 100644
  static ngx_int_t
  ngx_stream_lua_socket_tcp_read(ngx_stream_lua_request_t *r,
      ngx_stream_lua_socket_tcp_upstream_t *u)
-@@ -5971,6 +6031,672 @@ static ngx_int_t ngx_stream_lua_socket_insert_buffer(
+@@ -5971,6 +6031,691 @@ static ngx_int_t ngx_stream_lua_socket_insert_buffer(
  }
  
  
@@ -168,19 +168,27 @@ index 57f389d..6855e37 100644
 +ngx_stream_lua_ffi_socket_reset_buf(ngx_stream_lua_ctx_t *ctx,
 +    ngx_stream_lua_socket_tcp_upstream_t *u)
 +{
-+    ngx_chain_t             *cl = u->bufs_in;
-+    ngx_chain_t            **ll = NULL;
++    ngx_chain_t             *cl;
 +
-+    if (cl == NULL) {
++    if (u->bufs_in == NULL) {
 +        return;
 +    }
 +
-+    if (cl->next) {
-+        ll = &cl->next;
-+    }
++    if (u->bufs_in != u->buf_in) {
 +
-+    if (ll) {
-+        *ll = ctx->free_recv_bufs;
++        /*
++         * recycle every node before the current buf_in: link the whole
++         * [bufs_in, predecessor of buf_in] segment onto free_recv_bufs
++         * instead of only the head node, otherwise the nodes in between
++         * become unreachable and a new chain link is allocated from the
++         * request pool on every following read
++         */
++
++        for (cl = u->bufs_in; cl->next != u->buf_in; cl = cl->next) {
++            /* void */
++        }
++
++        cl->next = ctx->free_recv_bufs;
 +        ctx->free_recv_bufs = u->bufs_in;
 +        u->bufs_in = u->buf_in;
 +    }
@@ -197,14 +205,21 @@ index 57f389d..6855e37 100644
 +}
 +
 +
-+void
++int
 +ngx_stream_lua_ffi_socket_tcp_reset_read_buf(ngx_stream_lua_request_t *r,
-+    ngx_stream_lua_socket_tcp_upstream_t *u)
++    ngx_stream_lua_socket_tcp_upstream_t *u,
++    u_char *errbuf, size_t *errbuf_size)
 +{
 +    ngx_stream_lua_ctx_t    *ctx;
 +
++    /* resetting the buffers under a pending read would corrupt the data
++     * being read into them */
++    ngx_stream_lua_ffi_socket_check_busy_reading(r, u, errbuf, errbuf_size);
++
 +    ctx = ngx_stream_lua_get_module_ctx(r, ngx_stream_lua_module);
 +    ngx_stream_lua_ffi_socket_reset_buf(ctx, u);
++
++    return NGX_OK;
 +}
 +
 +
@@ -672,6 +687,10 @@ index 57f389d..6855e37 100644
 +
 +    ngx_stream_lua_ffi_socket_check_busy_connecting(r, u, errbuf, errbuf_size);
 +    ngx_stream_lua_ffi_socket_check_busy_writing(r, u, errbuf, errbuf_size);
++
++    /* the source buffers are consumed and reset below; a pending read on
++     * the source socket would have its data corrupted */
++    ngx_stream_lua_ffi_socket_check_busy_reading(r, src, errbuf, errbuf_size);
 +
 +    if (u->body_downstream) {
 +        *errbuf_size = ngx_snprintf(errbuf, *errbuf_size,

--- a/t/stream/xrpc/reset_move.t
+++ b/t/stream/xrpc/reset_move.t
@@ -1,19 +1,4 @@
-our $SkipReason;
-
-BEGIN {
-    my $nginx_binary = $ENV{'TEST_NGINX_BINARY'} || 'nginx';
-    my $version = eval { `$nginx_binary -V 2>&1` } // '';
-    my ($major, $minor) = $version =~ m{openresty/(\d+)\.(\d+)};
-
-    if (!defined $major || !defined $minor
-        || ($major < 1 || ($major == 1 && $minor < 29))) {
-        $SkipReason = "requires OpenResty 1.29 or later";
-    }
-}
-
-use t::APISIX_NGINX $SkipReason
-    ? (skip_all => $SkipReason)
-    : ('no_plan');
+use t::APISIX_NGINX 'no_plan';
 
 run_tests();
 

--- a/t/stream/xrpc/reset_move.t
+++ b/t/stream/xrpc/reset_move.t
@@ -1,0 +1,161 @@
+our $SkipReason;
+
+BEGIN {
+    my $nginx_binary = $ENV{'TEST_NGINX_BINARY'} || 'nginx';
+    my $version = eval { `$nginx_binary -V 2>&1` } // '';
+    my ($major, $minor) = $version =~ m{openresty/(\d+)\.(\d+)};
+
+    if (!defined $major || !defined $minor
+        || ($major < 1 || ($major == 1 && $minor < 29))) {
+        $SkipReason = "requires OpenResty 1.29 or later";
+    }
+}
+
+use t::APISIX_NGINX $SkipReason
+    ? (skip_all => $SkipReason)
+    : ('no_plan');
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: move rejects a source socket with a pending read
+--- stream_config
+    server {
+        listen 1995;
+        content_by_lua_block {
+            local sk = assert(ngx.req.socket(true))
+            assert(sk:send("AAAA"))
+            ngx.sleep(0.1)
+            assert(sk:send("BBBB"))
+        }
+    }
+--- stream_server_config
+    content_by_lua_block {
+        local ffi = require("ffi")
+        local xrpc = require("resty.apisix.stream.xrpc.socket")
+        local src = xrpc.upstream.socket()
+        src:settimeout(1000)
+        assert(src:connect("127.0.0.1", 1995))
+
+        local th = ngx.thread.spawn(function()
+            local p, err = src:read(8)
+            if p then
+                ngx.log(ngx.WARN, "read result hex: ",
+                        require("resty.string").to_hex(ffi.string(p, 8)))
+            else
+                ngx.log(ngx.WARN, "read error: ", err)
+            end
+        end)
+
+        ngx.sleep(0.02)
+        local dst = xrpc.downstream.socket()
+        local ok, err = dst:move(src)
+        ngx.log(ngx.WARN, "move result: ", ok, ", ", err)
+        assert(ngx.thread.wait(th))
+    }
+--- stream_request
+--- stream_response
+--- grep_error_log eval
+qr/(?:move result: nil, socket busy reading|read result hex: [0-9a-f]+)/
+--- grep_error_log_out
+move result: nil, socket busy reading
+read result hex: 4141414142424242
+
+
+
+=== TEST 2: reset_read_buf rejects a socket with a pending read
+--- stream_config
+    server {
+        listen 1996;
+        content_by_lua_block {
+            local sk = assert(ngx.req.socket(true))
+            assert(sk:send("AAAA"))
+            ngx.sleep(0.1)
+            assert(sk:send("BBBB"))
+        }
+    }
+--- stream_server_config
+    content_by_lua_block {
+        local ffi = require("ffi")
+        local xrpc = require("resty.apisix.stream.xrpc.socket")
+        local src = xrpc.upstream.socket()
+        src:settimeout(1000)
+        assert(src:connect("127.0.0.1", 1996))
+
+        local th = ngx.thread.spawn(function()
+            local p, err = src:read(8)
+            if p then
+                ngx.log(ngx.WARN, "read result hex: ",
+                        require("resty.string").to_hex(ffi.string(p, 8)))
+            else
+                ngx.log(ngx.WARN, "read error: ", err)
+            end
+        end)
+
+        ngx.sleep(0.02)
+        local ok, err = src:reset_read_buf()
+        ngx.log(ngx.WARN, "reset result: ", ok, ", ", err)
+        assert(ngx.thread.wait(th))
+    }
+--- stream_request
+--- stream_response
+--- grep_error_log eval
+qr/(?:reset result: nil, socket busy reading|read result hex: [0-9a-f]+)/
+--- grep_error_log_out
+reset result: nil, socket busy reading
+read result hex: 4141414142424242
+
+
+
+=== TEST 3: reset_read_buf recycles every receive buffer
+--- stream_server_config
+    lua_socket_buffer_size 128;
+    content_by_lua_block {
+        local sk = require("resty.apisix.stream.xrpc.socket").downstream.socket()
+        sk:settimeout(1000)
+
+        for _ = 1, 10 do
+            assert(sk:read(128))
+            assert(sk:read(128))
+            assert(sk:read(128))
+            assert(sk:reset_read_buf())
+        end
+
+        ngx.say("ok")
+    }
+--- stream_request eval
+"x" x (128 * 3 * 10)
+--- stream_response
+ok
+--- grep_error_log eval
+qr/lua allocate new chainlink and new buf of size 128/
+--- grep_error_log_out eval
+("lua allocate new chainlink and new buf of size 128\n" x 3)
+
+
+
+=== TEST 4: move still works on an idle source socket
+--- stream_config
+    server {
+        listen 1997;
+        content_by_lua_block {
+            local sk = assert(ngx.req.socket(true))
+            assert(sk:send("AAAABBBB"))
+        }
+    }
+--- stream_server_config
+    content_by_lua_block {
+        local xrpc = require("resty.apisix.stream.xrpc.socket")
+        local src = xrpc.upstream.socket()
+        src:settimeout(1000)
+        assert(src:connect("127.0.0.1", 1997))
+
+        assert(src:read(8))
+
+        local dst = xrpc.downstream.socket()
+        assert(dst:move(src))
+    }
+--- stream_request
+--- stream_response eval
+"AAAABBBB"


### PR DESCRIPTION
### Problem

Two defects in the xRPC read-buffer reset path (api7/rfcs#111, XRPC-1/XRPC-2):

1. `move(dst, src)` checked the destination for busy connecting/writing but never checked whether the **source** socket had a pending read before consuming and resetting its buffers, and the public `reset_read_buf()` performed the reset without any state check. A light thread waiting on `src:read()` while another thread called `move()`/`reset_read_buf()` had its in-flight data corrupted: reading 8 bytes across the reset returned `0000000042424242` instead of `AAAABBBB`.
2. The reset only relinked the head node of the receive chain onto `free_recv_bufs`: for a chain `A -> B -> C` with `C` being the current `buf_in`, `A->next` was repointed to the old free list and `B` became unreachable. Every following cross-buffer read allocated a new chain link from the request pool, which lives as long as the (long-lived) stream session — 10 read/reset rounds allocated 12 buffers instead of the expected 3.

### Fix

- Both entry points that reset the source buffers now fail with `socket busy reading` when a read is pending, consistent with the concurrent-access protection of the standard cosocket operations. `reset_read_buf()` accordingly returns `ok, err` instead of nothing; on older runtimes (whose patches keep the void FFI signature until the fix is backported) the Lua wrapper keeps the old calling convention via an nginx-version branch.
- The reset now walks to the predecessor of `buf_in` and recycles the whole `[head, predecessor]` segment.

### Tests

New `t/stream/xrpc/reset_move.t` covers move/reset rejection under a pending read (with data integrity assertions), buffer recycling across 10 reset rounds, and move on an idle socket.

The fix is also backported to the 1.21.4.x patches (both `patch/1.21.4` and `patch/1.21.4.1`, whose runtimes are indistinguishable by nginx version, which the shared Lua wrapper uses to pick the reset_read_buf FFI signature), so the test file runs unconditionally on both CI runtimes.

Ref api7/rfcs#111 (XRPC-1, XRPC-2).

Fixes api7/api7-ee-3-gateway#1973.