### PR TITLE
fix(privileged-agent): report the actual owner role in the listen address conflict error

### DIFF
--- a/patch/1.21.4/nginx-listen-in-privileged-agent.patch
+++ b/patch/1.21.4/nginx-listen-in-privileged-agent.patch
@@ -55,13 +55,17 @@ diff --git src/http/ngx_http.c src/http/ngx_http.c
 index e1d3d00..7ad72e3 100644
 --- src/http/ngx_http.c
 +++ src/http/ngx_http.c
-@@ -1217,6 +1217,13 @@ ngx_http_add_addresses(ngx_conf_t *cf, ngx_http_core_srv_conf_t *cscf,
+@@ -1217,6 +1217,17 @@ ngx_http_add_addresses(ngx_conf_t *cf, ngx_http_core_srv_conf_t *cscf,
              continue;
          }
 
 +        if (lsopt->privileged_agent != addr[i].opt.privileged_agent) {
++            /* report the role of the listener that actually occupies the
++             * address, not unconditionally the privileged agent */
 +            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
-+                               "%V is already occupied by privileged agent",
++                               addr[i].opt.privileged_agent
++                               ? "%V is already occupied by privileged agent"
++                               : "%V is already occupied by worker process",
 +                               &addr[i].opt.addr_text);
 +            return NGX_ERROR;
 +        }
@@ -132,7 +136,7 @@ index e8ebf3d..8227ecf 100644
 
      /* Set a moderate number of connections for a helper process. */
      cycle->connection_n = 512;
-@@ -1265,6 +1269,7 @@ ngx_privileged_agent_process_cycle(ngx_cycle_t *cycle, void *data)
+@@ -1265,5 +1269,6 @@ ngx_privileged_agent_process_cycle(ngx_cycle_t *cycle, void *data)
 
          if (ngx_terminate || ngx_quit) {
              ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0, "exiting");

--- a/patch/1.29.2.4/nginx-listen-in-privileged-agent.patch
+++ b/patch/1.29.2.4/nginx-listen-in-privileged-agent.patch
@@ -58,13 +58,17 @@ diff --git src/http/ngx_http.c src/http/ngx_http.c
 index d835f89..8f019c2 100644
 --- src/http/ngx_http.c
 +++ src/http/ngx_http.c
-@@ -1262,6 +1262,13 @@ ngx_http_add_addresses(ngx_conf_t *cf, ngx_http_core_srv_conf_t *cscf,
+@@ -1262,6 +1262,17 @@ ngx_http_add_addresses(ngx_conf_t *cf, ngx_http_core_srv_conf_t *cscf,
              continue;
          }
  
 +        if (lsopt->privileged_agent != addr[i].opt.privileged_agent) {
++            /* report the role of the listener that actually occupies the
++             * address, not unconditionally the privileged agent */
 +            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
-+                               "%V is already occupied by privileged agent",
++                               addr[i].opt.privileged_agent
++                               ? "%V is already occupied by privileged agent"
++                               : "%V is already occupied by worker process",
 +                               &addr[i].opt.addr_text);
 +            return NGX_ERROR;
 +        }

--- a/t/privileged_agent.t
+++ b/t/privileged_agent.t
@@ -95,6 +95,40 @@ server {
     }
 --- must_die
 --- error_log
+127.0.0.1:9091 is already occupied by worker process
+
+
+
+=== TEST 2a: address conflict detection (privileged agent listener declared first)
+--- http_config
+init_by_lua_block {
+    local process = require("ngx.process")
+    assert(process.enable_privileged_agent())
+}
+server {
+    listen 127.0.0.1:9091 enable_process=privileged_agent;
+    location / {
+        content_by_lua_block {
+            local process = require("ngx.process")
+            ngx.say(process.type())
+        }
+    }
+}
+server {
+    listen 127.0.0.1:9091;
+    location / {
+        content_by_lua_block {
+            local process = require("ngx.process")
+            ngx.say(process.type())
+        }
+    }
+}
+--- config
+    location /t {
+        return 200;
+    }
+--- must_die
+--- error_log
 127.0.0.1:9091 is already occupied by privileged agent
 
 


### PR DESCRIPTION
### Problem

When a normal worker listener and an `enable_process=privileged_agent` listener declare the same address, the conflict is correctly rejected, but the error text always claimed the address `is already occupied by privileged agent`, regardless of which side was declared first. With the worker listener declared first, the message blamed the wrong listener and misled troubleshooting (api7/rfcs#111, PA-5).

### Fix

Print the role of the listener that actually occupies the address. The same hunk is carried verbatim by every runtime patch generation, so the 1.21.4 patches used by the currently supported api7ee-runtime (OpenResty 1.21.4.4) get the same one-line fix, keeping the shared test suite consistent across both CI runtimes; the remaining historical patch directories are left untouched.

### Tests

The existing conflict test in `t/privileged_agent.t` asserted the misattributed message; it now asserts the correct role for both declaration orders.

Ref api7/rfcs#111 (PA-5).

Fixes api7/api7-ee-3-gateway#1973.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for assigning listeners to a privileged-agent process through configuration.
  * Improved listener ownership handling so only the appropriate process accepts connections.
  * Connections now fail fast when a privileged-agent listener is unavailable.

* **Bug Fixes**
  * Enhanced address-conflict errors to identify whether a worker or privileged agent already occupies the address.
  * Improved listener behavior across process startup, shutdown, and reloads.

* **Tests**
  * Expanded coverage for listener conflicts and role-specific error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->