### PR TITLE
fix(privileged-agent): let the master process own the privileged agent listener sockets

### DIFF
--- a/patch/1.21.4/nginx-listen-in-privileged-agent.patch
+++ b/patch/1.21.4/nginx-listen-in-privileged-agent.patch
@@ -1,18 +1,3 @@
-diff --git src/core/ngx_connection.c src/core/ngx_connection.c
-index 568ae3d..e22c990 100644
---- src/core/ngx_connection.c
-+++ src/core/ngx_connection.c
-@@ -434,6 +434,10 @@ ngx_open_listening_sockets(ngx_cycle_t *cycle)
-                 continue;
-             }
-
-+            if (ngx_is_privileged_agent != ls[i].privileged_agent) {
-+                continue;
-+            }
-+
- #if (NGX_HAVE_REUSEPORT)
-
-             if (ls[i].add_reuseport) {
 diff --git src/core/ngx_connection.h src/core/ngx_connection.h
 index be75d82..12c8694 100644
 --- src/core/ngx_connection.h
@@ -26,31 +11,34 @@ index be75d82..12c8694 100644
  #if (NGX_HAVE_INET6)
      unsigned            ipv6only:1;
 diff --git src/event/ngx_event.c src/event/ngx_event.c
-index d800af0..f73e57c 100644
+index 934f2cf..6f5a997 100644
 --- src/event/ngx_event.c
 +++ src/event/ngx_event.c
-@@ -818,7 +818,9 @@ ngx_event_process_init(ngx_cycle_t *cycle)
+@@ -820,6 +820,24 @@ ngx_event_process_init(ngx_cycle_t *cycle)
+     ls = cycle->listening.elts;
      for (i = 0; i < cycle->listening.nelts; i++) {
-
- #if (NGX_HAVE_REUSEPORT)
--        if (ls[i].reuseport && ls[i].worker != ngx_worker) {
-+        if ((ngx_is_privileged_agent && !ls[i].privileged_agent)
-+            || (ls[i].reuseport && ls[i].worker != ngx_worker))
-+        {
-             ngx_log_debug2(NGX_LOG_DEBUG_CORE, cycle->log, 0,
-                            "closing unused fd:%d listening on %V",
-                            ls[i].fd, &ls[i].addr_text);
-@@ -833,6 +835,10 @@ ngx_event_process_init(ngx_cycle_t *cycle)
-
-             continue;
-         }
+ 
++        if (ngx_is_privileged_agent != ls[i].privileged_agent) {
++            if (ls[i].fd != (ngx_socket_t) -1) {
++                ngx_log_debug2(NGX_LOG_DEBUG_CORE, cycle->log, 0,
++                               "closing unused fd:%d listening on %V",
++                               ls[i].fd, &ls[i].addr_text);
 +
-+        if (!ngx_is_privileged_agent && ls[i].privileged_agent) {
++                if (ngx_close_socket(ls[i].fd) == -1) {
++                    ngx_log_error(NGX_LOG_EMERG, cycle->log, ngx_socket_errno,
++                                  ngx_close_socket_n " %V failed",
++                                  &ls[i].addr_text);
++                }
++            }
++
++            ls[i].fd = (ngx_socket_t) -1;
++
 +            continue;
 +        }
- #endif
-
-         c = ngx_get_connection(ls[i].fd, cycle->log);
++
+ #if (NGX_HAVE_REUSEPORT)
+         if (ls[i].reuseport && ls[i].worker != ngx_worker) {
+             ngx_log_debug2(NGX_LOG_DEBUG_CORE, cycle->log, 0,
 diff --git src/http/ngx_http.c src/http/ngx_http.c
 index e1d3d00..7ad72e3 100644
 --- src/http/ngx_http.c
@@ -116,26 +104,67 @@ index 2aadae7..6ba3a90 100644
      int                        backlog;
      int                        rcvbuf;
 diff --git src/os/unix/ngx_process_cycle.c src/os/unix/ngx_process_cycle.c
-index e8ebf3d..8227ecf 100644
+index e4aa362..34c361b 100644
 --- src/os/unix/ngx_process_cycle.c
 +++ src/os/unix/ngx_process_cycle.c
-@@ -1250,7 +1250,11 @@ ngx_privileged_agent_process_cycle(ngx_cycle_t *cycle, void *data)
+@@ -443,12 +443,36 @@ ngx_start_cache_manager_processes(ngx_cycle_t *cycle, ngx_uint_t respawn)
+ static void
+ ngx_start_privileged_agent_processes(ngx_cycle_t *cycle, ngx_uint_t respawn)
+ {
++    ngx_uint_t             i;
++    ngx_listening_t       *ls;
+     ngx_core_conf_t       *ccf;
+ 
+     ccf = (ngx_core_conf_t *) ngx_get_conf(cycle->conf_ctx,
+                                            ngx_core_module);
+ 
+     if (!ccf->privileged_agent) {
++        /*
++         * no process will accept on the privileged agent listeners:
++         * close them in the master so that clients get "connection
++         * refused" instead of hanging in the accept backlog
++         */
++        ls = cycle->listening.elts;
++        for (i = 0; i < cycle->listening.nelts; i++) {
++            if (!ls[i].privileged_agent
++                || ls[i].fd == (ngx_socket_t) -1)
++            {
++                continue;
++            }
++
++            if (ngx_close_socket(ls[i].fd) == -1) {
++                ngx_log_error(NGX_LOG_EMERG, cycle->log, ngx_socket_errno,
++                              ngx_close_socket_n " %V failed",
++                              &ls[i].addr_text);
++            }
++
++            ls[i].fd = (ngx_socket_t) -1;
++        }
++
+         return;
+     }
+ 
+@@ -1262,7 +1286,14 @@ ngx_privileged_agent_process_cycle(ngx_cycle_t *cycle, void *data)
      ngx_process = NGX_PROCESS_HELPER;
      ngx_is_privileged_agent = 1;
-
+ 
 -    ngx_close_listening_sockets(cycle);
-+    if (ngx_open_listening_sockets(cycle) != NGX_OK) {
-+        ngx_log_error(NGX_LOG_ALERT, cycle->log, ngx_errno,
-+                      "failed to init privileged agent listeners");
-+        exit(2);
-+    }
-
++    /*
++     * the master process opens and owns every listening socket,
++     * including the privileged agent ones, so that bind failures abort
++     * startup/reload and the fds survive helper generations and role
++     * changes across reloads; this process keeps the inherited
++     * privileged agent fds and ngx_event_process_init() closes the
++     * listeners belonging to the other process roles
++     */
+ 
      /* Set a moderate number of connections for a helper process. */
-     cycle->connection_n = 512;
-@@ -1265,6 +1269,7 @@ ngx_privileged_agent_process_cycle(ngx_cycle_t *cycle, void *data)
-
+     cycle->connection_n = ccf->privileged_agent_connections;
+@@ -1277,6 +1308,7 @@ ngx_privileged_agent_process_cycle(ngx_cycle_t *cycle, void *data)
+ 
          if (ngx_terminate || ngx_quit) {
              ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0, "exiting");
 +            ngx_close_listening_sockets(cycle);
              ngx_worker_process_exit(cycle);
          }
+ 

--- a/patch/1.29.2.4/nginx-listen-in-privileged-agent.patch
+++ b/patch/1.29.2.4/nginx-listen-in-privileged-agent.patch
@@ -1,18 +1,3 @@
-diff --git src/core/ngx_connection.c src/core/ngx_connection.c
-index b7c0fe2..2e3e3c2 100644
---- src/core/ngx_connection.c
-+++ src/core/ngx_connection.c
-@@ -434,6 +434,10 @@ ngx_open_listening_sockets(ngx_cycle_t *cycle)
-                 continue;
-             }
- 
-+            if (ngx_is_privileged_agent != ls[i].privileged_agent) {
-+                continue;
-+            }
-+
- #if (NGX_HAVE_REUSEPORT)
- 
-             if (ls[i].add_reuseport) {
 diff --git src/core/ngx_connection.h src/core/ngx_connection.h
 index 84dd804..d3d6930 100644
 --- src/core/ngx_connection.h
@@ -119,23 +104,63 @@ index 765e7ff..302a14b 100644
      int                        backlog;
      int                        rcvbuf;
 diff --git src/os/unix/ngx_process_cycle.c src/os/unix/ngx_process_cycle.c
-index dadf03f..6794b34 100644
+index b4e140d..2a837bf 100644
 --- src/os/unix/ngx_process_cycle.c
 +++ src/os/unix/ngx_process_cycle.c
-@@ -1227,7 +1227,11 @@ ngx_privileged_agent_process_cycle(ngx_cycle_t *cycle, void *data)
+@@ -443,12 +443,36 @@ ngx_start_cache_manager_processes(ngx_cycle_t *cycle, ngx_uint_t respawn)
+ static void
+ ngx_start_privileged_agent_processes(ngx_cycle_t *cycle, ngx_uint_t respawn)
+ {
++    ngx_uint_t             i;
++    ngx_listening_t       *ls;
+     ngx_core_conf_t       *ccf;
+ 
+     ccf = (ngx_core_conf_t *) ngx_get_conf(cycle->conf_ctx,
+                                            ngx_core_module);
+ 
+     if (!ccf->privileged_agent) {
++        /*
++         * no process will accept on the privileged agent listeners:
++         * close them in the master so that clients get "connection
++         * refused" instead of hanging in the accept backlog
++         */
++        ls = cycle->listening.elts;
++        for (i = 0; i < cycle->listening.nelts; i++) {
++            if (!ls[i].privileged_agent
++                || ls[i].fd == (ngx_socket_t) -1)
++            {
++                continue;
++            }
++
++            if (ngx_close_socket(ls[i].fd) == -1) {
++                ngx_log_error(NGX_LOG_EMERG, cycle->log, ngx_socket_errno,
++                              ngx_close_socket_n " %V failed",
++                              &ls[i].addr_text);
++            }
++
++            ls[i].fd = (ngx_socket_t) -1;
++        }
++
+         return;
+     }
+ 
+@@ -1253,7 +1277,14 @@ ngx_privileged_agent_process_cycle(ngx_cycle_t *cycle, void *data)
      ngx_process = NGX_PROCESS_HELPER;
      ngx_is_privileged_agent = 1;
  
 -    ngx_close_listening_sockets(cycle);
-+    if (ngx_open_listening_sockets(cycle) != NGX_OK) {
-+        ngx_log_error(NGX_LOG_ALERT, cycle->log, ngx_errno,
-+                      "failed to init privileged agent listeners");
-+        exit(2);
-+    }
++    /*
++     * the master process opens and owns every listening socket,
++     * including the privileged agent ones, so that bind failures abort
++     * startup/reload and the fds survive helper generations and role
++     * changes across reloads; this process keeps the inherited
++     * privileged agent fds and ngx_event_process_init() closes the
++     * listeners belonging to the other process roles
++     */
  
      /* Set a moderate number of connections for a helper process. */
      cycle->connection_n = ccf->privileged_agent_connections;
-@@ -1242,6 +1246,7 @@ ngx_privileged_agent_process_cycle(ngx_cycle_t *cycle, void *data)
+@@ -1268,6 +1299,7 @@ ngx_privileged_agent_process_cycle(ngx_cycle_t *cycle, void *data)
  
          if (ngx_terminate || ngx_quit) {
              ngx_log_error(NGX_LOG_NOTICE, cycle->log, 0, "exiting");

--- a/t/privileged_agent_listener_lifecycle.t
+++ b/t/privileged_agent_listener_lifecycle.t
@@ -1,0 +1,115 @@
+our $SkipReason;
+
+BEGIN {
+    my $nginx_binary = $ENV{'TEST_NGINX_BINARY'} || 'nginx';
+    my $version = eval { `$nginx_binary -V 2>&1` } // '';
+    my ($major, $minor) = $version =~ m{openresty/(\d+)\.(\d+)};
+
+    if (!defined $major || !defined $minor
+        || ($major < 1 || ($major == 1 && $minor < 29))) {
+        $SkipReason = "requires OpenResty 1.29 or later";
+    }
+}
+
+use IO::Socket::INET;
+use t::APISIX_NGINX $SkipReason
+    ? (skip_all => $SkipReason)
+    : ('no_plan');
+
+# reserve the port used by TEST 1 so that the privileged agent listener
+# cannot bind it
+our $blocker = IO::Socket::INET->new(
+    LocalAddr => '127.0.0.1',
+    LocalPort => 19091,
+    Listen    => 5,
+    ReuseAddr => 1,
+) or die "failed to reserve 127.0.0.1:19091: $!";
+
+master_on();
+run_tests();
+
+__DATA__
+
+=== TEST 1: startup fails when a privileged-agent listener cannot bind
+The master process owns every listening socket, so an unavailable
+privileged agent address must abort startup instead of leaving a
+healthy-looking master without the listener.
+--- http_config
+init_by_lua_block {
+    local process = require "ngx.process"
+    assert(process.enable_privileged_agent())
+}
+server {
+    listen 127.0.0.1:19091 enable_process=privileged_agent;
+    location / {
+        return 200 "privileged\n";
+    }
+}
+--- config
+    location /t {
+        return 200 "worker\n";
+    }
+--- must_die
+--- error_log
+bind() to 127.0.0.1:19091 failed
+
+
+
+=== TEST 2: socket options are applied to the privileged agent listener
+The master configures the real fd, so rcvbuf must not hit
+"setsockopt(...) failed (9: Bad file descriptor)" (would show up as an
+[alert] in the error log) and the listener must serve requests.
+--- http_config
+init_by_lua_block {
+    local process = require "ngx.process"
+    assert(process.enable_privileged_agent())
+}
+server {
+    listen 127.0.0.1:19093 rcvbuf=64k enable_process=privileged_agent;
+    location / {
+        return 200 "privileged";
+    }
+}
+--- config
+    location /t {
+        content_by_lua_block {
+            local httpc = ngx.socket.tcp()
+            assert(httpc:connect("127.0.0.1", 19093))
+            assert(httpc:send("GET / HTTP/1.0\r\nHost: t\r\n\r\n"))
+            local resp = httpc:receive("*a")
+            httpc:close()
+            ngx.say(resp:match("privileged") or "no body")
+        }
+    }
+--- response_body
+privileged
+
+
+
+=== TEST 3: privileged agent listener is closed when the agent is disabled
+Nothing will accept on the listener, so the master closes it and
+clients get "connection refused" instead of hanging in the accept
+backlog.
+--- http_config
+server {
+    listen 127.0.0.1:19094 enable_process=privileged_agent;
+    location / {
+        return 200 "privileged";
+    }
+}
+--- config
+    location /t {
+        content_by_lua_block {
+            local sock = ngx.socket.tcp()
+            sock:settimeout(1000)
+            local ok, err = sock:connect("127.0.0.1", 19094)
+            ngx.say("connect: ", ok, ", ", err)
+            sock:close()
+        }
+    }
+--- response_body
+connect: nil, connection refused
+--- error_log
+connect() failed (111: Connection refused)
+--- no_error_log
+[alert]

--- a/t/privileged_agent_listener_lifecycle.t
+++ b/t/privileged_agent_listener_lifecycle.t
@@ -1,20 +1,5 @@
-our $SkipReason;
-
-BEGIN {
-    my $nginx_binary = $ENV{'TEST_NGINX_BINARY'} || 'nginx';
-    my $version = eval { `$nginx_binary -V 2>&1` } // '';
-    my ($major, $minor) = $version =~ m{openresty/(\d+)\.(\d+)};
-
-    if (!defined $major || !defined $minor
-        || ($major < 1 || ($major == 1 && $minor < 29))) {
-        $SkipReason = "requires OpenResty 1.29 or later";
-    }
-}
-
 use IO::Socket::INET;
-use t::APISIX_NGINX $SkipReason
-    ? (skip_all => $SkipReason)
-    : ('no_plan');
+use t::APISIX_NGINX 'no_plan';
 
 # reserve the port used by TEST 1 so that the privileged agent listener
 # cannot bind it


### PR DESCRIPTION
### Problem

The privileged agent listener implementation kept the listening fds entirely out of the master process: `ngx_open_listening_sockets()` skipped role-mismatched listeners, and the helper opened its own sockets after fork. That broke four invariants of the nginx listener lifecycle (api7/rfcs#111, PA-1..PA-4):

- **PA-1**: a bind failure only killed the helper after the master had already committed the new cycle, so startup reported success while the privileged endpoint did not exist (`nginx` exited 0 with the port occupied; the helper kept respawning and failing).
- **PA-2**: on every reload the new helper had to re-bind while the old helper still held the port, then sat in the fixed 500ms bind retry after the old fd was closed; a standard reload dropped ~30 consecutive requests over a ~380ms no-listener window.
- **PA-3**: switching an address from `enable_process=privileged_agent` to a normal listener could never be reloaded: the fd inherited by cycle matching was `-1`, the master had to bind while the old helper still held the address, and the reload was aborted with `still could not bind()`, keeping the old configuration forever.
- **PA-4**: the master ran `ngx_configure_listening_sockets()` on fd `-1`, so `rcvbuf`/`sndbuf`/keepalive/deferred-accept options hit `setsockopt(-1)` (`Bad file descriptor` alerts) and were silently ignored, while the real fd opened by the helper kept system defaults.

### Fix

Restore the normal ownership model, addressing all four defects as one design change (matching the repair direction proposed in the RFC):

- the master opens and configures every listening socket (the open-skip in `ngx_connection.c` is dropped);
- the privileged agent keeps the inherited fds instead of opening its own — the existing role check in `ngx_event_process_init()` already closes the listeners belonging to the other process roles in each child.

Listener fds now survive helper generations and role changes exactly like worker listeners, so reloads have no rebind window at all (re-verified with a reload probe: 0 failed requests, previously 32 over ~380ms; both role-switch directions reload cleanly) and binary upgrades inherit them like any other listener.

When the privileged agent is not enabled, no process would ever accept on those listeners, so `ngx_start_privileged_agent_processes()` closes them in the master and clients keep getting `connection refused` as before instead of hanging in the accept backlog.

### Tests

New `t/privileged_agent_listener_lifecycle.t` covers the bind-conflict startup failure (`--- must_die`), socket options taking effect on the privileged listener without alerts, and the agent-disabled refusal.

The same design change is backported to the 1.21.4 patches used by api7ee-runtime (whose event-init hunk previously used a worker-side skip inside the reuseport-only branch; it now uses the same role-based close). The reload probes were re-run on that generation with identical results (0 failed requests across a reload, both role-switch directions reload cleanly), and the test file runs unconditionally on both CI matrices. The reload-window and role-switch scenarios need a real master/helper reload and cannot be exercised from test-nginx; they were verified with dedicated reload probe scripts driving continuous requests across `nginx -s reload`.

Ref api7/rfcs#111 (PA-1, PA-2, PA-3, PA-4).

Fixes api7/api7-ee-3-gateway#1973.