### PR TITLE
fix(skip-filter): run the header filter skip check before the handler closure is loaded

### DIFF
--- a/patch/1.21.4/ngx_lua-skip_filter.patch
+++ b/patch/1.21.4/ngx_lua-skip_filter.patch
@@ -26,7 +26,7 @@ index 78e3b5c2..bfdb01b3 100644
 
      if (llcf->body_filter_handler == NULL || r->header_only) {
 diff --git src/ngx_http_lua_headerfilterby.c src/ngx_http_lua_headerfilterby.c
-index 86c58754..1bc946cd 100644
+index 86c5875..047e0d0 100644
 --- src/ngx_http_lua_headerfilterby.c
 +++ src/ngx_http_lua_headerfilterby.c
 @@ -19,6 +19,9 @@
@@ -39,16 +39,24 @@ index 86c58754..1bc946cd 100644
  
  
  static ngx_http_output_header_filter_pt ngx_http_next_header_filter;
-@@ -80,6 +83,12 @@ ngx_http_lua_header_filter_by_chunk(lua_State *L, ngx_http_request_t *r)
- #endif
-     ngx_http_lua_ctx_t          *ctx;
+@@ -236,6 +239,20 @@ ngx_http_lua_header_filter(ngx_http_request_t *r)
+     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                    "lua header filter for user lua code, uri \"%V\"", &r->uri);
  
 +#if (NGX_HTTP_APISIX)
++    /*
++     * the skip check must run before the inline/file handlers push the
++     * handler closure onto the Lua stack; skipping inside
++     * ngx_http_lua_header_filter_by_chunk() would return with that
++     * closure left behind on the main VM stack (the normal path only
++     * clears it via lua_settop() at the end), relying on an unrelated
++     * later lua_settop(L, 0) to clean it up
++     */
 +    if (ngx_http_apisix_is_header_filter_by_lua_skipped(r)) {
-+        return NGX_OK;
++        return ngx_http_next_header_filter(r);
 +    }
 +#endif
 +
-     ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
-     if (ctx->exited) {
-         old_exit_code = ctx->exit_code;
+     llcf = ngx_http_get_module_loc_conf(r, ngx_http_lua_module);
+ 
+     if (llcf->body_filter_handler) {

--- a/patch/1.29.2.4/ngx_lua-skip_filter.patch
+++ b/patch/1.29.2.4/ngx_lua-skip_filter.patch
@@ -26,7 +26,7 @@ index 9024889..88af761 100644
  
      if (llcf->body_filter_handler == NULL || r->header_only) {
 diff --git src/ngx_http_lua_headerfilterby.c src/ngx_http_lua_headerfilterby.c
-index ed0c3a6..5f04992 100644
+index 2fa40ae..4c41b6c 100644
 --- src/ngx_http_lua_headerfilterby.c
 +++ src/ngx_http_lua_headerfilterby.c
 @@ -19,6 +19,9 @@
@@ -39,16 +39,24 @@ index ed0c3a6..5f04992 100644
  
  
  static ngx_http_output_header_filter_pt ngx_http_next_header_filter;
-@@ -80,6 +83,12 @@ ngx_http_lua_header_filter_by_chunk(lua_State *L, ngx_http_request_t *r)
- #endif
-     ngx_http_lua_ctx_t          *ctx;
+@@ -244,6 +247,20 @@ ngx_http_lua_header_filter(ngx_http_request_t *r)
+     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                    "lua header filter for user lua code, uri \"%V\"", &r->uri);
  
 +#if (NGX_HTTP_APISIX)
++    /*
++     * the skip check must run before the inline/file handlers push the
++     * handler closure onto the Lua stack; skipping inside
++     * ngx_http_lua_header_filter_by_chunk() would return with that
++     * closure left behind on the main VM stack (the normal path only
++     * clears it via lua_settop() at the end), relying on an unrelated
++     * later lua_settop(L, 0) to clean it up
++     */
 +    if (ngx_http_apisix_is_header_filter_by_lua_skipped(r)) {
-+        return NGX_OK;
++        return ngx_http_next_header_filter(r);
 +    }
 +#endif
 +
-     ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
-     if (ctx->exited) {
-         old_exit_code = ctx->exit_code;
+     llcf = ngx_http_get_module_loc_conf(r, ngx_http_lua_module);
+ 
+     if (llcf->body_filter_handler) {


### PR DESCRIPTION
### Problem

The header-filter skip check sat inside `ngx_http_lua_header_filter_by_chunk()`, which is only called after the inline/file handlers have pushed the handler closure onto the main Lua VM stack; returning early there skips the `lua_settop(L, 0)` cleanup at the end of the normal path and leaves the closure behind on the stack (api7/rfcs#111, FILTER-1).

While re-verifying the report, no unbounded worker memory growth was observed: the leaked slots are wiped by the next entry-thread completion (`ngx_http_lua_run_thread()` clears the main VM stack), so the impact is a transient stack imbalance plus a reliance on that unrelated cleanup — not the sustained growth described in the report.

### Fix

Run the skip check in the outer `ngx_http_lua_header_filter()` before any Lua state is touched, aligning it with the placement the body filter already uses. Applied to both the 1.29.2.4 and 1.21.4 patch generations; the existing `t/skip_filter.t` behavior tests already run on both CI runtimes.

### Tests

Covered by the existing `t/skip_filter.t` behavior tests. The stack-slot imbalance itself is not observable from Lua land, and memory-growth assertions proved not reproducible because of the unrelated cleanup above (verified with 8000 consecutive skipped responses: main VM memory stays flat both before and after the fix).

Ref api7/rfcs#111 (FILTER-1).

Fixes api7/api7-ee-3-gateway#1973.